### PR TITLE
Increase Tycho IDE heap space to 4 GB

### DIFF
--- a/setup/Tycho.setup
+++ b/setup/Tycho.setup
@@ -89,7 +89,7 @@
   <setupTask
       xsi:type="setup:EclipseIniTask"
       option="-Xmx"
-      value="2048m"
+      value="4g"
       vm="true">
     <description>Set the heap space needed to work with the projects of ${scope.project.label}</description>
   </setupTask>


### PR DESCRIPTION
I've just experienced an Eclipse workbench out of memory error during the initial Oomph triggered Maven build of a newly created Tycho IDE.