### PR TITLE
Relocate `assemble-maven-repository` from `tycho-p2-repository-plugin` to `p2-maven-plugin`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -255,6 +255,55 @@ This can be useful if you like to execute the build with multiple threads (e.g. 
 
 ### Migration guide 2.x -> 3.x
 
+#### 
+
+`assemble-maven-repository` was relocated from `tycho-p2-repository-plugin` to `p2-maven-plugin` simply change your pom from
+
+
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-p2-repository-plugin</artifactId>
+	<version>${tycho-version}</version>
+	<executions>
+		<execution>
+			<configuration>
+				....
+			</configuration>
+			<id>maven-p2-site</id>
+			<phase>package</phase>
+			<goals>
+				<goal>assemble-maven-repository</goal>
+			</goals>
+		</execution>
+	</executions>
+</plugin>
+
+```
+
+to
+
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>p2-maven-plugin</artifactId>
+	<version>${tycho-version}</version>
+	<executions>
+		<execution>
+			<configuration>
+				....
+			</configuration>
+			<id>maven-p2-site</id>
+			<phase>package</phase>
+			<goals>
+				<goal>assemble-maven-repository</goal>
+			</goals>
+		</execution>
+	</executions>
+</plugin>
+
+```
+
 #### Default value for archive-products has changed
 
 Previously Tycho uses `zip` for all platforms when packaging a product, now `.tar.gz` is used for linux+mac. If you want you can restore old behaviour by:

--- a/p2-maven-plugin/pom.xml
+++ b/p2-maven-plugin/pom.xml
@@ -27,6 +27,24 @@
 
 	<properties></properties>
 	<dependencies>
+		<!-- Maven -->
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-archiver</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.equinox.p2.core</artifactId>

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/MavenP2SiteMojo.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/MavenP2SiteMojo.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.tycho.plugins.p2.repository;
+package org.eclipse.tycho.p2maven;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -74,9 +74,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
-import org.eclipse.sisu.equinox.EquinoxServiceFactory;
 import org.eclipse.tycho.TychoConstants;
-import org.eclipse.tycho.osgi.TychoServiceFactory;
 import org.eclipse.tycho.p2maven.tools.TychoFeaturesAndBundlesPublisherApplication;
 
 /**
@@ -186,9 +184,6 @@ public class MavenP2SiteMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project.build.directory}/repository")
     private File destination;
-
-    @Component(hint = TychoServiceFactory.HINT)
-    private EquinoxServiceFactory equinox;
 
     @Component
     private Logger logger;

--- a/tycho-its/projects/p2mavensite.pgp/site/pom.xml
+++ b/tycho-its/projects/p2mavensite.pgp/site/pom.xml
@@ -13,7 +13,7 @@
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<artifactId>p2-maven-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<executions>
 					<execution>

--- a/tycho-its/projects/p2mavensite.reactor/site/pom.xml
+++ b/tycho-its/projects/p2mavensite.reactor/site/pom.xml
@@ -13,7 +13,7 @@
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<artifactId>p2-maven-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<executions>
 					<execution>

--- a/tycho-its/projects/p2mavensite/producer/pom.xml
+++ b/tycho-its/projects/p2mavensite/producer/pom.xml
@@ -13,7 +13,7 @@
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<artifactId>p2-maven-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<executions>
 					<execution>


### PR DESCRIPTION
Now that we do not need the embedded tycho runtime anymore, we can
relocate the mojo to the p2-plugin where it actually belongs to.