### PR TITLE
Adjust and clean-up/simplify sisu-OSGi-connect

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -80,7 +80,7 @@ public class MyPlexusComponent {
 For the setup you need to do the following:
 
 1. include any bundle you like to make up your plexus-osgi-connect framework as a dependency of your maven plugin
-2. include a file `META-INF/sisu-connect.bundles` that list all your bundles you like to have installed in the format `bsn[,true]`, where `bsn` is the symbolid name and optionally you can control if your bundle has to be started or not
+2. include a file `META-INF/sisu/connect.bundles` that list all your bundles you like to have installed in the format `bsn[,true]`, where `bsn` is the symbolid name and optionally you can control if your bundle has to be started or not
 3. include the following additional dependency
 ```
 <dependency>

--- a/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/DummyClassRealm.java
+++ b/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/DummyClassRealm.java
@@ -21,7 +21,6 @@ import java.util.jar.JarFile;
 
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
-import org.codehaus.plexus.logging.Logger;
 
 final class DummyClassRealm extends ClassRealm {
 
@@ -30,7 +29,7 @@ final class DummyClassRealm extends ClassRealm {
 	private ClassLoader classLoader;
 	private List<URL> urls;
 
-	DummyClassRealm(String id, ClassLoader classLoader, Logger log) {
+	DummyClassRealm(String id, ClassLoader classLoader) {
 		super(new ClassWorld(), id, classLoader);
 		this.classLoader = classLoader;
 	}
@@ -38,7 +37,7 @@ final class DummyClassRealm extends ClassRealm {
 	@Override
 	public URL[] getURLs() {
 		if (urls == null) {
-			urls = new ArrayList<URL>();
+			urls = new ArrayList<>();
 			try {
 				Enumeration<URL> resources = classLoader.getResources(JarFile.MANIFEST_NAME);
 				while (resources.hasMoreElements()) {

--- a/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusConnectFramework.java
+++ b/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusConnectFramework.java
@@ -50,14 +50,14 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
  * created by plexus
  *
  */
-class PlexusConnectFramework
+class PlexusConnectFramework //
 		implements Logger, EmbeddedEquinox, EquinoxServiceFactory, FrameworkUtilHelper, FrameworkListener, LogListener,
 		BundleActivator {
 
 	private final Framework framework;
 	private final Logger logger;
 	private final String uuid = UUID.randomUUID().toString();
-	private final Map<Class<?>, ServiceTracker<?, ?>> trackerMap = new ConcurrentHashMap<Class<?>, ServiceTracker<?, ?>>();
+	private final Map<Class<?>, ServiceTracker<?, ?>> trackerMap = new ConcurrentHashMap<>();
 	private final ClassRealm realm;
 	final PlexusFrameworkConnectServiceFactory factory;
 	final boolean foreign;
@@ -313,29 +313,27 @@ class PlexusConnectFramework
 	@Override
 	public void start(BundleContext context) {
 		context.addFrameworkListener(this);
-		serviceTracker = new ServiceTracker<LogReaderService, LogReaderService>(
-				context, LogReaderService.class, new ServiceTrackerCustomizer<LogReaderService, LogReaderService>() {
+		serviceTracker = new ServiceTracker<>(context, LogReaderService.class, new ServiceTrackerCustomizer<>() {
 
-					@Override
-					public LogReaderService addingService(ServiceReference<LogReaderService> reference) {
-						LogReaderService service = context.getService(reference);
-						if (service != null) {
-							service.addLogListener(PlexusConnectFramework.this);
-						}
-						return service;
-					}
+			@Override
+			public LogReaderService addingService(ServiceReference<LogReaderService> reference) {
+				LogReaderService service = context.getService(reference);
+				if (service != null) {
+					service.addLogListener(PlexusConnectFramework.this);
+				}
+				return service;
+			}
 
-					@Override
-					public void modifiedService(ServiceReference<LogReaderService> reference,
-							LogReaderService service) {
-					}
+			@Override
+			public void modifiedService(ServiceReference<LogReaderService> reference, LogReaderService service) {
+			}
 
-					@Override
-					public void removedService(ServiceReference<LogReaderService> reference, LogReaderService service) {
-						service.removeLogListener(PlexusConnectFramework.this);
-						context.ungetService(reference);
-					}
-				});
+			@Override
+			public void removedService(ServiceReference<LogReaderService> reference, LogReaderService service) {
+				service.removeLogListener(PlexusConnectFramework.this);
+				context.ungetService(reference);
+			}
+		});
 		serviceTracker.open();
 	}
 

--- a/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusFrameworkConnectServiceFactory.java
+++ b/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusFrameworkConnectServiceFactory.java
@@ -200,7 +200,7 @@ public class PlexusFrameworkConnectServiceFactory implements Initializable, Disp
 		Map<String, String> frameworkProperties = new HashMap<>();
 		Enumeration<URL> resources;
 		try {
-			resources = classloader.getResources("META-INF/sisu-connect.properties");
+			resources = classloader.getResources("META-INF/sisu/connect.properties");
 		} catch (IOException e1) {
 			return frameworkProperties;
 		}
@@ -228,7 +228,8 @@ public class PlexusFrameworkConnectServiceFactory implements Initializable, Disp
 		Comparator<Bundle> byState = Comparator.comparingInt(Bundle::getState);
 		Arrays.stream(bundles).sorted(byState.thenComparing(bySymbolicName)).forEachOrdered(bundle -> {
 			String state = toBundleState(bundle.getState());
-			log.info(state + " | " + bundle.getSymbolicName() + " (" + bundle.getVersion() + ")");
+			log.info(state + " | " + bundle.getSymbolicName() + " (" + bundle.getVersion() + ") at "
+					+ bundle.getLocation());
 		});
 		ServiceTracker<ServiceComponentRuntime, ServiceComponentRuntime> st = new ServiceTracker<>(
 				framework.getBundleContext(), ServiceComponentRuntime.class, null);

--- a/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusFrameworkUtilHelper.java
+++ b/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusFrameworkUtilHelper.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.sisu.osgi.connect;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -45,23 +44,14 @@ public class PlexusFrameworkUtilHelper implements FrameworkUtilHelper {
 	}
 
 	public static void registerHelper(FrameworkUtilHelper helper) {
-		for (FrameworkUtilHelper spi : ServiceLoader.load(FrameworkUtilHelper.class,
-				FrameworkUtilHelper.class.getClassLoader())) {
-			Class<? extends FrameworkUtilHelper> spiHelperClass = spi.getClass();
-			Class<PlexusFrameworkUtilHelper> thisClass = PlexusFrameworkUtilHelper.class;
-			if (spiHelperClass.getName().equals(thisClass.getName())) {
-				if (spiHelperClass == thisClass) {
-					// register our instance here...
-					helpers.add(helper);
-				} else {
-					invokeForeignMethod(spiHelperClass, "registerHelper", helper);
-				}
-				break;
-			}
-		}
+		modifyHelperRegistry(helper, "registerHelper");
 	}
 
 	public static void unregisterHelper(FrameworkUtilHelper helper) {
+		modifyHelperRegistry(helper, "unregisterHelper");
+	}
+
+	private static void modifyHelperRegistry(FrameworkUtilHelper helper, String methodName) {
 		for (FrameworkUtilHelper spi : ServiceLoader.load(FrameworkUtilHelper.class,
 				FrameworkUtilHelper.class.getClassLoader())) {
 			Class<? extends FrameworkUtilHelper> spiHelperClass = spi.getClass();
@@ -71,7 +61,7 @@ public class PlexusFrameworkUtilHelper implements FrameworkUtilHelper {
 					// register our instance here...
 					helpers.add(helper);
 				} else {
-					invokeForeignMethod(spiHelperClass, "unregisterHelper", helper);
+					invokeForeignMethod(spiHelperClass, methodName, helper);
 				}
 				break;
 			}
@@ -82,8 +72,7 @@ public class PlexusFrameworkUtilHelper implements FrameworkUtilHelper {
 		try {
 			Method method = clazz.getMethod(methodName, FrameworkUtilHelper.class);
 			method.invoke(null, parameter);
-		} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
-				| InvocationTargetException e) {
+		} catch (ReflectiveOperationException e) {
 		}
 	}
 


### PR DESCRIPTION
This PR is split in two commits.

1. A few minor clean-ups/simplifications for the code of `sisu-osgi-connect` that I noticed while working on https://github.com/eclipse-tycho/tycho/pull/1328.

2. The path for the `connect.bundles` file is fixed in the release-notes and the path of the `connect.properties` is changed from `META-INF/sisu-connect.properties` to `META-INF/sisu/connect.properties`, to correspond to `META-INF/sisu/connect.bundles`.
@laeubi I assume that was the actual intention, wasn't it?