### PR TITLE
Avoid BND warning about missing developer id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,19 +42,11 @@
 	</scm>
 	<developers>
 		<developer>
-			<name>Igor Fedorenko</name>
-			<organization>Sonatype</organization>
-			<organizationUrl>https://www.sonatype.com</organizationUrl>
-		</developer>
-		<developer>
-			<name>Tobias Oberlies</name>
-			<organization>SAP</organization>
-			<organizationUrl>https://www.sap.com</organizationUrl>
-		</developer>
-		<developer>
-			<name>Jan Sievers</name>
-			<organization>SAP</organization>
-			<organizationUrl>https://www.sap.com</organizationUrl>
+			<id>tycho</id>
+			<name>Tycho</name>
+			<email>tycho-dev@eclipse.org</email> <!-- Tycho developer mailing list -->
+			<organization>Eclipse Tycho Project</organization>
+			<organizationUrl>https://projects.eclipse.org/projects/technology.tycho</organizationUrl>
 		</developer>
 	</developers>
 	<prerequisites>


### PR DESCRIPTION
BND complains: Cannot consider developer in line 'foo' of file 'bar/pom.xml' for bundle header 'Bundle-Developers' as it does not contain the mandatory id.

To avoid this developers must either have an ID or be removed. Maven itself considers the list of developers the list of people to be contacted for the project. Since the currently listed developers are no longer active, the error can be avoided best (and with little future maintenance effort) by having an organizational entry as developer, pointing the Tycho project.