### PR TITLE
Fix build path errors

### DIFF
--- a/sisu-osgi/sisu-osgi-connect/.classpath
+++ b/sisu-osgi/sisu-osgi-connect/.classpath
@@ -28,11 +28,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tycho-apitools-plugin/.classpath
+++ b/tycho-apitools-plugin/.classpath
@@ -23,16 +23,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tycho-build/.classpath
+++ b/tycho-build/.classpath
@@ -23,16 +23,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tycho-ds-plugin/.classpath
+++ b/tycho-ds-plugin/.classpath
@@ -28,11 +28,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
Just rerun "Update Maven projects" on all existing projects, no manual changes. The removed entries all caused build path errors complaining about non existing source/resource folders. With this change, I have only warnings remaining, but no errors.

<img width="483" alt="image" src="https://user-images.githubusercontent.com/406876/198520658-a3ddf12f-05a5-41b9-b7b4-7cf0364c15e7.png">

If you remember the discussion from EclipseCon: As long as the build path still contained errors, I had to manually fix them (like setting the classpath entries optional). Once all build path errors were fixed manually, the "Update Maven projects" action was suddenly able to fix the errors on its own (i.e. overwriting my "optional" and just removing the entries).