### PR TITLE
Move the RemoteRepositoryLoadingHelper out of OSGi bundles part

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/helper/P2PasswordUtil.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/helper/P2PasswordUtil.java
@@ -10,23 +10,23 @@
  * Contributors:
  *    Sonatype Inc. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.tycho.p2.remote;
+package org.eclipse.tycho.p2maven.helper;
 
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
+import org.codehaus.plexus.logging.Logger;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.p2.repository.IRepository;
 import org.eclipse.equinox.security.storage.ISecurePreferences;
 import org.eclipse.equinox.security.storage.SecurePreferencesFactory;
 import org.eclipse.equinox.security.storage.StorageException;
-import org.eclipse.tycho.core.shared.MavenLogger;
 
-class P2PasswordUtil {
+public class P2PasswordUtil {
 
-    static void setCredentials(URI location, String username, String password, MavenLogger logger) {
+	public static void setCredentials(URI location, String username, String password, Logger logger) {
         ISecurePreferences securePreferences = SecurePreferencesFactory.getDefault();
 
         // if URI is not opaque, just getting the host may be enough

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/helper/P2ServicesLifecycleListener.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/helper/P2ServicesLifecycleListener.java
@@ -1,0 +1,39 @@
+package org.eclipse.tycho.p2maven.helper;
+
+import java.util.Map;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
+import org.eclipse.sisu.equinox.embedder.EmbeddedEquinox;
+import org.eclipse.sisu.equinox.embedder.EquinoxLifecycleListener;
+import org.eclipse.tycho.IRepositoryIdManager;
+import org.osgi.framework.Constants;
+
+/**
+ * This registers maven components as {@link IAgentServiceFactory}s inside the
+ * OSGi framework
+ */
+@Component(role = EquinoxLifecycleListener.class, hint = "P2Services")
+public class P2ServicesLifecycleListener implements EquinoxLifecycleListener {
+
+	@Requirement
+	IRepositoryIdManager repositoryIdManager;
+
+	@Override
+	public void afterFrameworkStarted(EmbeddedEquinox framework) {
+		registerAgentFactory(repositoryIdManager, IRepositoryIdManager.SERVICE_NAME, framework);
+	}
+
+	private void registerAgentFactory(Object service, String serviceName, EmbeddedEquinox framework) {
+		framework.registerService(IAgentServiceFactory.class, new IAgentServiceFactory() {
+
+			@Override
+			public Object createService(IProvisioningAgent agent) {
+				return service;
+			}
+		}, Map.of(Constants.SERVICE_RANKING, 100, IAgentServiceFactory.PROP_CREATED_SERVICE_NAME, serviceName));
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/RemoteRepositoryLoadingHelper.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/RemoteRepositoryLoadingHelper.java
@@ -11,7 +11,7 @@
  *    SAP AG - initial API and implementation
  *    Christoph Läubrich - Issue #797 - Implement a caching P2 transport  
  *******************************************************************************/
-package org.eclipse.tycho.p2.remote;
+package org.eclipse.tycho.p2maven.repository;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -19,26 +19,27 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
 import org.eclipse.tycho.IRepositoryIdManager;
 import org.eclipse.tycho.MavenRepositoryLocation;
 import org.eclipse.tycho.MavenRepositorySettings;
-import org.eclipse.tycho.core.shared.MavenLogger;
+import org.eclipse.tycho.p2maven.helper.P2PasswordUtil;
 
 /**
  * Helper class for the Remote*RepositoryManagers taking care of mapping repository URLs to the
  * settings.xml-configured mirrors and setting passwords.
  */
-class RemoteRepositoryLoadingHelper implements IRepositoryIdManager {
+@Component(role = IRepositoryIdManager.class)
+public class RemoteRepositoryLoadingHelper implements IRepositoryIdManager {
 
-    private final MavenRepositorySettings settings;
-    private final MavenLogger logger;
+	@Requirement
+	private MavenRepositorySettings settings;
+	@Requirement
+	private Logger logger;
 
     private Map<URI, String> knownMavenRepositoryIds = new ConcurrentHashMap<>();
-
-    public RemoteRepositoryLoadingHelper(MavenRepositorySettings settings, MavenLogger logger) {
-        this.settings = settings;
-        this.logger = logger;
-    }
 
     @Override
     public void addMapping(String mavenRepositoryId, URI location) {
@@ -69,7 +70,8 @@ class RemoteRepositoryLoadingHelper implements IRepositoryIdManager {
         }
     }
 
-    public URI getEffectiveLocation(URI location) {
+    @Override
+	public URI getEffectiveLocation(URI location) {
         if (certainlyNoRemoteURL(location)) {
             return location;
         }
@@ -78,7 +80,8 @@ class RemoteRepositoryLoadingHelper implements IRepositoryIdManager {
         return effectiveLocation.getURL();
     }
 
-    public URI getEffectiveLocationAndPrepareLoad(URI location) {
+    @Override
+	public URI getEffectiveLocationAndPrepareLoad(URI location) {
         if (certainlyNoRemoteURL(location)) {
             return location;
         }
@@ -136,7 +139,8 @@ class RemoteRepositoryLoadingHelper implements IRepositoryIdManager {
         return location.isOpaque() || !location.isAbsolute();
     }
 
-    public Stream<MavenRepositoryLocation> getKnownMavenRepositoryLocations() {
+    @Override
+	public Stream<MavenRepositoryLocation> getKnownMavenRepositoryLocations() {
         return knownMavenRepositoryIds.entrySet().stream()
                 .map(e -> new MavenRepositoryLocation(e.getValue(), e.getKey()));
     }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMavenMirrorsTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMavenMirrorsTest.java
@@ -63,6 +63,8 @@ public class RemoteAgentMavenMirrorsTest {
 
         mavenRepositorySettings = new MavenRepositorySettingsStub();
         subject = new RemoteAgent(mavenContext, null, mavenRepositorySettings, OFFLINE);
+        IRepositoryIdManager idManager = subject.getService(IRepositoryIdManager.class);
+        System.out.println(idManager);
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/RemoteAgent.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/RemoteAgent.java
@@ -100,6 +100,7 @@ public class RemoteAgent implements IProvisioningAgent {
         }
 
         if (mavenRepositorySettings != null) {
+            agent.registerService(MavenRepositorySettings.class, mavenRepositorySettings);
             addMavenAwareRepositoryManagers(agent, mavenRepositorySettings, mavenContext.getLogger());
         }
 
@@ -119,9 +120,7 @@ public class RemoteAgent implements IProvisioningAgent {
     private static void addMavenAwareRepositoryManagers(AgentBuilder agent,
             MavenRepositorySettings mavenRepositorySettings, MavenLogger logger) {
 
-        // register service which stores mapping between URLs and IDs (used by Maven)
-        IRepositoryIdManager loadingHelper = new RemoteRepositoryLoadingHelper(mavenRepositorySettings, logger);
-        agent.registerService(IRepositoryIdManager.class, loadingHelper);
+        IRepositoryIdManager loadingHelper = agent.getAgent().getService(IRepositoryIdManager.class);
 
         // wrap metadata repository manager
         IMetadataRepositoryManager plainMetadataRepoManager = agent.getService(IMetadataRepositoryManager.class);

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/p2/remote/testutil/NoopRepositoryIdManager.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/p2/remote/testutil/NoopRepositoryIdManager.java
@@ -13,30 +13,99 @@
 package org.eclipse.tycho.p2.remote.testutil;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.tycho.IRepositoryIdManager;
 import org.eclipse.tycho.MavenRepositoryLocation;
+import org.eclipse.tycho.MavenRepositorySettings;
 
 public class NoopRepositoryIdManager implements IRepositoryIdManager {
 
+    private IProvisioningAgent agent;
+
+    public NoopRepositoryIdManager(IProvisioningAgent agent) {
+        this.agent = agent;
+    }
+
+    private Map<URI, String> knownMavenRepositoryIds = new ConcurrentHashMap<>();
+
     @Override
-    public void addMapping(String id, URI location) {
+    public void addMapping(String mavenRepositoryId, URI location) {
+        if (mavenRepositoryId == null)
+            return;
+
+        URI key = normalize(location);
+        knownMavenRepositoryIds.put(key, mavenRepositoryId);
+
+    }
+
+    private static URI normalize(URI location) {
+        // remove trailing slashes
+        try {
+            String path = location.getPath();
+            if (path != null && path.endsWith("/")) {
+                return new URI(location.getScheme(), location.getAuthority(), path.substring(0, path.length() - 1),
+                        location.getQuery(), location.getFragment());
+            } else {
+                return location;
+            }
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
     public URI getEffectiveLocation(URI location) {
-        return location;
+        if (certainlyNoRemoteURL(location)) {
+            return location;
+        }
+
+        MavenRepositoryLocation effectiveLocation = effectiveLocationFor(location, false);
+        return effectiveLocation.getURL();
     }
 
     @Override
     public URI getEffectiveLocationAndPrepareLoad(URI location) {
-        return location;
+        if (certainlyNoRemoteURL(location)) {
+            return location;
+        }
+
+        MavenRepositoryLocation effectiveLocation = effectiveLocationFor(location, true);
+        return effectiveLocation.getURL();
+    }
+
+    private MavenRepositoryLocation effectiveLocationFor(URI location, boolean forLoading) {
+        URI normalizedLocation = normalize(location);
+
+        String id = knownMavenRepositoryIds.get(normalizedLocation);
+        if (id == null) {
+            // fall back to URL as ID
+            id = normalizedLocation.toString();
+        }
+        MavenRepositoryLocation locationWithID = new MavenRepositoryLocation(id, normalizedLocation);
+
+        MavenRepositorySettings service = agent.getService(MavenRepositorySettings.class);
+        MavenRepositoryLocation mirror = service.getMirror(locationWithID);
+        if (mirror != null) {
+            return mirror;
+        } else {
+            return locationWithID;
+        }
+    }
+
+    private static boolean certainlyNoRemoteURL(URI location) {
+        // e.g. in-memory composite artifact repositories; see see org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository.createMemoryComposite(IProvisioningAgent)
+        return location.isOpaque() || !location.isAbsolute();
     }
 
     @Override
     public Stream<MavenRepositoryLocation> getKnownMavenRepositoryLocations() {
-        return Stream.empty();
+        return knownMavenRepositoryIds.entrySet().stream()
+                .map(e -> new MavenRepositoryLocation(e.getValue(), e.getKey()));
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/p2/remote/testutil/NoopRepositoryIdManagerFactory.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/p2/remote/testutil/NoopRepositoryIdManagerFactory.java
@@ -28,7 +28,7 @@ public class NoopRepositoryIdManagerFactory implements IAgentServiceFactory {
 
     @Override
     public Object createService(IProvisioningAgent agent) {
-        return new NoopRepositoryIdManager();
+        return new NoopRepositoryIdManager(agent);
     }
 
 }


### PR DESCRIPTION
This is finally the first attempt to begin moving out parts from the OSGi Bundles > Maven World and connect both with a simple AgentFactory registration.