### PR TITLE
 Make P2ArtifactRepositoryLayout actually lookup artifacts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ## 4.0.0 (under development)
 
+#### P2 repository now actually lookup artifacts
+
+Previously the P2 repository was just a "marker" for Tycho to know what repositories are there and was actually disabled.
+From now on P2 repositories can be used to actually look up artifacts even if not a Tycho build is executed, this becomes useful if you want to consume a P2 item in a regular maven build.
+A full example can be found here: https://github.com/eclipse/tycho/tree/master/tycho-its/projects/p2mavenDependency/pom.xml
+
 ### Migration guide 3.x > 4.x
 
 #### Properties for tycho-surefire-plugin's 'useUIThread' and 'useUIHarness' parameters

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/LoggerProgressMonitor.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/LoggerProgressMonitor.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class LoggerProgressMonitor implements IProgressMonitor {
+
+	private final Logger log;
+
+	private AtomicBoolean canceled = new AtomicBoolean();
+
+	public LoggerProgressMonitor(Logger log) {
+		this.log = log;
+	}
+
+	@Override
+	public void worked(int work) {
+
+	}
+
+	@Override
+	public void subTask(String name) {
+		if (name != null && !name.isBlank()) {
+			log.debug(name);
+		}
+	}
+
+	@Override
+	public void setTaskName(String name) {
+		if (name != null && !name.isBlank()) {
+			log.info(name);
+		}
+	}
+
+	@Override
+	public void setCanceled(boolean value) {
+		canceled.set(value);
+	}
+
+	@Override
+	public boolean isCanceled() {
+		return canceled.get();
+	}
+
+	@Override
+	public void internalWorked(double work) {
+
+	}
+
+	@Override
+	public void done() {
+
+	}
+
+	@Override
+	public void beginTask(String name, int totalWork) {
+		if (name != null && !name.isBlank()) {
+			log.info(name);
+		}
+	}
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2ArtifactRepositoryLayout.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2ArtifactRepositoryLayout.java
@@ -51,7 +51,7 @@ public class P2ArtifactRepositoryLayout implements ArtifactRepositoryLayout, Art
     @Override
     public ArtifactRepository newMavenArtifactRepository(String id, String url, ArtifactRepositoryPolicy snapshots,
             ArtifactRepositoryPolicy releases) {
-        return new MavenArtifactRepository(id, url, this, DISABLED_POLICY, DISABLED_POLICY);
+		return new MavenArtifactRepository(id, url, this, snapshots, releases);
     }
 
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2RepositoryConnector.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2RepositoryConnector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2011 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,60 +9,147 @@
  *
  * Contributors:
  *    Sonatype Inc. - initial API and implementation
+ *    Christoph Läubrich - actually lookup artifacts by P2 repository
  *******************************************************************************/
 package org.eclipse.tycho.p2maven.repository;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.stream.Stream;
 
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.ArtifactDownload;
 import org.eclipse.aether.spi.connector.ArtifactUpload;
 import org.eclipse.aether.spi.connector.MetadataDownload;
 import org.eclipse.aether.spi.connector.MetadataUpload;
 import org.eclipse.aether.spi.connector.RepositoryConnector;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
 import org.eclipse.aether.transfer.MetadataNotFoundException;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
+import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.metadata.VersionRange;
+import org.eclipse.equinox.p2.repository.artifact.ArtifactDescriptorQuery;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
+import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.p2maven.LoggerProgressMonitor;
 
 public class P2RepositoryConnector implements RepositoryConnector {
 
-    private final RemoteRepository repository;
+	private final RemoteRepository repository;
+	private RepositorySystemSession session;
+	private RepositoryLayout repositoryLayout;
+	private IArtifactRepository artifactRepository;
+	private Logger log;
 
-    public P2RepositoryConnector(RemoteRepository repository) {
-        this.repository = repository;
-    }
+	public P2RepositoryConnector(RemoteRepository repository, IArtifactRepository artifactRepository,
+			RepositorySystemSession session, RepositoryLayout repositoryLayout, Logger log) {
+		this.repository = repository;
+		this.artifactRepository = artifactRepository;
+		this.session = session;
+		this.repositoryLayout = repositoryLayout;
+		this.log = log;
+	}
 
-    @Override
-    public void get(Collection<? extends ArtifactDownload> artifactDownloads,
-            Collection<? extends MetadataDownload> metadataDownloads) {
-        if (artifactDownloads != null) {
-            for (ArtifactDownload a : artifactDownloads) {
-                a.setException(new ArtifactNotFoundException(a.getArtifact(), repository));
-            }
-        }
-        if (metadataDownloads != null) {
-            for (MetadataDownload m : metadataDownloads) {
-                m.setException(new MetadataNotFoundException(m.getMetadata(), repository));
-            }
-        }
-    }
+	@Override
+	public void get(Collection<? extends ArtifactDownload> artifactDownloads,
+			Collection<? extends MetadataDownload> metadataDownloads) {
+		if (artifactDownloads != null) {
+			for (ArtifactDownload a : artifactDownloads) {
+				Artifact artifact = a.getArtifact();
+				String property = artifact.getProperty("type", null);
+				if (PackagingType.TYPE_ECLIPSE_PLUGIN.equals(property)) {
+					Iterator<IArtifactDescriptor> iterator = descriptorsOf(artifact).iterator();
+					if (a.isExistenceCheck()) {
+						if (iterator.hasNext()) {
+							continue;
+						}
+					} else {
+						File file = downloadArtifact(iterator);
+						if (file != null) {
+							a.setFile(file);
+							continue;
+						}
+					}
+				}
+				a.setException(new ArtifactNotFoundException(artifact, repository));
+			}
+		}
+		if (metadataDownloads != null) {
+			for (MetadataDownload m : metadataDownloads) {
+				m.setException(new MetadataNotFoundException(m.getMetadata(), repository));
+			}
+		}
+	}
 
-    @Override
-    public void put(Collection<? extends ArtifactUpload> artifactUploads,
-            Collection<? extends MetadataUpload> metadataUploads) {
-        if (artifactUploads != null) {
-            for (ArtifactUpload a : artifactUploads) {
-                a.setException(new ArtifactNotFoundException(a.getArtifact(), repository));
-            }
-        }
-        if (metadataUploads != null) {
-            for (MetadataUpload m : metadataUploads) {
-                m.setException(new MetadataNotFoundException(m.getMetadata(), repository));
-            }
-        }
-    }
+	private File downloadArtifact(Iterator<IArtifactDescriptor> iterator) {
+		File basedir = session.getLocalRepository().getBasedir();
+		while (iterator.hasNext()) {
+			IArtifactDescriptor descriptor = iterator.next();
+			IArtifactKey key = descriptor.getArtifactKey();
+			URI location = repositoryLayout.getLocation(
+					new DefaultArtifact(TychoConstants.P2_GROUPID_PREFIX + key.getClassifier(), key.getId(), "jar",
+							key.getVersion().toString()),
+					false);
+			File file = new File(basedir, location.toString());
+			if (file.isFile()) {
+				return file;
+			}
+			file.getParentFile().mkdirs();
+			//TODO respect the batch mode from the session!
+			log.info("Downloading " + descriptor.getArtifactKey() + " to " + file.getAbsolutePath() + "...");
+			try (FileOutputStream outputStream = new FileOutputStream(file)) {
+				artifactRepository.getArtifact(descriptor, outputStream, new LoggerProgressMonitor(log));
+				return file;
+			} catch (IOException e) {
+				log.error("Download failed!", e);
+				file.delete();
+			}
+		}
+		return null;
+	}
 
-    @Override
-    public void close() {
-    }
+	private Stream<IArtifactDescriptor> descriptorsOf(Artifact artifact) {
+		Version version = Version.create(artifact.getVersion());
+		IArtifactKey key = artifactRepository.createArtifactKey(PublisherHelper.OSGI_BUNDLE_CLASSIFIER,
+				artifact.getArtifactId(), version);
+		return Stream
+				.of(new ArtifactDescriptorQuery(key),
+						new ArtifactDescriptorQuery(artifact.getArtifactId(),
+								new VersionRange(version, true, Version.MAX_VERSION, false), null))
+				.flatMap(q -> artifactRepository.descriptorQueryable().query(q, new LoggerProgressMonitor(log)).toSet()
+						.stream());
+	}
+
+	@Override
+	public void put(Collection<? extends ArtifactUpload> artifactUploads,
+			Collection<? extends MetadataUpload> metadataUploads) {
+		//TODO actually we can support uploads to local repository locations!
+		if (artifactUploads != null) {
+			for (ArtifactUpload a : artifactUploads) {
+				a.setException(new ArtifactNotFoundException(a.getArtifact(), repository));
+			}
+		}
+		if (metadataUploads != null) {
+			for (MetadataUpload m : metadataUploads) {
+				m.setException(new MetadataNotFoundException(m.getMetadata(), repository));
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+	}
 
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2RepositoryConnectorFactory.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2RepositoryConnectorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2011 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,31 +9,78 @@
  *
  * Contributors:
  *    Sonatype Inc. - initial API and implementation
+ *    Christop Läubrich - Make P2ArtifactRepositoryLayout actually lookup artifacts
  *******************************************************************************/
 package org.eclipse.tycho.p2maven.repository;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.RepositoryConnector;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutFactory;
 import org.eclipse.aether.transfer.NoRepositoryConnectorException;
+import org.eclipse.aether.transfer.NoRepositoryLayoutException;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
+import org.eclipse.tycho.p2maven.LoggerProgressMonitor;
 
 @Component(role = RepositoryConnectorFactory.class, hint = "p2")
 public class P2RepositoryConnectorFactory implements RepositoryConnectorFactory {
 
-    @Override
-    public float getPriority() {
-        return 0;
-    }
+	@Requirement
+	private Logger log;
 
-    @Override
-    public RepositoryConnector newInstance(RepositorySystemSession session, RemoteRepository repository)
-            throws NoRepositoryConnectorException {
-        if (P2ArtifactRepositoryLayout.ID.equals(repository.getContentType())) {
-            return new P2RepositoryConnector(repository);
-        }
-        throw new NoRepositoryConnectorException(repository);
-    }
+	@Requirement
+	private IProvisioningAgent agent;
+
+	@Requirement(hint = "maven2")
+	private RepositoryLayoutFactory factory;
+
+	@Override
+	public float getPriority() {
+		return 0;
+	}
+
+	@Override
+	public RepositoryConnector newInstance(RepositorySystemSession session, RemoteRepository repository)
+			throws NoRepositoryConnectorException {
+		if (P2ArtifactRepositoryLayout.ID.equals(repository.getContentType())) {
+			URI uri;
+			try {
+				uri = new URI(repository.getUrl());
+			} catch (URISyntaxException e) {
+				log.error("Invalid URI '" + repository.getUrl() + ": " + e.getMessage(), e);
+				throw new NoRepositoryConnectorException(repository, e);
+			}
+			RepositoryLayout repositoryLayout;
+			try {
+				repositoryLayout = factory.newInstance(session,
+						new RemoteRepository.Builder(null, "default", null).build());
+			} catch (NoRepositoryLayoutException e) {
+				log.error("Can't create RepositoryLayout", e);
+				throw new NoRepositoryConnectorException(repository, e);
+			}
+			try {
+				IArtifactRepositoryManager repositoryManager = agent.getService(IArtifactRepositoryManager.class);
+				IArtifactRepository artifactRepository = repositoryManager.loadRepository(uri,
+						new LoggerProgressMonitor(log));
+				return new P2RepositoryConnector(repository, artifactRepository, session, repositoryLayout,
+						log);
+			} catch (ProvisionException e) {
+				log.error("Can't access repository at URI '" + repository.getUrl() + ": " + e.getStatus(), e);
+				throw new NoRepositoryConnectorException(repository, e);
+			}
+		}
+		throw new NoRepositoryConnectorException(repository);
+	}
 
 }

--- a/tycho-its/projects/p2mavenDependency/pom.xml
+++ b/tycho-its/projects/p2mavenDependency/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.tycho-its</groupId>
+	<artifactId>p2mavendependency</artifactId>
+	<version>1.0.0</version>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<tycho-version>4.0.0-SNAPSHOT</tycho-version>
+		<p2-repo>https://download.eclipse.org/tools/orbit/downloads/2022-03/</p2-repo>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>p2-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>p2-data-repo</id>
+			<layout>p2</layout>
+			<url>${p2-repo}</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>p2.plugin</groupId>
+			<artifactId>org.slf4j.api</artifactId>
+			<version>1.7.30</version>
+			<type>eclipse-plugin</type>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryDownloadTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryDownloadTest.java
@@ -62,4 +62,11 @@ public class P2RepositoryDownloadTest extends AbstractTychoIntegrationTest {
 			}
 		}
 	}
+
+	@Test
+	public void testP2Resolves() throws Exception {
+		Verifier verifier = getVerifier("p2mavenDependency", false, true);
+		verifier.executeGoals(List.of("clean", "install"));
+		verifier.verifyErrorFreeLog();
+	}
 }


### PR DESCRIPTION
Currently the P2ArtifactRepositoryLayout only provides a disabled repository. This implement it that way that it is possible to resolve p2. prefixed artifacts e.g in the form of:

<dependency>
  <groupId>p2.eclipse.plugin</groupId>
  <artifactId>org.eclipse.osgi</artifactId>
  <version>3.17.0.v20210823-1805</version>
  <type>eclipse-plugin</type>
</dependency>
