### PR TITLE
Inject jars.extra.classpath jars into the maven model

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/publisher/AbstractMetadataGenerator.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/publisher/AbstractMetadataGenerator.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -42,6 +41,7 @@ import org.eclipse.tycho.IDependencyMetadata.DependencyMetadataType;
 import org.eclipse.tycho.Interpolator;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.TargetEnvironment;
+import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.p2.metadata.IArtifactFacade;
 import org.eclipse.tycho.p2.metadata.PublisherOptions;
 import org.eclipse.tycho.repository.util.StatusTool;
@@ -112,8 +112,7 @@ public abstract class AbstractMetadataGenerator {
     }
 
     private void createRequirementFromPlatformURL(ArrayList<IRequirement> result, String url) {
-        Pattern platformURL = Pattern.compile("platform:/(plugin|fragment)/([^/]*)(/)*.*");
-        Matcher m = platformURL.matcher(url);
+        Matcher m = TychoConstants.PLATFORM_URL_PATTERN.matcher(url);
         if (m.matches())
             result.add(MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, m.group(2),
                     VersionRange.emptyRange, null, false, false));

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.tycho;
 
+import java.util.regex.Pattern;
+
 public interface TychoConstants {
 
     static final String P2_GROUPID_PREFIX = "p2.";
@@ -39,6 +41,8 @@ public interface TychoConstants {
 
     static final String CTX_DEPENDENCY_WALKER = CTX_BASENAME + "/dependencyWalker";
     static final String CTX_DEPENDENCY_SEEDS = CTX_BASENAME + "/dependencySeeds";
+
+    static final Pattern PLATFORM_URL_PATTERN = Pattern.compile("platform:/(plugin|fragment)/([^/]*)(/)*.*");
 
     public String JAR_EXTENSION = "jar";
 


### PR DESCRIPTION
Currently jars.extra.classpath are only handled at some place internally by Tycho but actually the contribute to the compile model of maven.

Injecting those as well, makes them visible to standard maven tolls like the maven-javadoc-plugin