### PR TITLE
Improve the Github Action Builds

### DIFF
--- a/.github/toolchains.xml
+++ b/.github/toolchains.xml
@@ -22,4 +22,14 @@
 			<jdkHome>${env.JAVA_HOME_11_X64}</jdkHome>
 		</configuration>
 	</toolchain>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<id>JavaSE-1.8</id>
+			<version>11</version>
+		</provides>
+		<configuration>
+			<jdkHome>${env.JAVA_HOME_8_X64}</jdkHome>
+		</configuration>
+	</toolchain>
 </toolchains>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,15 +24,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
-        distribution: 'adopt'
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
+        java-version: |
+            8
+            11
+            17
         distribution: 'adopt'
     - name: Cache local Maven repository
       uses: actions/cache@v3
@@ -46,8 +44,10 @@ jobs:
       with:
         maven-version: 3.8.6
     - name: Build Tycho
+      env:
+       JAVA_HOME: ${{ env.JAVA_HOME_11_X64 }}
       run: | 
-        cp toolchains-gh.xml ~/.m2/toolchains.xml
+        cp .github/toolchains.xml ~/.m2/toolchains.xml
         mvn -U -V -e -B -ntp clean install --file pom.xml -T1C
     - name: Run Integration Tests
       run: mvn -U -V -e -B -ntp -Pits -D maven.test.failure.ignore=true clean install --file tycho-its/pom.xml

--- a/.github/workflows/verify-platform.yml
+++ b/.github/workflows/verify-platform.yml
@@ -26,15 +26,13 @@ jobs:
        lfs: true
        repository: 'eclipse-platform/eclipse.platform.releng.aggregator'
        fetch-depth: 0
-    - name: Set up JDK 17
+    - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
-        distribution: 'adopt'
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
+        java-version: |
+            8
+            11
+            17
         distribution: 'adopt'
     - name: Cache local Maven repository
       uses: actions/cache@v3
@@ -48,21 +46,26 @@ jobs:
       with:
         maven-version: 3.8.6
     - name: Build Tycho
+      env:
+       JAVA_HOME: ${{ env.JAVA_HOME_11_X64 }}
       working-directory: 'tycho'
       run: >- 
         mvn -U -V -e -B -ntp
         -DskipTests
         --file pom.xml
         -T1C
-        --global-toolchains ${{ github.workspace }}/tycho/toolchains-gh.xml
+        --global-toolchains ${{ github.workspace }}/tycho/.github/toolchains.xml
         clean install
     - name: Run Platform Build
+      env:
+       JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
       working-directory: 'platform'
       run: >- 
         mvn -U -V -e -B -ntp
-        --global-toolchains ${{ github.workspace }}/tycho/toolchains-gh.xml
+        --global-toolchains ${{ github.workspace }}/tycho/.github/toolchains.xml
         --file pom.xml
         --settings ${{ github.workspace }}/tycho/.github/settings.xml
         -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         -DskipTests
+        -Pbree-libs
         clean verify


### PR DESCRIPTION
- use never setup-java constructs
- move the toolchains file around
- use java 17 as default JVM
- include java 8 for verification build
- switch Java Home to current java 11 for the build
- include the bree profile in the platform build