### PR TITLE
Support considering maven dependencies for compilation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,28 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ### Migration guide 3.x > 4.x
 
+#### pom declared dependencies are considered for compile
+
+Previously dependencies declared in the pom are ignored by Tycho completely and even though one could enable these to be considered in target platform
+this still requires them to be imported in the bundle manifest to finally be usable for compilation.
+
+Now each pom defined dependency is always considered for compilation as this matches the expectation of most maven users and finally allows to have 'compile only' dependencies to be used,
+for example with annotations that are only retained at source or class level.
+
+One example that uses [API-Guardian](https://github.com/apiguardian-team/apiguardian) annotations can be found here: https://github.com/eclipse/tycho/tree/master/tycho-its/projects/compiler-pomdependencies
+
+You can disable this feature through the `tycho-compiler-plugin` configuration:
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-compiler-plugin</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		<pomOnlyDependencies>ignore</pomOnlyDependencies>
+	</configuration>
+</plugin>
+```
+
 #### Properties for tycho-surefire-plugin's 'useUIThread' and 'useUIHarness' parameters
 
 The configuration parameters `useUIThread` and `useUIHarness` parameter of the `tycho-surefire-plugin` can now be set via the properties `tycho.surefire.useUIHarness` respectively `tycho.surefire.useUIThread`.

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiCompilerMojo.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -81,6 +82,11 @@ public class OsgiCompilerMojo extends AbstractOsgiCompilerMojo {
             }
         }
         return entries;
+    }
+
+    @Override
+    protected String getDependencyScope() {
+        return Artifact.SCOPE_COMPILE;
     }
 
 }

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiTestCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiTestCompilerMojo.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -86,6 +87,11 @@ public class OsgiTestCompilerMojo extends AbstractOsgiCompilerMojo {
     @Override
     public List<ClasspathEntry> getClasspath() throws MojoExecutionException {
         return getBundleProject().getTestClasspath(DefaultReactorProject.adapt(project));
+    }
+
+    @Override
+    protected String getDependencyScope() {
+        return Artifact.SCOPE_TEST;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/BundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/BundleProject.java
@@ -12,8 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.core;
 
+import java.util.Collection;
 import java.util.List;
 
+import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ReactorProject;
@@ -42,5 +44,11 @@ public interface BundleProject extends TychoProject {
     public List<ClasspathEntry> getTestClasspath(ReactorProject project);
 
     public List<ClasspathEntry> getTestClasspath(ReactorProject project, boolean complete);
+
+    /**
+     * @return a collection of dependencies that where present before Tycho has injected the target
+     *         content of the project into the model
+     */
+    Collection<Dependency> getInitialDependencies(ReactorProject reactorProject);
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.component.annotations.Component;
@@ -109,6 +110,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
     private static final String CTX_ARTIFACT_KEY = CTX_OSGI_BUNDLE_BASENAME + "/artifactKey";
     private static final String CTX_MAVEN_SESSION = CTX_OSGI_BUNDLE_BASENAME + "/mavenSession";
     private static final String CTX_MAVEN_PROJECT = CTX_OSGI_BUNDLE_BASENAME + "/mavenProject";
+    private static final String CTX_INITIAL_MAVEN_DEPENDENCIES = CTX_OSGI_BUNDLE_BASENAME + "/initialDependencies";
     private static final String CTX_CLASSPATH = CTX_OSGI_BUNDLE_BASENAME + "/classPath";
 
     @Requirement
@@ -190,6 +192,17 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
         reactorProject.setContextValue(CTX_ARTIFACT_KEY, key);
         reactorProject.setContextValue(CTX_MAVEN_SESSION, session);
         reactorProject.setContextValue(CTX_MAVEN_PROJECT, project);
+        reactorProject.setContextValue(CTX_INITIAL_MAVEN_DEPENDENCIES, List.copyOf(project.getDependencies()));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Collection<Dependency> getInitialDependencies(ReactorProject reactorProject) {
+        Object contextValue = reactorProject.getContextValue(CTX_INITIAL_MAVEN_DEPENDENCIES);
+        if (contextValue instanceof Collection<?>) {
+            return (Collection<Dependency>) contextValue;
+        }
+        return Collections.emptyList();
     }
 
     private MavenSession getMavenSession(ReactorProject reactorProject) {

--- a/tycho-its/projects/compiler.pomdependencies/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.pomdependencies/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Exclude
+Bundle-SymbolicName: compiler-pomdependencies
+Bundle-Version: 1.0.0
+Bundle-Activator: guardian.Activator
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ActivationPolicy: lazy

--- a/tycho-its/projects/compiler.pomdependencies/build.properties
+++ b/tycho-its/projects/compiler.pomdependencies/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/compiler.pomdependencies/pom.xml
+++ b/tycho-its/projects/compiler.pomdependencies/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>tycho.its</groupId>
+	<artifactId>compiler-pomdependencies</artifactId>
+	<version>1.0.0</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<properties>
+		<tycho-version>4.0.0-SNAPSHOT</tycho-version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			
+			<!-- Example how to configure this (e.g. disable)
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-compiler-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<pomOnlyDependencies>ignore</pomOnlyDependencies>
+				</configuration>
+			</plugin>
+			-->
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+		  <groupId>org.apiguardian</groupId>
+		  <artifactId>apiguardian-api</artifactId>
+		  <version>1.1.2</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/tycho-its/projects/compiler.pomdependencies/src/guardian/MyApiInterface.java
+++ b/tycho-its/projects/compiler.pomdependencies/src/guardian/MyApiInterface.java
@@ -1,0 +1,11 @@
+package guardian;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(status = Status.MAINTAINED)
+public interface MyApiInterface {
+
+	@API(since = "0.0.1", status = Status.STABLE)
+	String sayHello();
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.compiler;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class CompilerClasspathTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testPomOnlyDependencies() throws Exception {
+		Verifier verifier = getVerifier("compiler.pomdependencies", true);
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+	}
+
+}


### PR DESCRIPTION
Previously dependencies declared in the pom are ignored by Tycho completely and even though one could enable these to be considered in target platform
this still requires them to be imported in the bundle manifest to finally be usable for compilation.

Now each pom defined dependency is always considered for compilation as this matches the expectation of most maven users and finally allows to have 'compile only' dependencies to be used,
for example with annotations that are only retained at source or class level.

Fix #1556