### PR TITLE
Support mixed Products and product 'type' attribute

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,11 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ## 3.0.0 (under development)
 
+### Support for Eclipse-Products with mixed Features and Plugins
+
+Tycho now supports building _mixed_ Products. In mixed Products both the listed features and listed plug-ins are installed.
+Therefore the Product attribute `type` is now supported, which can have the values `bundles`, `features` and `mixed` and takes precedence over the boolean-valued `useFeatures` attribute.
+
 ### New API Tools Mojo
 
 Tycho now provides a new API Tools Mojo, see https://github.com/eclipse/tycho/tree/master/tycho-its/projects/api-tools for an example how to use it.

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/actions/ProductDependenciesAction.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/actions/ProductDependenciesAction.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.IProductDescriptor;
+import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductContentType;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile;
 import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
@@ -28,7 +29,6 @@ import org.eclipse.equinox.p2.publisher.AdviceFileAdvice;
 import org.eclipse.equinox.p2.publisher.IPublisherInfo;
 import org.eclipse.equinox.p2.publisher.eclipse.FeatureEntry;
 
-@SuppressWarnings("restriction")
 public class ProductDependenciesAction extends AbstractDependenciesAction {
     private final IProductDescriptor product;
 
@@ -50,14 +50,16 @@ public class ProductDependenciesAction extends AbstractDependenciesAction {
     protected Set<IRequirement> getRequiredCapabilities() {
         Set<IRequirement> required = new LinkedHashSet<>();
 
-        if (product.useFeatures()) {
+        ProductContentType type = product.getProductContentType();
+        if (type == ProductContentType.FEATURES || type == ProductContentType.MIXED) {
             for (IVersionedId feature : product.getFeatures()) {
                 String id = feature.getId() + FEATURE_GROUP_IU_SUFFIX; //$NON-NLS-1$
                 Version version = feature.getVersion();
 
                 addRequiredCapability(required, id, version, null, false);
             }
-        } else {
+        }
+        if (type == ProductContentType.BUNDLES || type == ProductContentType.MIXED) {
             for (FeatureEntry plugin : ((ProductFile) product).getProductEntries()) {
                 addRequiredCapability(required, plugin.getId(), Version.parseVersion(plugin.getVersion()), null, true);
             }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/resources/generator/rcp-bundle-2/rcp-bundle-2.product
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/resources/generator/rcp-bundle-2/rcp-bundle-2.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="test" uid="org.eclipse.tycho.p2.impl.test.rcp-bundle" version="1.0.0.qualifier" application="test" useFeatures="false" includeLaunchers="true">
+<product name="test" uid="org.eclipse.tycho.p2.impl.test.rcp-bundle-2" version="1.0.0.qualifier" application="test" type="bundles" includeLaunchers="true">
 
    <plugins>
       <plugin id="included.bundle"/>

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/resources/generator/rcp-feature-2/rcp-feature-2.product
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/resources/generator/rcp-feature-2/rcp-feature-2.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="test" uid="org.eclipse.tycho.p2.impl.test.rcp-feature" version="1.0.0.qualifier" application="test" useFeatures="true" includeLaunchers="true">
+<product name="test" uid="org.eclipse.tycho.p2.impl.test.rcp-feature-2" version="1.0.0.qualifier" application="test" type="features" includeLaunchers="true">
 
    <plugins> <!-- shall not be used -->
       <plugin id="included.bundle"/>

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/resources/generator/rcp-mixed/rcp-mixed.product
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/resources/generator/rcp-mixed/rcp-mixed.product
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="test" uid="org.eclipse.tycho.p2.impl.test.rcp-feature" version="1.0.0.qualifier" application="test" useFeatures="true" includeLaunchers="true">
+<product name="test" uid="org.eclipse.tycho.p2.impl.test.rcp-mixed" version="1.0.0.qualifier" application="test" type="mixed" includeLaunchers="true">
 
-   <plugins> <!-- shall not be used -->
+   <plugins>
       <plugin id="included.bundle"/>
    </plugins>
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/impl/publisher/P2DependencyGeneratorImplTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/impl/publisher/P2DependencyGeneratorImplTest.java
@@ -167,23 +167,12 @@ public class P2DependencyGeneratorImplTest {
 
     @Test
     public void rcpBundle() throws Exception {
-        generateDependencies("rcp-bundle", PackagingType.TYPE_ECLIPSE_REPOSITORY);
+        assertGeneratedRequirements("rcp-bundle", List.of("included.bundle"));
+    }
 
-        assertEquals(1, units.size());
-        IInstallableUnit unit = units.iterator().next();
-
-        assertEquals("org.eclipse.tycho.p2.impl.test.rcp-bundle", unit.getId());
-        assertEquals("1.0.0.qualifier", unit.getVersion().toString());
-
-        List<IRequirement> requirements = new ArrayList<>(unit.getRequirements());
-
-        assertEquals(2, requirements.size());
-        assertNotNull(getRequiredCapability("included.bundle", requirements));
-
-        // implicit dependencies because includeLaunchers="true"
-        assertNotNull(getRequiredCapability("org.eclipse.equinox.executable.feature.group", requirements));
-
-        assertEquals(0, artifacts.size());
+    @Test
+    public void rcpBundleWithType() throws Exception {
+        assertGeneratedRequirements("rcp-bundle-2", List.of("included.bundle"));
     }
 
     @Test
@@ -221,15 +210,34 @@ public class P2DependencyGeneratorImplTest {
 
     @Test
     public void rcpFeature() throws Exception {
-        generateDependencies("rcp-feature", PackagingType.TYPE_ECLIPSE_REPOSITORY);
+        assertGeneratedRequirements("rcp-feature", List.of("included.feature.feature.group"));
+    }
+
+    @Test
+    public void rcpFeatureWithType() throws Exception {
+        assertGeneratedRequirements("rcp-feature-2", List.of("included.feature.feature.group"));
+    }
+
+    @Test
+    public void rcpMixed() throws Exception {
+        assertGeneratedRequirements("rcp-mixed", List.of("included.bundle", "included.feature.feature.group"));
+    }
+
+    private void assertGeneratedRequirements(String id, List<String> expectedIUs) throws IOException {
+        generateDependencies(id, PackagingType.TYPE_ECLIPSE_REPOSITORY);
 
         assertEquals(1, units.size());
-        IInstallableUnit unit = units.iterator().next();
-
-        assertEquals("org.eclipse.tycho.p2.impl.test.rcp-feature", unit.getId());
+        IInstallableUnit unit = units.get(0);
+        assertEquals("org.eclipse.tycho.p2.impl.test." + id, unit.getId());
         assertEquals("1.0.0.qualifier", unit.getVersion().toString());
 
-        assertEquals(2, unit.getRequirements().size());
+        List<IRequirement> requirements = new ArrayList<>(unit.getRequirements());
+        assertEquals(expectedIUs.size() + 1, requirements.size());
+        for (String expectedIU : expectedIUs) {
+            assertNotNull(getRequiredCapability(expectedIU, requirements));
+        }
+        // implicit dependencies because includeLaunchers="true"
+        assertNotNull(getRequiredCapability("org.eclipse.equinox.executable.feature.group", requirements));
 
         assertEquals(0, artifacts.size());
     }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/impl/publisher/ProductDependenciesAction.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/impl/publisher/ProductDependenciesAction.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.IProductDescriptor;
+import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductContentType;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile;
 import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
@@ -50,14 +51,16 @@ public class ProductDependenciesAction extends AbstractDependenciesAction {
     protected Set<IRequirement> getRequiredCapabilities() {
         Set<IRequirement> required = new LinkedHashSet<>();
 
-        if (product.useFeatures()) {
+        ProductContentType type = product.getProductContentType();
+        if (type == ProductContentType.FEATURES || type == ProductContentType.MIXED) {
             for (IVersionedId feature : product.getFeatures()) {
                 String id = feature.getId() + FEATURE_GROUP_IU_SUFFIX; //$NON-NLS-1$
                 Version version = feature.getVersion();
 
                 addRequiredCapability(required, id, version, null, false);
             }
-        } else {
+        }
+        if (type == ProductContentType.BUNDLES || type == ProductContentType.MIXED) {
             for (FeatureEntry plugin : ((ProductFile) product).getProductEntries()) {
                 addRequiredCapability(required, plugin.getId(), Version.parseVersion(plugin.getVersion()), null, true);
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactDependencyWalker.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactDependencyWalker.java
@@ -35,6 +35,7 @@ import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.model.FeatureRef;
 import org.eclipse.tycho.model.PluginRef;
 import org.eclipse.tycho.model.ProductConfiguration;
+import org.eclipse.tycho.model.ProductConfiguration.ProductType;
 import org.eclipse.tycho.model.UpdateSite;
 
 public abstract class AbstractArtifactDependencyWalker implements ArtifactDependencyWalker {
@@ -43,11 +44,11 @@ public abstract class AbstractArtifactDependencyWalker implements ArtifactDepend
 
     private final TargetEnvironment[] environments;
 
-    public AbstractArtifactDependencyWalker(DependencyArtifacts artifacts) {
+    protected AbstractArtifactDependencyWalker(DependencyArtifacts artifacts) {
         this(artifacts, null);
     }
 
-    public AbstractArtifactDependencyWalker(DependencyArtifacts artifacts, TargetEnvironment[] environments) {
+    protected AbstractArtifactDependencyWalker(DependencyArtifacts artifacts, TargetEnvironment[] environments) {
         this.artifacts = artifacts;
         this.environments = environments;
     }
@@ -114,11 +115,13 @@ public abstract class AbstractArtifactDependencyWalker implements ArtifactDepend
 
     protected void traverseProduct(ProductConfiguration product, ArtifactDependencyVisitor visitor,
             WalkbackPath visited) {
-        if (product.useFeatures()) {
+        ProductType type = product.getType();
+        if (type == ProductType.FEATURES || type == ProductType.MIXED) {
             for (FeatureRef ref : product.getFeatures()) {
                 traverseFeature(ref, visitor, visited);
             }
-        } else {
+        }
+        if (type == ProductType.BUNDLES || type == ProductType.MIXED) {
             for (PluginRef ref : product.getPlugins()) {
                 traversePlugin(ref, visitor, visited);
             }

--- a/tycho-its/projects/product.types/.mvn/extensions.xml
+++ b/tycho-its/projects/product.types/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>${tycho-version}</version>
+  </extension>
+</extensions>

--- a/tycho-its/projects/product.types/.mvn/maven.config
+++ b/tycho-its/projects/product.types/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho-version=3.0.0-SNAPSHOT

--- a/tycho-its/projects/product.types/foo.bar.feature/build.properties
+++ b/tycho-its/projects/product.types/foo.bar.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/product.types/foo.bar.feature/feature.xml
+++ b/tycho-its/projects/product.types/foo.bar.feature/feature.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="foo.bar.feature"
+      label="Feature"
+      version="1.0.0">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="foo.bar.plugin.in.feature"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/product.types/foo.bar.plugin.in.feature/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/product.types/foo.bar.plugin.in.feature/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.plugin.in.feature
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/product.types/foo.bar.plugin.in.feature/build.properties
+++ b/tycho-its/projects/product.types/foo.bar.plugin.in.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/product.types/foo.bar.plugin/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/product.types/foo.bar.plugin/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.plugin
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/product.types/foo.bar.plugin/build.properties
+++ b/tycho-its/projects/product.types/foo.bar.plugin/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/product.types/pom.xml
+++ b/tycho-its/projects/product.types/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>foo.bar</groupId>
+	<artifactId>simple</artifactId>
+	<version>1.0.0</version>
+
+	<packaging>pom</packaging>
+
+	<properties>
+		<tycho.version>${tycho-version}</tycho.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-director-plugin</artifactId>
+					<version>${tycho.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+	<modules>
+		<module>foo.bar.plugin</module>
+		<module>foo.bar.plugin.in.feature</module>
+		<module>foo.bar.feature</module>
+
+		<module>products</module>
+	</modules>
+</project>

--- a/tycho-its/projects/product.types/products/bundles1.product/bundles1.product
+++ b/tycho-its/projects/product.types/products/bundles1.product/bundles1.product
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="bundles1.product" version="1.0.0.qualifier" useFeatures="false" includeLaunchers="false" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="foo.bar.plugin"/>
+   </plugins>
+
+   <features>
+      <feature id="foo.bar.feature"/>
+   </features>
+
+</product>

--- a/tycho-its/projects/product.types/products/bundles2.product/bundles2.product
+++ b/tycho-its/projects/product.types/products/bundles2.product/bundles2.product
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="bundles2.product" version="1.0.0.qualifier" type="bundles" includeLaunchers="false" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="foo.bar.plugin"/>
+   </plugins>
+
+   <features>
+      <feature id="foo.bar.feature"/>
+   </features>
+
+</product>

--- a/tycho-its/projects/product.types/products/features1.product/features1.product
+++ b/tycho-its/projects/product.types/products/features1.product/features1.product
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="features1.product" version="1.0.0.qualifier" useFeatures="true" includeLaunchers="false" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="foo.bar.plugin"/>
+   </plugins>
+
+   <features>
+      <feature id="foo.bar.feature"/>
+   </features>
+
+</product>

--- a/tycho-its/projects/product.types/products/features2.product/features2.product
+++ b/tycho-its/projects/product.types/products/features2.product/features2.product
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="features2.product" version="1.0.0.qualifier" type="features" includeLaunchers="false" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="foo.bar.plugin"/>
+   </plugins>
+
+   <features>
+      <feature id="foo.bar.feature"/>
+   </features>
+
+</product>

--- a/tycho-its/projects/product.types/products/mixed.product/mixed.product
+++ b/tycho-its/projects/product.types/products/mixed.product/mixed.product
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="mixed.product" version="1.0.0.qualifier" type="mixed" includeLaunchers="false" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="foo.bar.plugin"/>
+   </plugins>
+
+   <features>
+      <feature id="foo.bar.feature"/>
+   </features>
+
+</product>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductTypesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductTypesTest.java
@@ -1,0 +1,72 @@
+package org.eclipse.tycho.test.product;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ProductTypesTest extends AbstractTychoIntegrationTest {
+
+	private static Verifier testBuildVerifier;
+
+	@BeforeClass
+	public static void setupBeforeClass() throws Exception {
+		testBuildVerifier = new ProductTypesTest().getVerifier("product.types", false);
+		testBuildVerifier.executeGoals(List.of("clean", "verify"));
+		testBuildVerifier.verifyErrorFreeLog();
+	}
+
+	@Test
+	public void testPluginBasedProductsWithUseFeatureAttribute() {
+		assertInstalledIUs("bundles1.product", //
+				List.of("foo.bar.plugin"), List.of());
+	}
+
+	@Test
+	public void testPluginBasedProductsWithTypeAttribute() {
+		assertInstalledIUs("bundles2.product", //
+				List.of("foo.bar.plugin"), List.of());
+	}
+
+	@Test
+	public void testFeatureBasedProductsWithUseFeatureAttribute() {
+		assertInstalledIUs("features1.product", //
+				List.of("foo.bar.plugin.in.feature"), List.of("foo.bar.feature"));
+	}
+
+	@Test
+	public void testFeatureBasedProductsWithTypeAttribute() {
+		assertInstalledIUs("features2.product", //
+				List.of("foo.bar.plugin.in.feature"), List.of("foo.bar.feature"));
+	}
+
+	@Test
+	public void testMixedProductsWithTypeAttribute() throws Exception {
+		assertInstalledIUs("mixed.product", //
+				List.of("foo.bar.plugin", "foo.bar.plugin.in.feature"), List.of("foo.bar.feature"));
+	}
+
+	private void assertInstalledIUs(String productId, List<String> bundles, List<String> features) {
+
+		Path basedir = Path.of(testBuildVerifier.getBasedir());
+
+		File prodRoot = basedir.resolve("products").resolve(productId).resolve("target").resolve("products")
+				.resolve(productId).toFile();
+
+		if (features.isEmpty()) {
+			assertDirectoryDoesNotExist(prodRoot, "*/*/*/features");
+		} else {
+			for (String featureName : features) {
+				// features are unzipped -> directory
+				assertDirectoryExists(prodRoot, "*/*/*/features/" + featureName + "_*");
+			}
+		}
+		for (String bundleName : bundles) {
+			assertFileExists(prodRoot, "*/*/*/plugins/" + bundleName + "_*.jar");
+		}
+	}
+}

--- a/tycho-metadata-model/src/test/java/org/eclipse/tycho/maven/test/ProductConfigurationTest.java
+++ b/tycho-metadata-model/src/test/java/org/eclipse/tycho/maven/test/ProductConfigurationTest.java
@@ -28,6 +28,7 @@ import org.eclipse.tycho.model.FeatureRef.InstallMode;
 import org.eclipse.tycho.model.Launcher;
 import org.eclipse.tycho.model.PluginRef;
 import org.eclipse.tycho.model.ProductConfiguration;
+import org.eclipse.tycho.model.ProductConfiguration.ProductType;
 import org.junit.jupiter.api.Test;
 
 class ProductConfigurationTest {
@@ -40,7 +41,7 @@ class ProductConfigurationTest {
         assertEquals("My First RCP", config.getName());
         assertEquals("MyFirstRCP.product1", config.getProduct());
         assertEquals("MyFirstRCP.application", config.getApplication());
-        assertEquals(false, config.useFeatures());
+        assertEquals(ProductType.BUNDLES, config.getType());
 
         /*
          * ConfigIni configIni = config.getConfigIni();assertNotNull(configIni);


### PR DESCRIPTION
With https://github.com/eclipse-pde/eclipse.pde/pull/291 PDE supports mixed Products, consisting of Features and Plug-ins.
P2 supports that already but Tycho has to be adjusted at a few locations to support it as well.

Furthermore this adds support for the `type` attribute of a product can have one of the following values: 
`bundles`, `features`, `mixed`.

I'm not sure if the change in `ProductConfiguration` is necessary, because I never hit that while debugging a product build.