### PR TITLE
Reproducer for the .settings folder of a project is not considdered if it is a linked resource

### DIFF
--- a/tycho-its/projects/linked-resources/.project
+++ b/tycho-its/projects/linked-resources/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>linked-resources</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/tycho-its/projects/linked-resources/.settings/org.eclipse.core.resources.prefs
+++ b/tycho-its/projects/linked-resources/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tycho-its/projects/linked-resources/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-its/projects/linked-resources/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/.classpath
+++ b/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/.project
+++ b/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/.project
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.tycho.test.linked.resources</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>.settings</name>
+			<type>2</type>
+			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/.settings</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Resources
+Bundle-SymbolicName: org.eclipse.tycho.test.linked.resources
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: org.eclipse.tycho.test.linked.resources
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/build.properties
+++ b/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/pom.xml
+++ b/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>linked-resources</groupId>
+	<artifactId>org.eclipse.tycho.test.linked.resources</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<parent>
+		<groupId>linked-resources</groupId>
+		<artifactId>linked-resources.build</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+</project>

--- a/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/src/org/eclipse/tycho/test/linked/resources/Dummy.java
+++ b/tycho-its/projects/linked-resources/org.eclipse.tycho.test.linked.resources/src/org/eclipse/tycho/test/linked/resources/Dummy.java
@@ -1,0 +1,5 @@
+package org.eclipse.tycho.test.linked.resources;
+
+public class Dummy {
+
+}

--- a/tycho-its/projects/linked-resources/pom.xml
+++ b/tycho-its/projects/linked-resources/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>linked-resources</groupId>
+	<artifactId>linked-resources.build</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<name>linked-resources.build</name>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>org.eclipse.tycho.test.linked.resources</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-compiler-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<useProjectSettings>true</useProjectSettings>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/linkedResources/LinkedResourcesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/linkedResources/LinkedResourcesTest.java
@@ -1,0 +1,32 @@
+package org.eclipse.tycho.test.linkedResources;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+public class LinkedResourcesTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testLinkedSettingsFolder() throws Exception {
+		Verifier verifier = getVerifier("linked-resources", false);
+		verifier.executeGoals(List.of("verify"));
+
+		verifyNoUseProjectSettingsWarning(verifier);
+	}
+
+	private void verifyNoUseProjectSettingsWarning(Verifier verifier) throws VerificationException {
+		List<String> lines = verifier.loadFile(verifier.getBasedir(), verifier.getLogFileName(), false);
+
+		String warningMsg = "[WARNING] Parameter 'useProjectSettings' is set to true, but preferences file";
+
+		assertThat(lines, not(hasItem(containsString(warningMsg))));
+	}
+}


### PR DESCRIPTION
This integration test tests if tycho follows project settings if the `.settings` folder of a project is a linked resource, which refers to another folder.