### PR TITLE
Construct the test runtime against filtered OSGi/PDE metadata

### DIFF
--- a/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
+++ b/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
@@ -165,7 +165,8 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
     protected Map<String, IDependencyMetadata> getDependencyMetadata(final MavenSession session,
             final MavenProject project, final List<TargetEnvironment> environments,
             final OptionalResolutionAction optionalAction) {
-        final File artifactLocation = (File) project.getContextValue(TychoConstants.CTX_METADATA_ARTIFACT_LOCATION);
+        final ReactorProject reactorProject = DefaultReactorProject.adapt(project);
+        final File artifactLocation = (File) reactorProject.getContextValue(TychoConstants.CTX_METADATA_ARTIFACT_LOCATION);
         final File location = artifactLocation != null ? artifactLocation : project.getBasedir();
         final Map<String, IDependencyMetadata> metadata = new LinkedHashMap<>();
         metadata.put(null, generator.generateMetadata(new AttachedArtifact(project, location, null), environments,

--- a/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.osgitools.EclipseRepositoryProject;
@@ -201,15 +202,15 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
                 destination.mkdirs();
                 copyResources(destination);
 
-                Collection<DependencySeed> projectSeeds = TychoProjectUtils.getDependencySeeds(getReactorProject());
+                final ReactorProject reactorProject = getReactorProject();
+                Collection<DependencySeed> projectSeeds = TychoProjectUtils.getDependencySeeds(reactorProject);
                 if (projectSeeds.isEmpty()) {
                     getLog().warn("No content specified for p2 repository");
                     return;
                 }
 
-                final MavenProject project = getProject();
-                project.setContextValue(TychoConstants.CTX_METADATA_ARTIFACT_LOCATION, categoriesDirectory);
-                RepositoryReferences sources = repositoryReferenceTool.getVisibleRepositories(project,
+                reactorProject.setContextValue(TychoConstants.CTX_METADATA_ARTIFACT_LOCATION, categoriesDirectory);
+                RepositoryReferences sources = repositoryReferenceTool.getVisibleRepositories(getProject(),
                         getSession(), RepositoryReferenceTool.REPOSITORIES_INCLUDE_CURRENT_MODULE);
 
                 List<RepositoryReference> repositoryReferences = getCategories(categoriesDirectory)


### PR DESCRIPTION
This completes what has been done in #1625.

@laeubi let me know if you think this might arise some sort if issues. 
Per my testing, it's perfectly backward compatible.

Draft for now as I'm open to discussion.