### PR TITLE
Clean-up and improve documentation of baseline comparing Mojos

### DIFF
--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/artifactcomparator/ArtifactComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/artifactcomparator/ArtifactComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Sonatype Inc. and others.
+ * Copyright (c) 2012, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,28 @@ package org.eclipse.tycho.artifactcomparator;
 
 import java.io.File;
 import java.io.IOException;
-
-import org.apache.maven.plugin.MojoExecution;
+import java.util.List;
 
 public interface ArtifactComparator {
-    public ArtifactDelta getDelta(File baseline, File reactor, MojoExecution execution) throws IOException;
+
+    public static class ComparisonData {
+
+        public ComparisonData(List<String> ignoredPattern, boolean writeDelta) {
+            this.ignoredPattern = ignoredPattern != null ? List.copyOf(ignoredPattern) : List.of();
+            this.writeDelta = writeDelta;
+        }
+
+        private final List<String> ignoredPattern;
+        private boolean writeDelta;
+
+        public List<String> ignoredPattern() {
+            return ignoredPattern;
+        }
+
+        public boolean writeDelta() {
+            return writeDelta;
+        }
+    }
+
+    public ArtifactDelta getDelta(File baseline, File reactor, ComparisonData execution) throws IOException;
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ClassfileComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ClassfileComparator.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.maven.plugin.MojoExecution;
 import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
@@ -40,7 +40,7 @@ public class ClassfileComparator implements ContentsComparator {
     // which is not exported, so can't use this either.
 
     @Override
-    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, MojoExecution mojo) throws IOException {
+    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, ComparisonData data) throws IOException {
         byte[] baselineBytes = baseline.readAllBytes();
         byte[] reactorBytes = reactor.readAllBytes();
 

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ContentsComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ContentsComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Sonatype Inc. and others.
+ * Copyright (c) 2012, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,9 @@ package org.eclipse.tycho.zipcomparator.internal;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.maven.plugin.MojoExecution;
+import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 
 public interface ContentsComparator {
-    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, MojoExecution mojo) throws IOException;
+    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, ComparisonData data) throws IOException;
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/DefaultContentsComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/DefaultContentsComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Sonatype Inc. and others.
+ * Copyright (c) 2012, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,9 @@ package org.eclipse.tycho.zipcomparator.internal;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.maven.plugin.MojoExecution;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
+import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 
 @Component(role = ContentsComparator.class, hint = DefaultContentsComparator.TYPE)
@@ -26,7 +26,7 @@ public class DefaultContentsComparator implements ContentsComparator {
     public static final String TYPE = "default";
 
     @Override
-    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, MojoExecution mojo) throws IOException {
+    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, ComparisonData data) throws IOException {
         return !IOUtil.contentEquals(baseline, reactor) ? new SimpleArtifactDelta("different") : null;
     }
 

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ManifestComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ManifestComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Sonatype Inc. and others.
+ * Copyright (c) 2012, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,9 +14,6 @@ package org.eclipse.tycho.zipcomparator.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.TreeMap;
@@ -24,8 +21,8 @@ import java.util.jar.Attributes;
 import java.util.jar.Attributes.Name;
 import java.util.jar.Manifest;
 
-import org.apache.maven.plugin.MojoExecution;
 import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 
 @Component(role = ContentsComparator.class, hint = ManifestComparator.TYPE)
@@ -33,32 +30,22 @@ public class ManifestComparator implements ContentsComparator {
 
     public static final String TYPE = "manifest";
 
-    private static final Collection<Name> IGNORED_KEYS;
-
-    static {
-        ArrayList<Name> ignoredKeys = new ArrayList<>();
-
-        // these keys are added by plexus archiver
-        ignoredKeys.add(new Name("Archiver-Version"));
-        ignoredKeys.add(new Name("Created-By"));
-        ignoredKeys.add(new Name("Build-Jdk"));
-        ignoredKeys.add(new Name("Built-By"));
-        ignoredKeys.add(new Name("Build-Jdk-Spec"));
-
-        // lets be friendly to bnd/maven-bundle-plugin
-        ignoredKeys.add(new Name("Bnd-LastModified"));
-        ignoredKeys.add(new Name("Tool"));
-
-        // this is common attribute not supported by Tycho yet
-        ignoredKeys.add(new Name("Eclipse-SourceReferences"));
-
-        // TODO make it possible to disable default ignores and add custom ignore
-
-        IGNORED_KEYS = Collections.unmodifiableCollection(ignoredKeys);
-    }
+    private static final Set<Name> IGNORED_KEYS = Set.of(
+            // these keys are added by plexus archiver
+            new Name("Archiver-Version"), //
+            new Name("Created-By"), //
+            new Name("Build-Jdk"), //
+            new Name("Built-By"), //
+            new Name("Build-Jdk-Spec"),
+            // lets be friendly to bnd/maven-bundle-plugin
+            new Name("Bnd-LastModified"), //
+            new Name("Tool"),
+            // this is common attribute not supported by Tycho yet
+            new Name("Eclipse-SourceReferences"));
+    // TODO make it possible to disable default ignores and add custom ignore
 
     @Override
-    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, MojoExecution mojo) throws IOException {
+    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, ComparisonData data) throws IOException {
         TreeMap<String, ArtifactDelta> result = new TreeMap<>();
 
         Manifest manifest = new Manifest(baseline);

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/PropertiesComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/PropertiesComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Sonatype Inc. and others.
+ * Copyright (c) 2012, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,8 +20,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.apache.maven.plugin.MojoExecution;
 import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 
 @Component(role = ContentsComparator.class, hint = PropertiesComparator.TYPE)
@@ -29,7 +29,7 @@ public class PropertiesComparator implements ContentsComparator {
     public static final String TYPE = "properties";
 
     @Override
-    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, MojoExecution mojo) throws IOException {
+    public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, ComparisonData data) throws IOException {
         TreeMap<String, ArtifactDelta> result = new TreeMap<>();
 
         Properties props = new Properties();

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ZipComparatorImpl.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ZipComparatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Sonatype Inc. and others.
+ * Copyright (c) 2012, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,12 +16,11 @@ package org.eclipse.tycho.zipcomparator.internal;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -29,12 +28,10 @@ import java.util.TreeSet;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.apache.maven.plugin.MojoExecution;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.util.SelectorUtils;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.MatchPatterns;
 import org.eclipse.tycho.artifactcomparator.ArtifactComparator;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 
@@ -43,15 +40,7 @@ public class ZipComparatorImpl implements ArtifactComparator {
 
     public static final String TYPE = "zip";
 
-    private static final Collection<String> IGNORED_PATTERNS;
-
-    static {
-        ArrayList<String> ignoredPatterns = new ArrayList<>();
-
-        ignoredPatterns.add("meta-inf/maven/**");
-
-        IGNORED_PATTERNS = Collections.unmodifiableList(ignoredPatterns);
-    }
+    private static final List<String> IGNORED_PATTERNS = List.of("META-INF/maven/**");
 
     @Requirement
     private Logger log;
@@ -60,52 +49,45 @@ public class ZipComparatorImpl implements ArtifactComparator {
     private Map<String, ContentsComparator> comparators;
 
     @Override
-    public CompoundArtifactDelta getDelta(File baseline, File reactor, MojoExecution execution) throws IOException {
+    public CompoundArtifactDelta getDelta(File baseline, File reactor, ComparisonData data) throws IOException {
         Map<String, ArtifactDelta> result = new LinkedHashMap<>();
         Collection<String> ignoredPatterns = new HashSet<>(IGNORED_PATTERNS);
-        if (execution != null) {
-            Xpp3Dom pluginConfiguration = (Xpp3Dom) execution.getPlugin().getConfiguration();
-            if (pluginConfiguration != null) {
-                Xpp3Dom ignoredPatternsNode = pluginConfiguration.getChild("ignoredPatterns");
-                if (ignoredPatternsNode != null) {
-                    for (Xpp3Dom node : ignoredPatternsNode.getChildren()) {
-                        ignoredPatterns.add(node.getValue());
-                    }
-                }
-            }
-        }
+        ignoredPatterns.addAll(data.ignoredPattern());
+        MatchPatterns ignored = MatchPatterns.from(ignoredPatterns);
 
-        try (ZipFile jar = new ZipFile(baseline); ZipFile jar2 = new ZipFile(reactor)) {
-            Map<String, ZipEntry> entries = toEntryMap(jar, ignoredPatterns);
-            Map<String, ZipEntry> entries2 = toEntryMap(jar2, ignoredPatterns);
+        try (ZipFile baselineJar = new ZipFile(baseline); ZipFile reactorJar = new ZipFile(reactor)) {
+            Map<String, ZipEntry> baselineEntries = toEntryMap(baselineJar, ignored);
+            Map<String, ZipEntry> reachtorEntries = toEntryMap(reactorJar, ignored);
 
             Set<String> names = new TreeSet<>();
-            names.addAll(entries.keySet());
-            names.addAll(entries2.keySet());
+            names.addAll(baselineEntries.keySet());
+            names.addAll(reachtorEntries.keySet());
 
             for (String name : names) {
-                ZipEntry entry = entries.get(name);
-                if (entry == null) {
-                    result.put(name, new SimpleArtifactDelta("not present in baseline"));
-                    continue;
-                }
-                ZipEntry entry2 = entries2.get(name);
-                if (entry2 == null) {
-                    result.put(name, new SimpleArtifactDelta("present in baseline only"));
-                    continue;
-                }
-
-                try (InputStream is = jar.getInputStream(entry); InputStream is2 = jar2.getInputStream(entry2);) {
-                    ContentsComparator comparator = comparators.get(getContentType(name));
-                    ArtifactDelta differences = comparator.getDelta(is, is2, execution);
-                    if (differences != null) {
-                        result.put(name, differences);
-                        continue;
-                    }
+                ArtifactDelta delta = getDelta(name, baselineEntries, reachtorEntries, baselineJar, reactorJar, data);
+                if (delta != null) {
+                    result.put(name, delta);
                 }
             }
         }
         return !result.isEmpty() ? new CompoundArtifactDelta("different", result) : null;
+    }
+
+    private ArtifactDelta getDelta(String name, Map<String, ZipEntry> baseline, Map<String, ZipEntry> reachtor,
+            ZipFile baselineJar, ZipFile reactorJar, ComparisonData data) throws IOException {
+        ZipEntry entry = baseline.get(name);
+        if (entry == null) {
+            return new SimpleArtifactDelta("not present in baseline");
+        }
+        ZipEntry entry2 = reachtor.get(name);
+        if (entry2 == null) {
+            return new SimpleArtifactDelta("present in baseline only");
+        }
+
+        try (InputStream is = baselineJar.getInputStream(entry); InputStream is2 = reactorJar.getInputStream(entry2);) {
+            ContentsComparator comparator = comparators.get(getContentType(name));
+            return comparator.getDelta(is, is2, data);
+        }
     }
 
     private String getContentType(String name) {
@@ -126,24 +108,15 @@ public class ZipComparatorImpl implements ArtifactComparator {
         return DefaultContentsComparator.TYPE;
     }
 
-    private static Map<String, ZipEntry> toEntryMap(ZipFile zip, Collection<String> ignoredPatterns) {
-        Map<String, ZipEntry> result = new LinkedHashMap<>();
+    private static Map<String, ZipEntry> toEntryMap(ZipFile zip, MatchPatterns ignored) {
+        Map<String, ZipEntry> result = new LinkedHashMap<>(zip.size());
         Enumeration<? extends ZipEntry> entries = zip.entries();
         while (entries.hasMoreElements()) {
             ZipEntry entry = entries.nextElement();
-            if (!entry.isDirectory() && !isIgnored(entry.getName(), ignoredPatterns)) {
+            if (!entry.isDirectory() && !ignored.matches(entry.getName(), false)) {
                 result.put(entry.getName(), entry);
             }
         }
         return result;
-    }
-
-    private static boolean isIgnored(String name, Collection<String> ignoredPatterns) {
-        for (String pattern : ignoredPatterns) {
-            if (SelectorUtils.matchPath(pattern, name, false)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/BytesArtifactComparator.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/BytesArtifactComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc., and others
+ * Copyright (c) 2017, 2022 Red Hat Inc., and others
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ package org.eclipse.tycho.plugins.p2.extras;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.maven.plugin.MojoExecution;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.tycho.artifactcomparator.ArtifactComparator;
@@ -28,7 +27,7 @@ public class BytesArtifactComparator implements ArtifactComparator {
     public static final String HINT = "bytes";
 
     @Override
-    public ArtifactDelta getDelta(File baseline, File reactor, MojoExecution mojoExecution) throws IOException {
+    public ArtifactDelta getDelta(File baseline, File reactor, ComparisonData data) throws IOException {
         if (FileUtils.contentEquals(baseline, reactor)) {
             return null;
         }

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat Inc., and others
+ * Copyright (c) 2015, 2022 Red Hat Inc., and others
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,7 @@ import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.artifactcomparator.ArtifactComparator;
+import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.utils.TychoProjectUtils;
@@ -83,6 +84,21 @@ public class CompareWithBaselineMojo extends AbstractMojo {
      */
     @Parameter(property = "baselines", name = "baselines")
     private List<String> baselines;
+
+    /**
+     * A list of file path patterns that are ignored when comparing the build artifact against the
+     * baseline version.
+     * 
+     * {@code
+     * <ignoredPatterns>
+     *   <pattern>META-INF/ECLIPSE_.RSA<pattern>
+     *   <pattern>META-INF/ECLIPSE_.SF</pattern>
+     * </ignoredPatterns>
+     * }
+     * 
+     */
+    @Parameter
+    private List<String> ignoredPatterns;
 
     @Parameter(property = "skip")
     private boolean skip;
@@ -171,8 +187,9 @@ public class CompareWithBaselineMojo extends AbstractMojo {
                         } else {
                             reactorFile = reactorProject.getArtifact();
                         }
+                        ComparisonData data = new ComparisonData(ignoredPatterns, false);
                         ArtifactDelta artifactDelta = this.artifactComparators.get(this.comparator)
-                                .getDelta(baselineFile, reactorFile, execution);
+                                .getDelta(baselineFile, reactorFile, data);
                         String message = "Baseline and reactor have same fully qualified version, but with different content";
                         if (artifactDelta != null) {
                             if (this.onIllegalVersion == ReportBehavior.warn) {


### PR DESCRIPTION
The 'ignoredPatterns' parameter of the 'p2-metadata' and 'compare-version-with-baselines' goal is now documented.

Slightly improve performance of nested Zip-comparision and of the check if a file is ignored.