### PR TITLE
Replace deprecated projectresolver

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -40,7 +40,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
-import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -532,13 +531,11 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
             }
         }
         if (pomOnlyDependencies != PomDependencies.ignore) {
-            String dependencyScope = getDependencyScope();
-            ScopeArtifactFilter artifactFilter = new ScopeArtifactFilter(dependencyScope);
             List<Artifact> additionalClasspathEntries = getBundleProject()
-                    .getInitialArtifactMap(DefaultReactorProject.adapt(project)).values().stream() //
+                    .getInitialArtifacts(DefaultReactorProject.adapt(project), List.of(getDependencyScope())).stream() //
                     .filter(a -> a.getFile() != null) //
                     .filter(a -> includedPathes.add(a.getFile().getAbsolutePath())) //
-                    .filter(a -> artifactFilter.include(a)).toList();
+                    .toList();
             for (Artifact artifact : additionalClasspathEntries) {
                 String path = artifact.getFile().getAbsolutePath();
                 getLog().debug("Add a pom only classpath entry: " + artifact + " @ " + path);

--- a/tycho-core/pom.xml
+++ b/tycho-core/pom.xml
@@ -169,6 +169,11 @@
 			<artifactId>maven-core</artifactId>
 		</dependency>
 		<dependency>
+	      <groupId>org.apache.maven.resolver</groupId>
+	      <artifactId>maven-resolver-util</artifactId>
+	      <version>1.6.3</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 		</dependency>

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProject.java
@@ -12,10 +12,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.core;
 
-import java.util.Map;
+import java.util.Collection;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ReactorProject;
@@ -54,9 +53,10 @@ public interface TychoProject {
     public TargetEnvironment getImplicitTargetEnvironment(MavenProject project);
 
     /**
-     * @return a collection of dependencies that where present before Tycho has injected the target
-     *         content of the project into the model
+     * @return a collection of dependencies (and their transitive dependencies) that where present
+     *         before Tycho has injected the target content of the project into the model, also
+     *         known as "pom considered dependencies"
      */
-    Map<Dependency, Artifact> getInitialArtifactMap(ReactorProject reactorProject);
+    Collection<Artifact> getInitialArtifacts(ReactorProject reactorProject, Collection<String> scopes);
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependenciesResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependenciesResolver.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.core.maven;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.RepositorySessionDecorator;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.util.filter.ScopeDependencyFilter;
+
+@Component(role = MavenDependenciesResolver.class)
+public class MavenDependenciesResolver {
+
+    @Requirement
+    RepositorySystem repoSystem;
+
+    @Requirement
+    List<RepositorySessionDecorator> decorators;
+
+    @Requirement
+    Logger logger;
+
+    /**
+     * Resolves the specified dependencies including their transitive ones.
+     *
+     * @param project
+     *            The project whose dependencies should be resolved, must not be {@code null}.
+     * @param dependencies
+     * @param scopesToResolve
+     *            The dependency scopes that should be resolved, may be {@code null}.
+     * @param session
+     *            The current build session, must not be {@code null}.
+     * @return The transitive dependencies of the specified project that match the requested scopes,
+     *         never {@code null}.
+     * @throws DependencyCollectionException
+     * @throws DependencyResolutionException
+     */
+    public Collection<org.apache.maven.artifact.Artifact> resolve(MavenProject project,
+            Collection<org.apache.maven.model.Dependency> dependencies, Collection<String> scopesToResolve,
+            MavenSession session) throws DependencyCollectionException, DependencyResolutionException {
+        if (dependencies.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Set<Artifact> resultSet = new HashSet<>();
+
+        CollectRequest collect = new CollectRequest();
+        RepositorySystemSession repositorySession = session.getRepositorySession();
+        for (RepositorySessionDecorator decorator : decorators) {
+            RepositorySystemSession decorated = decorator.decorate(project, repositorySession);
+            if (decorated != null) {
+                repositorySession = decorated;
+            }
+        }
+        ArtifactTypeRegistry stereotypes = repositorySession.getArtifactTypeRegistry();
+        for (org.apache.maven.model.Dependency dependency : dependencies) {
+            collect.addDependency(RepositoryUtils.toDependency(dependency, stereotypes));
+        }
+        DependencyManagement dependencyManagement = project.getDependencyManagement();
+        if (dependencyManagement != null) {
+            for (org.apache.maven.model.Dependency dependency : dependencyManagement.getDependencies()) {
+                collect.addManagedDependency(RepositoryUtils.toDependency(dependency, stereotypes));
+            }
+        }
+        collect.setRepositories(project.getRemoteProjectRepositories());
+
+        CollectResult collectResult = repoSystem.collectDependencies(repositorySession, collect);
+        DependencyNode rootNode = collectResult.getRoot();
+
+        CumulativeScopeArtifactFilter scopeArtifactFilter = new CumulativeScopeArtifactFilter(scopesToResolve);
+        DependencyFilter filter = new ScopeDependencyFilter(scopeArtifactFilter.getScopes(),
+                List.of(Artifact.SCOPE_SYSTEM));
+        DependencyRequest dependencyRequest = new DependencyRequest(collect, filter);
+        dependencyRequest.setRoot(rootNode);
+
+        DependencyResult dependencyResult = repoSystem.resolveDependencies(repositorySession, dependencyRequest);
+        List<ArtifactResult> artifactResults = dependencyResult.getArtifactResults();
+        for (ArtifactResult ar : artifactResults) {
+            DependencyNode node = ar.getRequest().getDependencyNode();
+            org.eclipse.aether.graph.Dependency dependency = node.getDependency();
+            if (ar.isResolved()) {
+                Artifact artifact = RepositoryUtils.toArtifact(dependency.getArtifact());
+                if (scopeArtifactFilter.include(artifact)) {
+                    resultSet.add(artifact);
+
+                }
+            } else {
+                logger.error("Can't resolve " + dependency);
+                for (Exception e : ar.getExceptions()) {
+                    logger.error("", e);
+                }
+            }
+        }
+        return resultSet;
+    }
+}

--- a/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
+++ b/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
@@ -293,7 +293,8 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
         ArrayList<String> scopes = new ArrayList<>();
         scopes.add(Artifact.SCOPE_COMPILE);
         Collection<Artifact> artifacts = projectManager.getTychoProject(project)
-                .map(tp -> tp.getInitialArtifactMap(reactorProject).values()).orElse(Collections.emptyList());
+                .map(tp -> tp.getInitialArtifacts(reactorProject, List.of(Artifact.SCOPE_COMPILE)))
+                .orElse(Collections.emptyList());
         List<Artifact> externalArtifacts = new ArrayList<>(artifacts.size());
         for (Artifact artifact : artifacts) {
             String key = ArtifactUtils.key(artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion());


### PR DESCRIPTION
Currently Tycho uses a deprecated class from maven to resolve dependencies of the pom. THis replaces the access by a more modern recommended approach using the Aether API.