### PR TITLE
Fix failing CiFriendlyVersionsTest

### DIFF
--- a/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
@@ -1,8 +1,10 @@
 package org.eclipse.tycho.test.buildextension;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.List;
 import java.util.TimeZone;
@@ -36,9 +38,15 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		// XXX Must be updated if the test is changed but should remain constant
 		// otherwise as this is the git timestamp!
-		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0.202205.jar");
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
+		File targetDir = new File(verifier.getBasedir(), "bundle/target");
+		String[] jarFiles = targetDir.list((dir, name) -> name.endsWith(".jar"));
+		assertEquals(1, jarFiles.length);
+		File file = new File(targetDir, jarFiles[0]);
 		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
-
+		String qualifier = jarFiles[0].substring(13, jarFiles[0].lastIndexOf('.'));
+		// if formatter fails to parse it will throw exception and thus fail the test
+		formatter.parse(qualifier);
 	}
 
 	@Test


### PR DESCRIPTION
It expects the date of last commit to be of given format but the exact
date is not constant as this is the git repo.
Change the test to verify that the qualifier is of 'yyyyMM' format
instead of checking exact value.