### PR TITLE
Remove the incomplete resolver feature

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
@@ -228,18 +228,7 @@ public class P2ResolverImpl implements P2Resolver {
         strategy.setData(data);
         Collection<IInstallableUnit> newState;
         try {
-            data.setFailOnMissing(pomDependencies == PomDependencies.ignore);
             newState = strategy.resolve(environment, monitor);
-            if (pomDependencies != PomDependencies.ignore) {
-                Collection<IRequirement> missingRequirements = data.getMissingRequirements();
-                if (!missingRequirements.isEmpty()) {
-                    logger.info(
-                            "The following requirements are not satisfied yet and must be provided through pom dependencies:");
-                    for (IRequirement requirement : missingRequirements) {
-                        logger.info("   - " + requirement);
-                    }
-                }
-            }
         } catch (ResolverException e) {
             logger.info(e.getSelectionContext());
             logger.error("Cannot resolve project dependencies:");

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ResolutionData.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ResolutionData.java
@@ -36,16 +36,6 @@ public interface ResolutionData {
     Map<String, String> getAdditionalFilterProperties();
 
     /**
-     * @return <code>true</code> if the resolve operation should fail if there are missing
-     *         requirements
-     */
-    boolean failOnMissingRequirements();
-
-    void addMissingRequirement(IRequirement requirement);
-
-    Collection<IRequirement> getMissingRequirements();
-
-    /**
      * 
      * @return a predicate that us used to check if a given unit should be accepted by the slicer
      */

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ResolutionDataImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ResolutionDataImpl.java
@@ -39,8 +39,6 @@ public class ResolutionDataImpl implements ResolutionData {
     private List<IRequirement> additionalRequirements;
     private Map<String, String> additionalFilterProperties;
     private Collection<IRequirement> missing = new ArrayList<>();
-    private boolean failOnMissing = true;
-
     private Predicate<IInstallableUnit> slicerPredicate;
 
     private IQueryable<IInstallableUnit> additionalUnitStore;
@@ -122,29 +120,6 @@ public class ResolutionDataImpl implements ResolutionData {
 
     public void setAdditionalFilterProperties(Map<String, String> additionalFilterProperties) {
         this.additionalFilterProperties = additionalFilterProperties;
-    }
-
-    @Override
-    public boolean failOnMissingRequirements() {
-        return failOnMissing;
-    }
-
-    public void setFailOnMissing(boolean failOnMissing) {
-        this.failOnMissing = failOnMissing;
-    }
-
-    @Override
-    public void addMissingRequirement(IRequirement requirement) {
-        missing.add(requirement);
-    }
-
-    @Override
-    public Collection<IRequirement> getMissingRequirements() {
-        return Collections.unmodifiableCollection(missing);
-    }
-
-    public void clearMissingRequirements() {
-        missing.clear();
     }
 
     @Override


### PR DESCRIPTION
The incomplete resolving feature was introduced to allow mixed reactor builds. They way it worked has several implications:

- pom-dependencies=consider was required what has a lot of other implications
- the resolver does not really allow incomplete resolving, because of this we have tried to generate missing requirements
- this required several rounds of resolving and is slow and fragile

This feature is now removed and will be replaced by the new resolver approach.

**This PR is just to check what tests fail without this feature** (expectation: one test fails) **so it can be used as a base-commit to implements the new approach on top of it** (that fixes the test again).