### PR TITLE
Fixes #348: Error out if p2 directory does not exist

### DIFF
--- a/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/FixArtifactsMetadataMetadataMojo.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/FixArtifactsMetadataMetadataMojo.java
@@ -70,7 +70,8 @@ public class FixArtifactsMetadataMetadataMojo extends AbstractRepositoryMojo {
             try {
                 File destination = getAssemblyRepositoryLocation();
                 if (!destination.isDirectory()) {
-                    return;
+                    throw new MojoExecutionException(
+                            "Could not update p2 repository, directory does not exist: " + destination);
                 }
                 MirrorApplicationService mirrorApp = p2.getService(MirrorApplicationService.class);
                 DestinationRepositoryDescriptor destinationRepoDescriptor = new DestinationRepositoryDescriptor(


### PR DESCRIPTION
Prior to this fix the FixArtifactsMetadataMetadataMojo would silently
complete successfully if the p2 directory did not exist.