### PR TITLE
Do not bind integration-test mojo to the default life-cycle

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,39 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ## 3.1.0 (under development)
 
+### Migration guide
+
+#### Using integration/plugin tests with eclipse-plugin packaging
+
+Some improvements have been made for the test execution with `eclipse-plugin` packaging that probably needs some adjustments to your pom configuration or build scripts:
+
+1. The property `skipITs` has been renamed to `tycho.plugin-test.skip`
+2. the mojo `integration-test` has been renamed to `plugin-test`
+3. the default pattern of the former `integration-test` has been changed from `**/PluginTest*.class", "**/*IT.class` to the maven default `**/Test*.class", "**/*Test.class", "**/*Tests.class", "**/*TestCase.class`
+4. the former `integration-test` mojo is no longer part of the default life-cycle, that means to use it it has to be explicitly be enabled to be more flexible and this is how standard maven behaves
+
+To restore old behaviour you can add the follwoing snippet to your (master) pom:
+
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-surefire-plugin</artifactId>
+	<version>${tycho-version}</version>
+	<executions>
+		<execution>
+			<id>execute-plugin-tests</id>
+			<configuration>
+				<includes>**/PluginTest*.class,**/*IT.class</includes>
+			</configuration>
+			<goals>
+				<goal>plugin-test</goal>
+				<goal>verify</goal>
+			</goals>
+		</execution>
+	</executions>
+</plugin>
+```
+
 ### New Maven dependency consistency check
 
 Tycho has a new mojo to check the consistency of the pom used for your bundle.

--- a/tycho-its/projects/surefire.combinedtests/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.combinedtests/bundle.test/pom.xml
@@ -5,6 +5,10 @@
 	<artifactId>bundle.test</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	<version>1.0.0</version>
+	<properties>
+		<target-platform>https:////download.eclipse.org/releases/2022-09/</target-platform>
+		<tycho-version>3.1.0-SNAPSHOT</tycho-version>
+	</properties>
 	<repositories>
 		<repository>
 			<id>platform</id>
@@ -32,6 +36,23 @@
 						<version>3.0.0-M5</version>
 					</dependency>
 				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>execute-plugin-tests</id>
+						<configuration>
+							<includes>**/PluginTest*.class,**/*IT.class</includes>
+						</configuration>
+						<goals>
+							<goal>plugin-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -47,10 +47,8 @@
                 org.eclipse.tycho:tycho-p2-plugin:${project.version}:p2-metadata-default
               </package>
               <integration-test>
-               org.eclipse.tycho:tycho-surefire-plugin:${project.version}:integration-test
               </integration-test>
               <verify>
-               org.apache.maven.plugins:maven-failsafe-plugin:${surefire-plugin.version}:verify
               </verify>
               <install>
                 org.apache.maven.plugins:maven-install-plugin:${install-plugin.version}:install,

--- a/tycho-surefire/tycho-surefire-plugin/pom.xml
+++ b/tycho-surefire/tycho-surefire-plugin/pom.xml
@@ -263,6 +263,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+		      <groupId>org.apache.maven.plugins</groupId>
+	          <artifactId>maven-failsafe-plugin</artifactId>
+	          <version>${surefire-version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.surefire</groupId>
 			<artifactId>surefire-api</artifactId>
 			<version>${surefire-version}</version>

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -690,6 +690,10 @@ public abstract class AbstractTestMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!isCompatiblePackagingType(project.getPackaging())) {
+            getLog().debug("Skip because of incompatible packaging type: " + project.getPackaging());
+            return;
+        }
         if (shouldSkip()) {
             getLog().info("Skipping tests");
             return;
@@ -719,6 +723,8 @@ public abstract class AbstractTestMojo extends AbstractMojo {
             }
         }
     }
+
+    protected abstract boolean isCompatiblePackagingType(String packaging);
 
     protected abstract boolean shouldRun();
 
@@ -1051,7 +1057,9 @@ public abstract class AbstractTestMojo extends AbstractMojo {
         return Arrays.asList("**/*$*");
     }
 
-    protected abstract List<String> getDefaultInclude();
+    protected List<String> getDefaultInclude() {
+        return List.of("**/Test*.class", "**/*Test.class", "**/*Tests.class", "**/*TestCase.class");
+    }
 
     private void storeProperties(Map<String, String> propertiesMap, File file) throws MojoExecutionException {
         Properties p = new Properties();

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TestPluginMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TestPluginMojo.java
@@ -17,8 +17,6 @@
 package org.eclipse.tycho.surefire;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -71,19 +69,12 @@ public class TestPluginMojo extends AbstractTestMojo {
 
     @Override
     protected boolean shouldRun() {
-        if (PackagingType.TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging())) {
-            return false;
-        }
-        if (!PackagingType.TYPE_ECLIPSE_TEST_PLUGIN.equals(project.getPackaging())) {
-            getLog().warn("Unsupported packaging type " + project.getPackaging());
-            return false;
-        }
         return true;
     }
 
     @Override
-    protected List<String> getDefaultInclude() {
-        return Arrays.asList("**/Test*.class", "**/*Test.class", "**/*Tests.class", "**/*TestCase.class");
+    protected boolean isCompatiblePackagingType(String packaging) {
+        return PackagingType.TYPE_ECLIPSE_TEST_PLUGIN.equals(project.getPackaging());
     }
 
     @Override

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
@@ -13,7 +13,6 @@
 package org.eclipse.tycho.surefire;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -80,7 +79,7 @@ import aQute.bnd.osgi.Jar;
  * summary files are generated according to the default maven-surefire-plugin for integration with
  * tools that already work with maven-surefire-plugin (e.g. CI servers)
  */
-@Mojo(name = "integration-test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+@Mojo(name = "plugin-test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class TychoIntegrationTestMojo extends AbstractTestMojo {
 
     /**
@@ -89,7 +88,7 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
     @Parameter(property = "project.build.testOutputDirectory")
     private File testClassesDirectory;
 
-    @Parameter(property = "skipITs")
+    @Parameter(property = "tycho.plugin-test.skip")
     private boolean skipITs;
 
     @Parameter(defaultValue = "${project.build.directory}/failsafe-reports/failsafe-summary.xml", required = true)
@@ -112,12 +111,12 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
 
     @Override
     protected boolean shouldRun() {
-        return PackagingType.TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging()) && scanForTests().size() > 0;
+        return scanForTests().size() > 0;
     }
 
     @Override
-    protected List<String> getDefaultInclude() {
-        return Arrays.asList("**/PluginTest*.class", "**/*IT.class");
+    protected boolean isCompatiblePackagingType(String packaging) {
+        return PackagingType.TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging());
     }
 
     @Override

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoVerifyMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoVerifyMojo.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.tycho.surefire;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.failsafe.VerifyMojo;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.tycho.PackagingType;
+
+/**
+ * Verifies plugin-test runs from the integration-test stage
+ */
+@Mojo(name = "verify", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
+public class TychoVerifyMojo extends VerifyMojo {
+
+    @Parameter(property = "project", readonly = true)
+    protected MavenProject project;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (PackagingType.TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging())) {
+            super.execute();
+        }
+    }
+}


### PR DESCRIPTION
Also it is better named plugin-test mojo instead as users still could use the failsafe integration-test mojo as well if desired.

Fix https://github.com/eclipse-tycho/tycho/issues/1495