### PR TITLE
Reproducer for generate-sources issue

### DIFF
--- a/tycho-its/projects/resolver.generateSources/a/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.generateSources/a/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Automatic-Module-Name: a
+Bundle-ManifestVersion: 2
+Bundle-Name: a
+Bundle-Vendor: My Company
+Bundle-Version: 1.0.0.qualifier
+Bundle-SymbolicName: a; singleton:=true
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/resolver.generateSources/a/build.properties
+++ b/tycho-its/projects/resolver.generateSources/a/build.properties
@@ -1,0 +1,3 @@
+source.. = src/
+bin.includes = .,\
+               META-INF/

--- a/tycho-its/projects/resolver.generateSources/a/pom.xml
+++ b/tycho-its/projects/resolver.generateSources/a/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.lppedd.tycho.repro</groupId>
+		<artifactId>repro-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>a</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/resolver.generateSources/b/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.generateSources/b/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Automatic-Module-Name: b
+Bundle-ManifestVersion: 2
+Bundle-Name: b
+Bundle-Vendor: My Company
+Bundle-Version: 1.0.0.qualifier
+Bundle-SymbolicName: b; singleton:=true
+Bundle-ActivationPolicy: lazy
+Require-Bundle: a
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/resolver.generateSources/b/build.properties
+++ b/tycho-its/projects/resolver.generateSources/b/build.properties
@@ -1,0 +1,3 @@
+source.. = src/
+bin.includes = .,\
+               META-INF/

--- a/tycho-its/projects/resolver.generateSources/b/pom.xml
+++ b/tycho-its/projects/resolver.generateSources/b/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.lppedd.tycho.repro</groupId>
+    <artifactId>repro-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>b</artifactId>
+  <packaging>eclipse-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <source>${project.basedir}/scripts/example.groovy</source>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tycho-its/projects/resolver.generateSources/b/scripts/example.groovy
+++ b/tycho-its/projects/resolver.generateSources/b/scripts/example.groovy
@@ -1,0 +1,2 @@
+final dataDir = new File(basedir, 'data')
+println "reproducer! $dataDir"

--- a/tycho-its/projects/resolver.generateSources/pom.xml
+++ b/tycho-its/projects/resolver.generateSources/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.lppedd.tycho.repro</groupId>
+  <version>1.0.0-SNAPSHOT</version>
+  <artifactId>repro-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>tycho-snapshots</id>
+      <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <tycho-version>2.7.5</tycho-version>
+  </properties>
+
+  <modules>
+    <module>a</module>
+    <module>b</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.gmaven</groupId>
+          <artifactId>groovy-maven-plugin</artifactId>
+          <version>2.1.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <environments>
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+          </environments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/TychoGenerateSourcesIssueTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/TychoGenerateSourcesIssueTest.java
@@ -1,0 +1,17 @@
+package org.eclipse.tycho.test.resolver;
+
+import java.util.List;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class TychoGenerateSourcesIssueTest extends AbstractTychoIntegrationTest {
+    @Test
+    public void testTychoGenerateSourcesIssue() throws Exception {
+        Verifier verifier = getVerifier("resolver.generateSources", false, false);
+        verifier.addCliOption("-Dtycho.resolver.classic=false");
+        verifier.executeGoals(List.of("clean", "generate-sources"));
+        verifier.verifyErrorFreeLog();
+    }
+}


### PR DESCRIPTION
Command from root project directory: `mvn clean generate-sources`
(**do not** `install` before)

Expected issue output:
```
[INFO] Reactor Summary for repro-parent 1.0.0-SNAPSHOT:
[INFO]
[INFO] repro-parent ....................................... SUCCESS [  0.059 s]
[INFO] a .................................................. SUCCESS [  3.354 s]
[INFO] b .................................................. FAILURE [  0.005 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58.727 s
[INFO] Finished at: 2022-09-22T11:20:47+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project b: Could not resolve dependencies for project com.lppedd.tycho.repro:b:eclipse-plugin:1.0.0-SNAPSHOT: Could not find artifact com.lppedd.tycho.repro:a:jar:1.0.0-SNAPSHOT -> [Help 1]    
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :b
```

This is a follow up for [this comment](https://github.com/eclipse-tycho/tycho/pull/1323#issuecomment-1254142927).