### PR TITLE
[backport] Fix MavenLocation scope filtering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This page describes the noteworthy improvements provided by each release of Ecli
 Fixes:
 
 - [reverted] Not all (direct) requirements of a feature are considered when building an update-site
+- [backport] Fix MavenLocation scope filtering
 
 ## 2.7.4
 

--- a/tycho-core/pom.xml
+++ b/tycho-core/pom.xml
@@ -228,6 +228,13 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- See MavenDependenciesResolverTest -->
+		<dependency>
+			<groupId>io.takari.aether</groupId>
+			<artifactId>aether-connector-okhttp</artifactId>
+			<version>0.17.8</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>osgi.annotation</artifactId>

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/maven/MavenDependenciesResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/maven/MavenDependenciesResolverTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.core.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.execution.DefaultMavenExecutionRequestPopulator;
+import org.apache.maven.execution.MavenExecutionRequestPopulationException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.sisu.equinox.embedder.EquinoxLifecycleListener;
+import org.eclipse.tycho.core.shared.DependencyResolutionException;
+import org.eclipse.tycho.core.shared.MavenArtifactRepositoryReference;
+import org.eclipse.tycho.osgi.configuration.MavenDependenciesResolverConfigurer;
+import org.junit.Test;
+
+public class MavenDependenciesResolverTest extends AbstractMojoTestCase {
+
+    @Test
+    public void testResolveCommonsIO() throws DependencyResolutionException, PlexusContainerException,
+            ComponentLookupException, MavenExecutionRequestPopulationException, IOException {
+        MavenSession session = newMavenSession(new MavenProject());
+        File localRepo = Files.createTempDirectory("testResolveCommonsIO").toFile();
+        session.getRequest().setLocalRepositoryPath(localRepo);
+        DefaultMavenExecutionRequestPopulator populator = getContainer()
+                .lookup(DefaultMavenExecutionRequestPopulator.class);
+        populator.populateDefaults(session.getRequest());
+        getContainer().lookup(LegacySupport.class).setSession(session);
+        MavenDependenciesResolverConfigurer resolver = (MavenDependenciesResolverConfigurer) getContainer()
+                .lookup(EquinoxLifecycleListener.class, "MavenDependenciesResolver");
+        // the artifact must be pre-existing in the local repo, so the dep is added to pom.xml for this module. Test could be enhanced to fetch the artifact.
+        Collection<?> deps = resolver.resolve("commons-io", "commons-io", "2.11.0", "jar", null, List.of(),
+                Integer.MAX_VALUE, session.getRequest().getRemoteRepositories().stream()
+                        .map(repo -> new MavenArtifactRepositoryReference() {
+
+                            @Override
+                            public String getUrl() {
+                                return repo.getUrl();
+                            }
+
+                            @Override
+                            public String getId() {
+                                return repo.getId();
+                            }
+                        }).map(MavenArtifactRepositoryReference.class::cast) //
+                        .collect(Collectors.toList()),
+                session);
+        assertEquals(deps.toString(), 1, deps.size());
+        FileUtils.deleteDirectory(localRepo);
+    }
+}

--- a/tycho-its/projects/target.maven-deps/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven-deps/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: test.bundle
+Bundle-Version: 0.0.1.qualifier
+Automatic-Module-Name: test.bundle
+Require-Bundle: org.apache.commons.commons-io

--- a/tycho-its/projects/target.maven-deps/build.properties
+++ b/tycho-its/projects/target.maven-deps/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/target.maven-deps/pom.xml
+++ b/tycho-its/projects/target.maven-deps/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <!--
+    Copyright (c) 2012 SAP AG All rights reserved. This program
+    and the accompanying materials are made available under the terms of
+    the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at https://www.eclipse.org/legal/epl-v10.html
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>issue-1133</groupId>
+	<artifactId>test.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>test.target</file>
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/projects/target.maven-deps/src/test/bundle/TestClass.java
+++ b/tycho-its/projects/target.maven-deps/src/test/bundle/TestClass.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package test.bundle;
+
+public class TestClass {
+	public static void main(String[] args) {
+	}
+}

--- a/tycho-its/projects/target.maven-deps/test.target
+++ b/tycho-its/projects/target.maven-deps/test.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="test">
+	<locations>
+		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="false" missingManifest="error" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+					<version>2.11.0</version>
+				</dependency>
+			</dependencies>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
@@ -122,4 +122,10 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 	}
 
+	@Test
+	public void testMavenLocationTransitiveFeature() throws Exception {
+		Verifier verifier = getVerifier("target.maven-deps", false, true);
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+	}
 }


### PR DESCRIPTION
Use a CollectionFilter for scopes, as scope is not
as accurate when using the ResolutionFilter (eg case of commons-io with
test deps reported as compile scope)