### PR TITLE
Support arbitrary aggregator directories without extra setup

### DIFF
--- a/tycho-extras/tycho-pomless/pom.xml
+++ b/tycho-extras/tycho-pomless/pom.xml
@@ -23,8 +23,8 @@
   <artifactId>tycho-pomless</artifactId>
 
   <name>Tycho POM-less build extension</name>
-  <description>A build extension which allows to omit pom.xml files for bundles and features. 
-  Maven groupId is inherited from the mandatory parent pom in the parent directory, artifactId and version are derived from MANIFEST.MF and feature.xml.
+  <description>A build extension which allows to omit pom.xml files for all Eclipse PDE projects, Plug-ins(Bundles) and Features 
+  as well as Eclipse Products, Target-Platforms and p2-repository definitions (category.xml).
   </description>
 
   <build>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.takari.polyglot</groupId>
       <artifactId>polyglot-common</artifactId>
-      <version>0.4.8</version>
+      <version>0.4.9-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
@@ -54,7 +54,6 @@ public abstract class AbstractTychoMapping implements Mapping, ModelReader {
 
     // All build.properties entries specifically considered by Tycho. Extends the list in Mapping interface
     protected static final String TYCHO_POMLESS_PARENT_PROPERTY = "tycho.pomless.parent";
-    protected static final String TYCHO_POMLESS_AGGREGATOR_NAMES_PROPERTY = "tycho.pomless.aggregator.names";
 
     private static final String PARENT_POM_DEFAULT_VALUE = System.getProperty(TYCHO_POMLESS_PARENT_PROPERTY, "..");
     private static final String QUALIFIER_SUFFIX = ".qualifier";
@@ -231,11 +230,6 @@ public abstract class AbstractTychoMapping implements Mapping, ModelReader {
         } catch (ComponentLookupException e) {
         }
         return reference;
-    }
-
-    @Override
-    public float getPriority() {
-        return 0;
     }
 
     @Override

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoBundleMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoBundleMapping.java
@@ -47,6 +47,16 @@ public class TychoBundleMapping extends AbstractTychoMapping {
     private static final String PACKAGING_TEST = "eclipse-test-plugin";
 
     @Override
+    protected String getPackaging() {
+        return PACKAGING;
+    }
+
+    @Override
+    public float getPriority() {
+        return +2;
+    }
+
+    @Override
     protected boolean isValidLocation(String location) {
         File polyglotFile = new File(location);
         return polyglotFile.getName().equals(META_INF_DIRECTORY) && new File(polyglotFile, MANIFEST_MF).isFile();
@@ -59,11 +69,6 @@ public class TychoBundleMapping extends AbstractTychoMapping {
             return metaInfDirectory;
         }
         return null;
-    }
-
-    @Override
-    protected String getPackaging() {
-        return PACKAGING;
     }
 
     @Override

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoFeatureMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoFeatureMapping.java
@@ -17,6 +17,7 @@ package org.eclipse.tycho.pomless;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Properties;
 import java.util.function.Supplier;
 
@@ -32,6 +33,18 @@ public class TychoFeatureMapping extends AbstractXMLTychoMapping {
     private static final String NAME_PREFIX = "[feature] ";
     private static final String FEATURE_XML = "feature.xml";
     public static final String PACKAGING = "eclipse-feature";
+
+    @Override
+    protected String getPackaging() {
+        return PACKAGING;
+    }
+
+    @Override
+    public float getPriority() {
+        // It is important that this mapping has a higher priority than the 'XmlMapping' provided by polyglot. 
+        // Otherwise it can happen that the the pom.xml reader is used to read the feature.xml which will break the build!
+        return +1;
+    }
 
     @Override
     protected void initModelFromXML(Model model, Element xml, File artifactFile) throws IOException {
@@ -54,7 +67,7 @@ public class TychoFeatureMapping extends AbstractXMLTychoMapping {
 
     @Override
     protected boolean isValidLocation(String location) {
-        return location.endsWith(FEATURE_XML);
+        return Path.of(location).endsWith(FEATURE_XML);
     }
 
     @Override
@@ -64,11 +77,6 @@ public class TychoFeatureMapping extends AbstractXMLTychoMapping {
             return featureXml;
         }
         return null;
-    }
-
-    @Override
-    protected String getPackaging() {
-        return PACKAGING;
     }
 
 }

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoRepositoryMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoRepositoryMapping.java
@@ -61,6 +61,11 @@ public class TychoRepositoryMapping extends AbstractXMLTychoMapping {
     }
 
     @Override
+    public float getPriority() {
+        return -1;
+    }
+
+    @Override
     protected void initModel(Model model, Reader artifactReader, File artifactFile) throws IOException {
         if (artifactFile.getName().endsWith(PRODUCT_EXTENSION)) {
             File projectRoot = artifactFile.getParentFile();

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoTargetMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoTargetMapping.java
@@ -38,6 +38,11 @@ public class TychoTargetMapping extends AbstractXMLTychoMapping {
     }
 
     @Override
+    public float getPriority() {
+        return -2;
+    }
+
+    @Override
     protected boolean isValidLocation(String location) {
         return location.endsWith(TARGET_EXTENSION);
     }

--- a/tycho-its/projects/pomless-model/.mvn/maven.config
+++ b/tycho-its/projects/pomless-model/.mvn/maven.config
@@ -1,2 +1,1 @@
 -Dtycho-version=3.0.0-SNAPSHOT
--Dtycho.pomless.aggregator.names=bundles,bundles-with-enhanced-parents

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/otherFolder/nested/aFile.txt
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/otherFolder/nested/aFile.txt
@@ -1,0 +1,1 @@
+Just an arbitrary file.

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/target/some.data
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/target/some.data
@@ -1,0 +1,1 @@
+Imagine having a large, deep folder structre of working files.

--- a/tycho-its/projects/pomless-model/bundles/target/some.data
+++ b/tycho-its/projects/pomless-model/bundles/target/some.data
@@ -1,0 +1,1 @@
+Imagine having a large, deep folder structre of working files.


### PR DESCRIPTION
Removes the need to specify a Set of allowed aggregator-directory names and simply scans all modules listed (transitively) in the root pom.xml for directly nested modules, if the directory is not any other kind of project (and has not pom.xml).

Update to the latest version of `io.takari.polyglot:polyglot-common` which reduces the calls to `Mapping.locatePom()` to the minimum. Polyglot-maven already only checks those directories listed as modules. But before it located a pom for all available mappings. Now it starts with the highest priority and tires those with lower once until a `Mapping.locatePom()` returns a result.
I proposed to change that: https://github.com/takari/polyglot-maven/pull/242
This PR requires that change (and therefore already has the not yet functional version update in the pom).

To minimize the number of file-system interactions the following distinct order of Tycho-Mappings is introduced:
- Bundle
- Feature
- pom.xml (provided by polyglot-maven)
- Repository (means Product or p2-repository)
- Target-Platform
- Aggregator

It is important that the Tycho-Feature-Mapping has a higher priority than the Pom-Mapping. Otherwise it can happen that the Pom-Reader is used to load the model from the `feature.xml` file and to populate the polyglot model, which would then be flawed. Until now we have been lucky that the `PolyglotModelManager` has sorted the default-pom mapping behind the feature mapping despite their same priority. Or is there another mechanism that reliable ensures that?

The remaining relations imposed by this order reflect the likelihood of a match (usually more occurring project types get a higher priority) and the cost of a match attempt (more expensive mappings get a lower priority), which results in the aggregator-mapping having the lowest priority.


With those changes AFAICT a directory should never be scanned unnecessarily. 

Additionally I update the description of the tycho-pomless pom a bit.