### PR TITLE
Add Custom URL for generic Eclipse sponsoring

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -10,4 +10,4 @@ liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
 lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ['https://www.eclipse.org/sponsor/']


### PR DESCRIPTION
@mickaelistria WDYT?

As  https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/963 is stuck, would you mind to bring this to the [Committer Board Representatives](https://www.eclipse.org/org/foundation/directors.php) of Red Hat?