### PR TITLE
Fix broken equals in StandardEEResolutionHints

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/ee/impl/StandardEEResolutionHints.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/ee/impl/StandardEEResolutionHints.java
@@ -138,7 +138,7 @@ public final class StandardEEResolutionHints implements ExecutionEnvironmentReso
 
     @Override
     public boolean equals(Object obj) {
-        return this == obj && //
+        return this == obj || //
                 (obj instanceof StandardEEResolutionHints other
                         && Objects.equals(executionEnvironment, other.executionEnvironment));
     }


### PR DESCRIPTION
Regression from e261bbe1889964c5a0e60083952521e6a42f2567

This causes the target platform to be resolved over and over again, FYI @mickaelistria 

By the way this shows that less lines do not imply less errors / better code, this was really hard to debug as the method looks so innocent and obvious here...