### PR TITLE
[Setup] Add Oomph-configuration setup for Tycho

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ and the minimal reproducer project to Tycho's [issue tracker](https://github.com
 
 ## Development environment
 
+[![Create Eclipse Development Environment for Tycho](https://download.eclipse.org/oomph/www/setups/svg/tycho.svg)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-tycho/tycho/master/setup/TychoDevelopmentConfiguration.setup&show=true "Click to open Eclipse-Installer Auto Launch or drag into your running installer")
+
+&nbsp;&nbsp;&nbsp;or just&nbsp;&nbsp;&nbsp;
+
 <a href="https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/redirect.html"><img src="https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/cloneToEclipseBadge.png" alt="Clone to Eclipse IDE"/></a>
 
 ### Prerequisites

--- a/setup/Tycho.setup
+++ b/setup/Tycho.setup
@@ -15,6 +15,22 @@
     xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore http://www.eclipse.org/oomph/setup/pde/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/PDE.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore"
     name="tycho"
     label="Tycho">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://www.eclipse.org/downloads/images/committers.png</value>
+    </detail>
+    <detail
+        key="siteURI">
+      <value>https://www.eclipse.org/tycho/</value>
+    </detail>
+  </annotation>
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+    <reference
+        href="TychoDevelopmentConfiguration.setup#/"/>
+  </annotation>
   <setupTask
       xsi:type="setup:CompoundTask"
       name="User Preferences">

--- a/setup/TychoDevelopmentConfiguration.setup
+++ b/setup/TychoDevelopmentConfiguration.setup
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Configuration
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    label="Tycho Development Environment">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://www.eclipse.org/downloads/images/committers.png</value>
+    </detail>
+    <detail
+        key="siteURI">
+      <value>https://www.eclipse.org/tycho/</value>
+    </detail>
+  </annotation>
+  <installation
+      name="tycho.dev.installation"
+      label="Tycho Development Installation">
+    <productVersion
+        href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.products']/@products[name='epp.package.committers']/@versions[name='latest']"/>
+    <description>The Tycho development environment installation provides the full environment to develop for Eclipse Tycho.</description>
+  </installation>
+  <workspace
+      name="tycho.dev.workspace"
+      label="Tycho Development Workspace">
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='tycho']/@streams[name='master']"/>
+    <description>The Tycho development environment workspace includes all modules and tests of Eclipse Tycho.</description>
+  </workspace>
+  <description>
+    &lt;p>
+    The &lt;a href=&quot;https://www.eclipse.org/tycho/&quot;/>Tycho&lt;/a> Development Environment configuration provisions a dedicated development environment 
+    for the complete set of source projects used by &lt;a href=&quot;https://ci.eclipse.org/tycho/&quot;>Tycho's build server&lt;/a> 
+    to produce &lt;a href=&quot;https://repo1.maven.org/maven2/org/eclipse/tycho/&quot;>Eclipse Tycho Maven plugins&lt;/a>.
+    &lt;/p>
+    &lt;p>
+    The installation is based on the latest milestone or release candiate of the Eclipse-for-commiters.
+    The workspace consists of all the projects from &lt;a href=&quot;https://github.com/eclipse-tycho/tycho.git&quot;>tycho's Git Repository&lt;/a>
+    , organized into working sets, and ready for contribution.
+    &lt;/p>
+    &lt;/p>
+    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the analgous tutorial instructions&lt;/a> for the Eclispe Platform SDK's configuration for more details.
+    &lt;/p>
+  </description>
+</setup:Configuration>


### PR DESCRIPTION
Fixes https://github.com/eclipse-tycho/tycho/issues/24

Based on the Oomph Config for M2E I created one for Tycho and added a Button  to use it to the Contribution guide.
The button image will be created at https://download.eclipse.org/oomph/www/setups/svg/ when the setup exists, which is checked by a Oomph build job once a day (IIRC), but I can check that again.

Furthermore we can add an icon for Tycho that is displayed with the description if one opens the config. For M2E I reused the IDE icon, but for Tycho I didn't found any suitable icon. So if somebody can suggest one, I can reference it (it has to be somewhere on the internet) but we can probably also leaf that blank.

@laeubi what do you think about the descriptions?

We could also add the Button more prominent in the main READ.ME, like M2E does it?