### PR TITLE
Use specific P2 types

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/impl/test/ArtifactMock.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/impl/test/ArtifactMock.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.tycho.IDependencyMetadata;
 import org.eclipse.tycho.IDependencyMetadata.DependencyMetadataType;
 import org.eclipse.tycho.p2.metadata.IArtifactFacade;
@@ -33,9 +34,9 @@ public class ArtifactMock implements IArtifactFacade {
 
     private String classifier;
 
-    private Set<Object> dependencyMetadata = new LinkedHashSet<>();
+    private Set<IInstallableUnit> dependencyMetadata = new LinkedHashSet<>();
 
-    private Set<Object> secondaryDependencyMetadata = new LinkedHashSet<>();
+    private Set<IInstallableUnit> secondaryDependencyMetadata = new LinkedHashSet<>();
 
     public ArtifactMock(File location, String groupId, String artifactId, String version, String packagingType,
             String classifier) {
@@ -90,7 +91,7 @@ public class ArtifactMock implements IArtifactFacade {
         this.classifier = classifier;
     }
 
-    public Set<Object> getDependencyMetadata(boolean primary) {
+    public Set<IInstallableUnit> getDependencyMetadata(boolean primary) {
         return primary ? dependencyMetadata : secondaryDependencyMetadata;
     }
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/publisher/P2GeneratorImplTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/publisher/P2GeneratorImplTest.java
@@ -95,9 +95,8 @@ public class P2GeneratorImplTest {
         assertEquals(0, unit.getRequirements().size());
     }
 
-    private IInstallableUnit getUnit(String id, Set<?> units) {
-        for (Object obj : units) {
-            IInstallableUnit unit = (IInstallableUnit) obj;
+    private IInstallableUnit getUnit(String id, Set<IInstallableUnit> units) {
+        for (IInstallableUnit unit : units) {
             if (id.equals(unit.getId())) {
                 return unit;
             }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/impl/publisher/DependencyMetadata.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/impl/publisher/DependencyMetadata.java
@@ -36,14 +36,14 @@ public class DependencyMetadata implements IDependencyMetadata {
 
     @Override
     public Set<IInstallableUnit> getDependencyMetadata() {
-        LinkedHashSet<IInstallableUnit> result = new LinkedHashSet<>();
+        Set<IInstallableUnit> result = new LinkedHashSet<>();
         result.addAll(getDependencyMetadata(DependencyMetadataType.SEED));
         result.addAll(getDependencyMetadata(DependencyMetadataType.RESOLVE));
         return result;
     }
 
+    @Override
     public void setDependencyMetadata(DependencyMetadataType type, Collection<IInstallableUnit> units) {
-
         typeMap.put(type, new LinkedHashSet<>(units));
     }
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/impl/publisher/P2GeneratorImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/impl/publisher/P2GeneratorImpl.java
@@ -184,9 +184,7 @@ public class P2GeneratorImpl extends AbstractMetadataGenerator implements P2Gene
         Set<IInstallableUnit> units = new LinkedHashSet<>();
         Set<IArtifactDescriptor> artifactDescriptors = new LinkedHashSet<>();
         for (IP2Artifact artifact : metadata.values()) {
-            for (IInstallableUnit unit : artifact.getInstallableUnits()) {
-                units.add(unit);
-            }
+            units.addAll(artifact.getInstallableUnits());
             artifactDescriptors.add(artifact.getArtifactDescriptor());
         }
         new MetadataIO().writeXML(units, unitsXml);

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/P2ResolverImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/P2ResolverImpl.java
@@ -123,11 +123,11 @@ public class P2ResolverImpl implements P2Resolver {
         // we need a linked hashmap to maintain iteration-order, some of the code relies on it!
         Map<TargetEnvironment, P2ResolutionResult> results = new LinkedHashMap<>();
         Set<IInstallableUnit> usedTargetPlatformUnits = new LinkedHashSet<>();
-        Set<?> metadata = project != null ? project.getDependencyMetadata(DependencyMetadataType.SEED)
+        Set<IInstallableUnit> metadata = project != null ? project.getDependencyMetadata(DependencyMetadataType.SEED)
                 : Collections.emptySet();
         for (TargetEnvironment environment : environments) {
             if (isMatchingEnv(metadata, environment, logger::debug)) {
-                results.put(environment, resolveDependencies(Collections.<IInstallableUnit> emptySet(), project,
+                results.put(environment, resolveDependencies(Collections.emptySet(), project,
                         new ProjectorResolutionStrategy(logger), environment, targetPlatform, usedTargetPlatformUnits));
             } else {
                 logger.info(MessageFormat.format(
@@ -505,19 +505,17 @@ public class P2ResolverImpl implements P2Resolver {
      * @param environment
      * @return
      */
-    private static boolean isMatchingEnv(Set<?> metadata, TargetEnvironment environment,
+    private static boolean isMatchingEnv(Set<IInstallableUnit> metadata, TargetEnvironment environment,
             Consumer<String> debugConsumer) {
         if (metadata != null) {
-            for (Object meta : metadata) {
-                if (meta instanceof IInstallableUnit) {
-                    IMatchExpression<IInstallableUnit> filter = ((IInstallableUnit) meta).getFilter();
-                    if (filter != null) {
-                        boolean match = filter.isMatch(InstallableUnit.contextIU(environment.toFilterProperties()));
-                        debugConsumer.accept(MessageFormat.format("{0}: {1} (matches {2})", filter,
-                                Arrays.toString(filter.getParameters()), match));
-                        if (!match) {
-                            return false;
-                        }
+            for (IInstallableUnit meta : metadata) {
+                IMatchExpression<IInstallableUnit> filter = meta.getFilter();
+                if (filter != null) {
+                    boolean match = filter.isMatch(InstallableUnit.contextIU(environment.toFilterProperties()));
+                    debugConsumer.accept(MessageFormat.format("{0}: {1} (matches {2})", filter,
+                            Arrays.toString(filter.getParameters()), match));
+                    if (!match) {
+                        return false;
                     }
                 }
             }

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublishProductToolTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublishProductToolTest.java
@@ -278,8 +278,7 @@ public class PublishProductToolTest {
         assertThat(productUnit.getRequirements(), not(hasItem(requirement("org.eclipse.egit.feature.group", "2.0"))));
 
         assertEquals("org.eclipse.help", seeds.get(1).getId());
-        assertThat((IInstallableUnit) seeds.get(1).getInstallableUnit(),
-                is(unitWithId("org.eclipse.help.feature.group")));
+        assertThat(seeds.get(1).getInstallableUnit(), is(unitWithId("org.eclipse.help.feature.group")));
         assertEquals("org.eclipse.egit", seeds.get(2).getId());
         assertThat((IInstallableUnit) seeds.get(2).getInstallableUnit(),
                 is(unitWithId("org.eclipse.egit.feature.group")));
@@ -291,13 +290,13 @@ public class PublishProductToolTest {
      */
     private static IInstallableUnit getUnit(Collection<DependencySeed> seeds) {
         assertEquals(1, seeds.size());
-        return (IInstallableUnit) seeds.iterator().next().getInstallableUnit();
+        return seeds.iterator().next().getInstallableUnit();
     }
 
     private Set<IInstallableUnit> unitsIn(Collection<DependencySeed> seeds) {
         Set<IInstallableUnit> result = new HashSet<>();
         for (DependencySeed seed : seeds) {
-            result.add((IInstallableUnit) seed.getInstallableUnit());
+            result.add(seed.getInstallableUnit());
         }
         return result;
     }

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublisherServiceTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublisherServiceTest.java
@@ -130,7 +130,7 @@ public class PublisherServiceTest {
     private static Map<String, IInstallableUnit> unitsById(Collection<DependencySeed> seeds) {
         Map<String, IInstallableUnit> result = new HashMap<>();
         for (DependencySeed seed : seeds) {
-            IInstallableUnit iu = (IInstallableUnit) seed.getInstallableUnit();
+            IInstallableUnit iu = seed.getInstallableUnit();
             result.put(iu.getId(), iu);
         }
         return result;

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultReactorProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultReactorProject.java
@@ -186,16 +186,16 @@ public class DefaultReactorProject implements ReactorProject {
 
     @Override
     public Set<IInstallableUnit> getDependencyMetadata() {
-        LinkedHashSet<IInstallableUnit> result = new LinkedHashSet<>(
-                getDependencyMetadata(DependencyMetadataType.SEED));
+        Set<IInstallableUnit> result = new LinkedHashSet<>(getDependencyMetadata(DependencyMetadataType.SEED));
         result.addAll(getDependencyMetadata(DependencyMetadataType.RESOLVE));
         return result;
     }
 
     @Override
     public Set<IInstallableUnit> getDependencyMetadata(DependencyMetadataType type) {
-        return Objects.requireNonNullElse((Set<IInstallableUnit>) getContextValue(getDependencyMetadataKey(type)),
-                Collections.emptySet());
+        @SuppressWarnings("unchecked")
+        Set<IInstallableUnit> contextValue = (Set<IInstallableUnit>) getContextValue(getDependencyMetadataKey(type));
+        return Objects.requireNonNullElse(contextValue, Collections.emptySet());
     }
 
     private static String getDependencyMetadataKey(DependencyMetadataType type) {

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -13,7 +13,6 @@
 package org.eclipse.tycho.plugins.p2.extras;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +29,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.sisu.equinox.EquinoxServiceFactory;
 import org.eclipse.tycho.IDependencyMetadata.DependencyMetadataType;
 import org.eclipse.tycho.ReactorProject;
@@ -112,7 +112,7 @@ public class CompareWithBaselineMojo extends AbstractMojo {
             return;
         }
         ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-        Set<?> dependencyMetadata = reactorProject.getDependencyMetadata(DependencyMetadataType.SEED);
+        Set<IInstallableUnit> dependencyMetadata = reactorProject.getDependencyMetadata(DependencyMetadataType.SEED);
         if (dependencyMetadata == null || dependencyMetadata.isEmpty()) {
             getLog().debug("Skipping baseline version comparison, no p2 artifacts created in build.");
             return;
@@ -134,12 +134,10 @@ public class CompareWithBaselineMojo extends AbstractMojo {
         TargetPlatform baselineTP = resolverFactory.getTargetPlatformFactory().createTargetPlatform(baselineTPStub,
                 TychoProjectUtils.getExecutionEnvironmentConfiguration(reactorProject), null);
 
-        for (Object item : dependencyMetadata) {
+        for (IInstallableUnit item : dependencyMetadata) {
             try {
-                Method getIdMethod = item.getClass().getMethod("getId");
-                Method getVersionMethod = item.getClass().getMethod("getVersion");
-                String id = (String) getIdMethod.invoke(item);
-                Version version = new Version(getVersionMethod.invoke(item).toString());
+                String id = item.getId();
+                Version version = new Version(item.getVersion().toString());
                 P2ResolutionResult res = resolver.resolveInstallableUnit(baselineTP, id, "0.0.0");
 
                 for (Entry foundInBaseline : res.getArtifacts()) {

--- a/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
+++ b/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
@@ -92,7 +92,6 @@ import org.eclipse.tycho.osgi.TychoServiceFactory;
 import org.eclipse.tycho.osgi.adapters.MavenLoggerAdapter;
 import org.eclipse.tycho.p2.facade.internal.AttachedArtifact;
 import org.eclipse.tycho.p2.metadata.DependencyMetadataGenerator;
-import org.eclipse.tycho.p2.metadata.IArtifactFacade;
 import org.eclipse.tycho.p2.metadata.PublisherOptions;
 import org.eclipse.tycho.p2.repository.LocalRepositoryP2Indices;
 import org.eclipse.tycho.p2.resolver.facade.P2ResolutionResult;
@@ -150,15 +149,13 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
             typeMap.put(type, new LinkedHashSet<>());
         }
         for (IDependencyMetadata metadata : metadataMap.values()) {
-            for (Entry<DependencyMetadataType, Set<IInstallableUnit>> map : typeMap.entrySet()) {
-                map.getValue().addAll(metadata.getDependencyMetadata(map.getKey()));
-            }
+            typeMap.forEach((key, value) -> value.addAll(metadata.getDependencyMetadata(key)));
         }
         Set<IInstallableUnit> initial = new HashSet<>();
-        for (Entry<DependencyMetadataType, Set<IInstallableUnit>> entry : typeMap.entrySet()) {
-            reactorProject.setDependencyMetadata(entry.getKey(), entry.getValue());
-            initial.addAll(entry.getValue());
-        }
+        typeMap.forEach((key, value) -> {
+        	reactorProject.setDependencyMetadata(key, value);
+            initial.addAll(value);
+        });
         reactorProject.setDependencyMetadata(DependencyMetadataType.INITIAL, initial);
     }
 
@@ -239,8 +236,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
         Map<String, IDependencyMetadata> dependencyMetadata = getDependencyMetadata(session, project, environments,
                 optionalAction);
         Map<DependencyMetadataType, Set<IInstallableUnit>> typeMap = new TreeMap<>();
-        for (Map.Entry<String, IDependencyMetadata> entry : dependencyMetadata.entrySet()) {
-            IDependencyMetadata value = entry.getValue();
+        for (IDependencyMetadata value : dependencyMetadata.values()) {
             for (DependencyMetadataType type : DependencyMetadataType.values()) {
                 typeMap.computeIfAbsent(type, t -> new LinkedHashSet<>()).addAll(value.getDependencyMetadata(type));
             }
@@ -343,11 +339,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
         if (dependencyArtifacts instanceof ArtifactCollection) {
             //enhance the dependency set
             ArtifactCollection collection = (ArtifactCollection) dependencyArtifacts;
-            Map<IInstallableUnit, IArtifactFacade> mavenInstallableUnits = dependencyCollector
-                    .getMavenInstallableUnits();
-            for (var entry : mavenInstallableUnits.entrySet()) {
-                IInstallableUnit key = entry.getKey();
-                IArtifactFacade val = entry.getValue();
+            dependencyCollector.getMavenInstallableUnits().forEach((key, val) -> {
                 ArtifactKey artifactKey = dependencyCollector.getArtifactKey(val);
                 File location = val.getLocation();
                 try {
@@ -355,7 +347,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
                 } catch (IllegalStateException e) {
                     //already contained in the collection --> ignore it...
                 }
-            }
+            });
         }
         return dependencyCollector;
     }

--- a/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/P2MetadataMojo.java
+++ b/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/P2MetadataMojo.java
@@ -191,10 +191,7 @@ public class P2MetadataMojo extends AbstractMojo {
             ReactorProject reactorProject = DefaultReactorProject.adapt(project);
 
             Set<IInstallableUnit> installableUnits = new LinkedHashSet<>();
-            for (Map.Entry<String, IP2Artifact> entry : generatedMetadata.entrySet()) {
-                String classifier = entry.getKey();
-                IP2Artifact p2artifact = entry.getValue();
-
+            generatedMetadata.forEach((classifier, p2artifact) -> {
                 installableUnits.addAll(p2artifact.getInstallableUnits());
 
                 // attach any new classified artifacts, like feature root files for example
@@ -202,7 +199,7 @@ public class P2MetadataMojo extends AbstractMojo {
                     projectHelper.attachArtifact(project, getExtension(p2artifact.getLocation()), classifier,
                             p2artifact.getLocation());
                 }
-            }
+            });
 
             // TODO 353889 distinguish between dependency resolution seed units ("primary") and other units of the project
             reactorProject.setDependencyMetadata(DependencyMetadataType.SEED, installableUnits);


### PR DESCRIPTION
While going through the code I noticed that there are a few Interfaces that use the generic-wildcard (?) or `Object` instead of the specific P2 types.
Since we are currently preparing a new Major version I want to proposed to use the specific types to get the usual benefits of static types. Or are there reasons to not depend on p2 in the affected modules that speak against it?
Affected are:
- org.eclipse.tycho.core.shared
- org.eclipse.tycho.embedder.shared
- org.eclipse.tycho.p2.resolver.shared
