### PR TITLE
Fix URIs pointing the old tycho location to use the new location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Make sure you have set the property for the Tycho version (e.g. `tycho-version`)
 For documentation of the most recent snapshot build, see the [Snapshot Tycho Site](https://ci.eclipse.org/tycho/job/tycho-sitedocs/lastSuccessfulBuild/artifact/target/staging/index.html).
 
 If you identify an issue, please try to reduce the case to the minimal project and steps to reproduce, and then report the bug with details to reproduce
-and the minimal reproducer project to Tycho's [issue tracker](https://github.com/eclipse/tycho/issues).
+and the minimal reproducer project to Tycho's [issue tracker](https://github.com/eclipse-tycho/tycho/issues).
 
 ## Development environment
 
@@ -83,9 +83,9 @@ Alternatively, e.g. if you are only interested in modifying an integration test 
 
 ### Writing Tycho integration tests
 
-The tycho integration tests are located in the [tycho-its](https://github.com/eclipse/tycho/tree/master/tycho-its) subfolder of the repository. Creating a new integration test usually includes the following steps:
+The tycho integration tests are located in the [tycho-its](https://github.com/eclipse-tycho/tycho/tree/master/tycho-its) subfolder of the repository. Creating a new integration test usually includes the following steps:
 
-1. create a new folder in the the [projects](https://github.com/eclipse/tycho/tree/master/tycho-its/projects) directory (see below for a good naming, but this could be improved as part of the review so don't mind to choose an intermediate name first), usually you would like to use `${tycho-version}` as a placeholder in your pom so the execution picks up the current tycho version
+1. create a new folder in the the [projects](https://github.com/eclipse-tycho/tycho/tree/master/tycho-its/projects) directory (see below for a good naming, but this could be improved as part of the review so don't mind to choose an intermediate name first), usually you would like to use `${tycho-version}` as a placeholder in your pom so the execution picks up the current tycho version
 2. Check if there is already a suitable test-class available or simply create your own (again the name could be improved later on if required), the usual pattern for a self-contained test-case that fails the build is:
 ```
 @Test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Eclipse Tycho
 =============
 
-[![Build Tycho](https://github.com/eclipse/tycho/actions/workflows/maven.yml/badge.svg)](https://github.com/eclipse/tycho/actions/workflows/maven.yml) [![Unit Test Results](https://github.com/eclipse/tycho/actions/workflows/check.yml/badge.svg)](https://github.com/eclipse/tycho/actions/workflows/check.yml) [![License check](https://github.com/eclipse/tycho/actions/workflows/licensecheck.yml/badge.svg)](https://github.com/eclipse/tycho/actions/workflows/licensecheck.yml)
+[![Build Tycho](https://github.com/eclipse-tycho/tycho/actions/workflows/maven.yml/badge.svg)](https://github.com/eclipse-tycho/tycho/actions/workflows/maven.yml) [![Unit Test Results](https://github.com/eclipse-tycho/tycho/actions/workflows/check.yml/badge.svg)](https://github.com/eclipse-tycho/tycho/actions/workflows/check.yml) [![License check](https://github.com/eclipse-tycho/tycho/actions/workflows/licensecheck.yml/badge.svg)](https://github.com/eclipse-tycho/tycho/actions/workflows/licensecheck.yml)
 
 Tycho is a manifest-first way to build
 
@@ -44,7 +44,7 @@ In general, if Tycho is key technology for your Organization, you can help with 
 Test snapshots of Tycho early and often so that regressions are found early before we start the release process, this gives faster release and maybe even more often releases if we are certain that snapshots are production-ready.
 
 ### Donate some time
-Consider donate some developer time to improve code (e.g. fixing bugs), enhancing documentation, help with review of open PRs, [answer questions on the discussions](https://github.com/eclipse/tycho/discussions), or [providing integration test](https://github.com/eclipse/tycho/wiki#providing-an-integration-test) to cover your important features.
+Consider donate some developer time to improve code (e.g. fixing bugs), enhancing documentation, help with review of open PRs, [answer questions on the discussions](https://github.com/eclipse-tycho/tycho/discussions), or [providing integration test](https://github.com/eclipse-tycho/tycho/wiki#providing-an-integration-test) to cover your important features.
 
 ## Sponsor individual contributors
 If you want to help with development of Tycho itself but can't afford to do it by yourself, you can sponsor some of the contributors of Tycho directly:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,16 +3,16 @@
 This describes the steps to perform a release of Tycho:
 
 - [ ] Make sure all fixed issues and merged PRs have the correct milestone for this release, to finding PRs without milestone you can use the following filter `is:pr is:merged no:milestone` issues without milestone can be found with `is:issue no:milestone is:closed`
-- [ ] Prepare the [release notes](https://github.com/eclipse/tycho/blob/master/RELEASE_NOTES.md) which should provide a quick overview of new features and bug fixes
+- [ ] Prepare the [release notes](https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md) which should provide a quick overview of new features and bug fixes
 - [ ] When no more incoming change is expected for this release, create branch `tycho-N.M.x` (e.g. `tycho-2.4.x`) for upcoming release and push it to remote; this branch should remain frozen until the release, only major fixes for regressions could be merged in before release. Work can still happen regularly for the following version on the `master` branch.
-- [ ] Create release record on https://projects.eclipse.org/projects/technology.tycho projects.eclipse.org, link the N&N to https://github.com/eclipse/tycho/blob/[branch-name]/RELEASE_NOTES.md release notes]
+- [ ] Create release record on https://projects.eclipse.org/projects/technology.tycho projects.eclipse.org, link the N&N to https://github.com/eclipse-tycho/tycho/blob/[branch-name]/RELEASE_NOTES.md release notes]
 - [ ] Update the Jenkinsfile on the `tycho-N.M.x` and adjust the `stage('Deploy Snapshot')` to reference the new branch in the when conditional.
 - [ ] Update versions on `master `to future release with `mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=<NEXT_VERSION>-SNAPSHOT` and push to remote
-- [ ] Announce the intent to release and request feedback about snapshots on the [GitHub discussions](https://github.com/eclipse/tycho/discussions):
+- [ ] Announce the intent to release and request feedback about snapshots on the [GitHub discussions](https://github.com/eclipse-tycho/tycho/discussions):
 ```
 Subject: Tycho <VERSION> release
 
-We plan to release Tycho <VERSION> next week. For details of new features and bugfixes, see [release notes](https://github.com/eclipse/tycho/blob/tycho-x.y.z/RELEASE_NOTES.md).
+We plan to release Tycho <VERSION> next week. For details of new features and bugfixes, see [release notes](https://github.com/eclipse-tycho/tycho/blob/tycho-x.y.z/RELEASE_NOTES.md).
 Please help by testing the SNAPSHOTS build. To use it, change your tycho version to <VERSION>-SNAPSHOT and add the following snippet to your pom.
 
 <pluginRepositories>
@@ -78,8 +78,8 @@ Subject: Tycho <VERSION> is released
 
 Tycho <VERSION> has been released and is available from Maven Central repository.
 
-🆕 https://github.com/eclipse/tycho/blob/master/RELEASE_NOTES.md#xyz
-🏷️ https://github.com/eclipse/tycho/tree/tycho-x.y.z
+🆕 https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md#xyz
+🏷️ https://github.com/eclipse-tycho/tycho/tree/tycho-x.y.z
 👔 https://projects.eclipse.org/projects/technology.tycho/releases/x.y.z
 🙏 contributors who contributed patches for this release:
     <contributors>

--- a/demo/README.md
+++ b/demo/README.md
@@ -16,9 +16,9 @@ in the corresponding folder.
 About Tycho
 ===========
 
-  * [Project Homepage](https://github.com/eclipse/tycho)
+  * [Project Homepage](https://github.com/eclipse-tycho/tycho)
   * [Documentation](https://www.eclipse.org/tycho/sitedocs/)
-  * [Bug Tracker](https://github.com/eclipse/tycho/issues)
-  * [How to Contribute](https://github.com/eclipse/tycho/blob/master/CONTRIBUTING.md)
+  * [Bug Tracker](https://github.com/eclipse-tycho/tycho/issues)
+  * [How to Contribute](https://github.com/eclipse-tycho/tycho/blob/master/CONTRIBUTING.md)
   * [Contact Us](https://dev.eclipse.org/mailman/listinfo/tycho-user)
 

--- a/setup/Tycho.setup
+++ b/setup/Tycho.setup
@@ -116,7 +116,7 @@
   <setupTask
       xsi:type="setup:EclipseIniTask"
       option="-Doomph.redirection.tycho="
-      value="https://raw.githubusercontent.com/eclipse/tycho/master/setup/Tycho.setup->${git.cloneTycho.location|uri}/setup/Tycho.setup"
+      value="https://raw.githubusercontent.com/eclipse-tycho/tycho/master/setup/Tycho.setup->${git.cloneTycho.location|uri}/setup/Tycho.setup"
       vm="true"/>
   <setupTask
       xsi:type="setup.p2:P2Task"

--- a/tycho-extras/README.md
+++ b/tycho-extras/README.md
@@ -3,9 +3,9 @@ About Tycho Extras
 
 Additional tools for Tycho.
 
-  * [Project Homepage](https://github.com/eclipse/tycho)
+  * [Project Homepage](https://github.com/eclipse-tycho/tycho)
   * [Documentation](https://www.eclipse.org/tycho/sitedocs/)
-  * [Bug Tracker](https://github.com/eclipse/tycho/issues)
-  * [How to Contribute](https://github.com/eclipse/tycho/blob/master/CONTRIBUTING.md)
+  * [Bug Tracker](https://github.com/eclipse-tycho/tycho/issues)
+  * [How to Contribute](https://github.com/eclipse-tycho/tycho/blob/master/CONTRIBUTING.md)
   * [Contact Us](https://dev.eclipse.org/mailman/listinfo/tycho-user)
 


### PR DESCRIPTION
https://github.com/eclipse/tycho ->
https://github.com/eclipse-tycho/tycho