### PR TITLE
Disable automatically adding derived resources to gitignore

### DIFF
--- a/setup/Tycho.setup
+++ b/setup/Tycho.setup
@@ -43,6 +43,16 @@
     </setupTask>
     <setupTask
         xsi:type="setup:CompoundTask"
+        name="org.eclipse.egit.core">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.egit.core/core_autoIgnoreDerivedResources"
+          value="false">
+        <description>Avoid lots of project local gitignore files being created.</description>
+      </setupTask>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
         name="org.eclipse.egit.ui">
       <setupTask
           xsi:type="setup:PreferenceTask"


### PR DESCRIPTION
In a second step the .derived configuration shall be updated to also mark target folders of nested projects as derived. Without this change that second change would lead to lots of unwanted gitignore changes.

Applying this change also allows to combine project local gitignore files into a single working directory gitignore file later.