### PR TITLE
Backport fix for missing method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,11 @@
 			    <artifactId>bcprov-jdk18on</artifactId>
 			    <version>(,1.71]</version>
 			</dependency>
+			<dependency>
+			 	<groupId>org.bouncycastle</groupId>
+  				<artifactId>bcpg-jdk18on</artifactId>
+  				 <version>(,1.71]</version>
+  			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusFrameworkConnectServiceFactory.java
+++ b/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusFrameworkConnectServiceFactory.java
@@ -387,4 +387,14 @@ public class PlexusFrameworkConnectServiceFactory implements Initializable, Disp
 		}
 		return null;
 	}
+
+	// DO NOT DELETE THIS METHOD! It is referenced by reflection in
+	// getForeignFramework!
+	public static Framework getOsgiFramework(ClassRealm realm) {
+		PlexusConnectFramework cachedFramework = frameworkMap.get(realm);
+		if (cachedFramework != null) {
+			return cachedFramework.getFramework();
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
The method
PlexusFrameworkConnectServiceFactory.getOsgiFramework(ClassRealm) was accidentally deleted