### PR TITLE
Support forking of the Eclipse Java Compiler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ## 3.0.0 (under development)
 
+### Tycho now support forking of the Eclipse Java Compiler
+
+Previously forking was not supported, now forking is possible and will be used if a custom java home is specified.
+
 ### New option to transform P2 dependencies into real maven coordinates
 
 The `tycho-consumer-pom` mojo has a new option to resolve p2 introduced dependencies to 'real' maven coordinates now, when enabled it queries maven-central with the SHA1 of the file to find out what are the actual maven central coordinates


### PR DESCRIPTION
Previously forking was not supported, now it is. Beside that this is used when a custom java home is specified and version Java 9+ is requested.

This will fix https://github.com/eclipse-tycho/tycho/issues/1354

FYI @mickaelistria @akurtakov @iloveeclipse @sravanlakkimsetti 