### PR TITLE
Clarify CONTRIBUTING.md about mojo changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,9 +247,9 @@ The micro version will only be used for critical bug-fix releases, in most other
 The following list contains changes that only can happen between major version updates:
 
 - changing the java version to run the build
-- requiring a new minimum Maven version (e.g. once we require maven 4)
+- requiring a new minimum maven version (e.g. once we require maven 4.x)
 - requiring to change their pom.xml in a non trivial way (e.g. beside
-changing some configuration value in an existing mojo)
+changing some configuration value in an existing mojo, or providing a drop-in replacement in the migration guide)
 
 If you require such a change, please note that in the issue and we will assign the next major release to it, those changes would not be merged until the next major release keep your changes small and local as it possible take some time and you probably have to catch up with minor changes in the meantime.
 


### PR DESCRIPTION
@mickaelistria @akurtakov We have already recently talked about that we do not want require a majo-version for mojo changes that are compatible (e.g. just moving a mojo or replace it by something other), but this was not reflected in the contributing guide.

Therefore I'd like to propose the following change.