### PR TITLE
Make the classic resolver the default choice for now

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -60,7 +60,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
     static final boolean DUMP_DATA = Boolean.getBoolean("tycho.p2.dump") || Boolean.getBoolean("tycho.p2.dump.model");
 
-    static final boolean USE_OLD_RESOLVER = Boolean.getBoolean("tycho.resolver.classic");
+    static final boolean USE_OLD_RESOLVER = Boolean.parseBoolean(System.getProperty("tycho.resolver.classic", "true"));
 
     private static final String TYCHO_GROUPID = "org.eclipse.tycho";
     private static final Set<String> TYCHO_PLUGIN_IDS = new HashSet<>(


### PR DESCRIPTION
This will for now make the classic resolver the default unless we find a good reproducer for the fragment problem.

@mickaelistria WDYT? This will allow the builds to succeed and we can enable the resolver to test individual builds, this might be less disturbing.

See  #1124 