### PR TITLE
Add a surrogate implementation of UI dependencies

### DIFF
--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/pom.xml
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/pom.xml
@@ -45,7 +45,7 @@
 				<executions>
 					<execution>
 						<id>copy</id>
-						<phase>process-resources</phase>
+						<phase>validate</phase>
 						<goals>
 							<goal>copy</goal>
 						</goals>

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/ui/PlatformUI.java
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/ui/PlatformUI.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui;
+
+import org.eclipse.ui.testing.TestableObject;
+
+/**
+ * Surrogate object in case optional import can not be resolved
+ */
+public class PlatformUI {
+
+    public static TestableObject getTestableObject() {
+        throw new IllegalStateException(
+                "Can't create TestableObject make sure bundle 'org.eclipse.ui.workbench' is available in your test setup");
+    }
+
+}

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/ui/testing/ITestHarness.java
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/ui/testing/ITestHarness.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2015 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.ui.testing;
+
+/**
+ * Represents an arbitrary test harness.
+ *
+ * @since 3.0
+ */
+public interface ITestHarness {
+
+    /**
+     * Runs the tests.
+     */
+    public void runTests();
+
+}

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/ui/testing/TestableObject.java
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/ui/testing/TestableObject.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2015 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.ui.testing;
+
+import org.eclipse.core.runtime.AssertionFailedException;
+
+/**
+ * A testable object. Allows a test harness to register itself with a testable object. The test
+ * harness is notified of test-related lifecycle events, such as when is an appropriate time to run
+ * tests on the object. This also provides API for running tests as a runnable, and for signaling
+ * when the tests are starting and when they are finished.
+ * <p>
+ * The workbench provides an implementation of this facade, available via
+ * <code>PlatformUI.getTestableObject()</code>.
+ * </p>
+ *
+ * @since 3.0
+ */
+public class TestableObject {
+
+    private ITestHarness testHarness;
+
+    public ITestHarness getTestHarness() {
+        return testHarness;
+    }
+
+    /**
+     * Sets the test harness.
+     *
+     * @param testHarness
+     *            the test harness
+     */
+    public void setTestHarness(ITestHarness testHarness) {
+        if (testHarness == null)
+            throw new AssertionFailedException("null argument:");
+        this.testHarness = testHarness;
+    }
+
+    /**
+     * Runs the given test runnable. The default implementation simply invokes <code>run</code> on
+     * the given test runnable. Subclasses may extend.
+     *
+     * @param testRunnable
+     *            the test runnable to run
+     */
+    public void runTest(Runnable testRunnable) {
+        testRunnable.run();
+    }
+
+    /**
+     * Notification from the test harness that it is starting to run the tests. The default
+     * implementation does nothing. Subclasses may override.
+     */
+    public void testingStarting() {
+        // do nothing
+    }
+
+    /**
+     * Notification from the test harness that it has finished running the tests. The default
+     * implementation does nothing. Subclasses may override.
+     */
+    public void testingFinished() {
+        // do nothing
+    }
+}


### PR DESCRIPTION
There is an optional import for org.eclipse.ui.workbench to support UI test. If the import can not be resolved, there is no fallback in two scenarios:

1. we only want compile but do not pull in half of platform 
2. the bundle can not be resolved

for those cases the minimal necessary API is copied into the bundle that will be shaded by the imports if available in the running system.

FYI @akurtakov @mickaelistria this is an attempt to reduce the compile time dependencies to platform-ui what pulls in a large dependency chain and has many bad maven meta-data that causes trouble...