### PR TITLE
Adapt usage example in buildtimestamp-jgit provider to move to 'core'

### DIFF
--- a/tycho-buildtimestamp-jgit/src/main/java/org/eclipse/tycho/extras/buildtimestamp/jgit/JGitBuildTimestampProvider.java
+++ b/tycho-buildtimestamp-jgit/src/main/java/org/eclipse/tycho/extras/buildtimestamp/jgit/JGitBuildTimestampProvider.java
@@ -75,7 +75,7 @@ import org.eclipse.tycho.build.BuildTimestampProvider;
  *         &lt;version&gt;${tycho-version}&lt;/version&gt;
  *         &lt;dependencies&gt;
  *           &lt;dependency&gt;
- *             &lt;groupId&gt;org.eclipse.tycho.extras&lt;/groupId&gt;
+ *             &lt;groupId&gt;org.eclipse.tycho&lt;/groupId&gt;
  *             &lt;artifactId&gt;tycho-buildtimestamp-jgit&lt;/artifactId&gt;
  *             &lt;version&gt;${tycho-version}&lt;/version&gt;
  *           &lt;/dependency&gt;


### PR DESCRIPTION
The 'tycho-buildtimestamp-jgit' was moved from tycho-extras to tycho(-core) in https://github.com/eclipse-tycho/tycho/pull/930.

The usage example has to be adapted accordingly.

For the sake of completeness the 'extras' segment of the package name could be removed too.