### PR TITLE
Add user-properties for tycho-surefire 'useUIThread' and 'useUIHarness'

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ### Migration guide 3.x > 4.x
 
+#### Properties for tycho-surefire-plugin's 'useUIThread' and 'useUIHarness' parameters
+
+The configuration parameters `useUIThread` and `useUIHarness` parameter of the `tycho-surefire-plugin` can now be set via the properties `tycho.surefire.useUIHarness` respectively `tycho.surefire.useUIThread`.
+
 #### Minimum version for running integration/plugin tests
 
 Previously the `osgibooter` has claimed to be Java 1.5 compatible but as such old JVMs are hard to find/test against already some newer code was slipping in. It was therefore decided to raise the minimum requirement to Java 1.8 what implicitly makes it the lowest bound for running integration/plugin tests with Tycho.

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -107,7 +107,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
 
     private static final String SYSTEM_JDK = "jdk";
 
-    private static String[] UNIX_SIGNAL_NAMES = { "not a signal", // padding, signals start with 1
+    private static final String[] UNIX_SIGNAL_NAMES = { "not a signal", // padding, signals start with 1
             "SIGHUP", "SIGINT", "SIGQUIT", "SIGILL", "SIGTRAP", "SIGABRT", "SIGBUS", "SIGFPE", "SIGKILL", "SIGUSR1",
             "SIGSEGV", "SIGUSR2", "SIGPIPE", "SIGALRM", "SIGTERM", "SIGSTKFLT", "SIGCHLD", "SIGCONT", "SIGSTOP",
             "SIGTSTP", "SIGTTIN", "SIGTTOU", "SIGURG", "SIGXCPU", "SIGXFSZ", "SIGVTALRM", "SIGPROF", "SIGWINCH",
@@ -310,13 +310,13 @@ public abstract class AbstractTestMojo extends AbstractMojo {
     /**
      * Run tests using UI (true) or headless (false) test harness.
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(property = "tycho.surefire.useUIHarness", defaultValue = "false")
     private boolean useUIHarness;
 
     /**
      * Run tests in UI (true) or background (false) thread. Only applies to UI test harness.
      */
-    @Parameter(defaultValue = "true")
+    @Parameter(property = "tycho.surefire.useUIThread", defaultValue = "true")
     private boolean useUIThread;
 
     /**


### PR DESCRIPTION
This allows to configure `useUIHarness` and `useUIThread` of the `tycho-surefire-plugin` via properties, for example on the command-line or via corresponding pom.model.property.* entries in the build.properties.

At least for Eclipse Platform projects setting the mentioned properties is/was sometimes the only reason to have a pom.xml for a test plugin.
One could work make such properties available by adding the following snippet to the root pom, but this little change makes even that obsolete.
```
  <properties>
    <tycho.surefire.useUIHarness>false</tycho.surefire.useUIHarness>
    <tycho.surefire.useUIThread>true</tycho.surefire.useUIThread>
  </properties>

    <pluginManagement>
      <plugins>
        <plugin>
          <groupId>org.eclipse.tycho</groupId>
          <artifactId>tycho-surefire-plugin</artifactId>
          <configuration>
            <useUIHarness>${tycho.surefire.useUIHarness}</useUIHarness>
            <useUIThread>${tycho.surefire.useUIThread}</useUIThread>
          </configuration>
        </plugin>
      </plugins>
    </pluginManagement>
```