### PR TITLE
Bug #1261 Check artifact classifier before PGP signing

### DIFF
--- a/tycho-gpg-plugin/src/main/java/org/eclipse/tycho/gpg/SignRepositoryArtifactsMojo.java
+++ b/tycho-gpg-plugin/src/main/java/org/eclipse/tycho/gpg/SignRepositoryArtifactsMojo.java
@@ -120,8 +120,24 @@ public class SignRepositoryArtifactsMojo extends AbstractGpgMojoExtension {
                 // skip packed artifacts
                 continue;
             }
-            var file = new File(repository,
-                    "plugins/" + artifact.getAttribute("id") + '_' + artifact.getAttribute("version") + ".jar");
+            /*
+             * Different types of artifact have different locations in the repo. So we need to check
+             * the classifier to correctly get the location of the jar file.
+             * 
+             * Could potentially do this dynamically based on the mappings attribute with the repo.
+             */
+            String subDir = null;
+            switch (artifact.getAttribute("classifier")) {
+            case "osgi.bundle":
+                subDir = "plugins";
+                break;
+            case "org.eclipse.update.feature": //Not yet signing features
+            case "binary": //Not yet signing binaries
+            default:
+                continue; // Skip signing
+            }
+            var file = new File(repository, subDir + File.separator + artifact.getAttribute("id") + '_'
+                    + artifact.getAttribute("version") + ".jar");
             if (!file.canRead()) {
                 continue;
             }


### PR DESCRIPTION
In some cases (e.g. org.eclipse.rcp) a bundle & feature can have the
same ID & version. To avoid generate an invalid sigurature in theses
cases check the artifact classifier before checking if the jar exists
in plugins/

As Platform does check signatures on feature this could be enhanced
to correctly PGP sign features in future

I couldn't see any integration tests for this feature