### PR TITLE
Normalize logging messages

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/DefaultProvisioningAgent.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/DefaultProvisioningAgent.java
@@ -61,7 +61,7 @@ public class DefaultProvisioningAgent implements IProvisioningAgent {
 		} catch (ComponentLookupException e) {
 			log.debug("Service " + serviceName + " was not found in PlexusContainer");
 		}
-		log.warn("Can't locate service = " + serviceName + " because no provisioning agent was found!");
+		log.warn("Cannot locate service " + serviceName + " because no provisioning agent was found");
 		return null;
 
 	}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/InstallableUnitGenerator.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/InstallableUnitGenerator.java
@@ -165,14 +165,14 @@ public class InstallableUnitGenerator {
 						log.debug("Using cached value for " + project);
 						return collection;
 					} else {
-						log.debug("Can't use cached value for " + project
-								+ " because of incompatible classloaders, update is forced!");
+						log.debug("Cannot use cached value for " + project
+								+ " because of incompatible classloaders, update is forced");
 					}
 				}
 			}
 			File basedir = project.getBasedir();
 			if (basedir == null || !basedir.isDirectory()) {
-				log.warn("No valid basedir for " + project + "!");
+				log.warn("No valid basedir for " + project + " found");
 				return Collections.emptyList();
 			}
 			String packaging = project.getPackaging();
@@ -181,7 +181,7 @@ public class InstallableUnitGenerator {
 			List<IPublisherAction> actions = getPublisherActions(packaging, basedir, version, artifactId);
 			Collection<IInstallableUnit> publishedUnits = publisher.publishMetadata(actions);
 			for (InstallableUnitProvider unitProvider : getProvider(project, session)) {
-				log.debug("Asking: " + unitProvider + " for additional units for " + project + "...");
+				log.debug("Asking " + unitProvider + " for additional units for " + project + "...");
 				Collection<IInstallableUnit> installableUnits = unitProvider.getInstallableUnits(project, session);
 				log.debug("Provider " + unitProvider + " generated " + installableUnits.size() + " (" + installableUnits
 						+ ") units for " + project);
@@ -196,7 +196,7 @@ public class InstallableUnitGenerator {
 				}
 			}
 			if (result.isEmpty()) {
-				log.debug("Can't generate any InstallableUnit for packaging type '" + packaging + "' for " + project);
+				log.debug("Cannot generate any InstallableUnit for packaging type '" + packaging + "' for " + project);
 			}
 			project.setContextValue(KEY_UNITS, result);
 			return result;

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultMavenRepositorySettings.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultMavenRepositorySettings.java
@@ -78,7 +78,7 @@ public class DefaultMavenRepositorySettings implements MavenRepositorySettings {
         MavenSession session = context.getSession();
 		if (session == null) {
 			logger.warn(
-					"Called MavenRepositorySettings.getMirror() outside maven thread, mirrors can't be determined!");
+					"Called MavenRepositorySettings.getMirror() outside maven thread, mirrors cannot be determined");
 			return null;
 		}
 		Mirror mirror = getTychoMirror(locationAsMavenRepository, session.getRequest().getMirrors());

--- a/sisu-osgi/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/internal/DefaultEquinoxLauncher.java
+++ b/sisu-osgi/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/internal/DefaultEquinoxLauncher.java
@@ -73,7 +73,7 @@ public class DefaultEquinoxLauncher implements EquinoxLauncher {
             return executor.execute(cli, getMergedEnvironment(configuration));
         } catch (ExecuteException e) {
             if (watchdog != null && watchdog.killedProcess()) {
-                log.error("Timeout " + forkedProcessTimeoutInSeconds + " s exceeded. Process was killed.");
+                log.error("Timeout of " + forkedProcessTimeoutInSeconds + "s exceeded. Process was killed.");
             }
             return e.getExitValue();
         } catch (IOException e) {

--- a/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusFrameworkConnectServiceFactory.java
+++ b/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusFrameworkConnectServiceFactory.java
@@ -113,7 +113,7 @@ public class PlexusFrameworkConnectServiceFactory implements Initializable, Disp
 		}
 		Collection<ClassRealm> realms = collectRealms(realm, new LinkedHashSet<>());
 
-		log.debug("Create framework for " + this + " with realm " + realm);
+		log.debug("Create framework for " + this + " with Realm " + realm);
 		Logger fwLogger = new PlexusConnectFramework(null, log, this, realm, false);
 		Map<String, String> p = readProperties(realm, fwLogger);
 		p.put(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA,
@@ -212,7 +212,7 @@ public class PlexusFrameworkConnectServiceFactory implements Initializable, Disp
 			try (InputStream stream = url.openStream()) {
 				properties.load(stream);
 			} catch (IOException e) {
-				logger.warn("Can't read properties from url " + url);
+				logger.warn("Cannot read properties from URL " + url);
 			}
 			for (String property : properties.stringPropertyNames()) {
 				String value = properties.getProperty(property);
@@ -249,7 +249,7 @@ public class PlexusFrameworkConnectServiceFactory implements Initializable, Disp
 							}
 						});
 			} else {
-				log.info("No service component runtime installed (or started) in this framework!");
+				log.info("No service component runtime installed (or started) in this framework");
 			}
 		} finally {
 			st.close();

--- a/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusModuleConnector.java
+++ b/sisu-osgi/sisu-osgi-connect/src/main/java/org/eclipse/sisu/osgi/connect/PlexusModuleConnector.java
@@ -149,7 +149,7 @@ final class PlexusModuleConnector implements ModuleConnector {
 		for (URL url : realm.getURLs()) {
 			File file = getFile(url);
 			if (file == null) {
-				logger.debug("Can't convert url " + url + " to file!");
+				logger.debug("Cannot convert URL " + url + " to File");
 				continue;
 			}
 			try {
@@ -208,11 +208,11 @@ final class PlexusModuleConnector implements ModuleConnector {
 						}
 					}
 				} catch (IOException e) {
-					logger.warn("Can't process jar at " + file, e);
+					logger.warn("Cannot process jar at " + file, e);
 					jarFile.close();
 				}
 			} catch (IOException e) {
-				logger.warn("Can't open jar at " + file, e);
+				logger.warn("Cannot open jar at " + file, e);
 			}
 		}
 	}
@@ -250,7 +250,7 @@ final class PlexusModuleConnector implements ModuleConnector {
 			try (InputStream stream = url.openStream()) {
 				parseCoreExports(stream, exports);
 			} catch (IOException e) {
-				logger.warn("Can't process extension descriptor from " + url, e);
+				logger.warn("Cannot process extension descriptor from " + url, e);
 			}
 		}
 		readBundles(classRealm, exports.bundleStartMap, logger);
@@ -270,9 +270,9 @@ final class PlexusModuleConnector implements ModuleConnector {
 			return bundle;
 		} catch (BundleException e) {
 			if (logger.isDebugEnabled()) {
-				logger.warn("Can't install bundle at " + location, e);
+				logger.warn("Cannot install bundle at " + location, e);
 			} else {
-				logger.warn("Can't install bundle at " + location + ": " + e.getMessage());
+				logger.warn("Cannot install bundle at " + location + ": " + e.getMessage());
 			}
 			PlexusConnectContent content = modulesMap.remove(location);
 			if (content != null) {
@@ -338,9 +338,9 @@ final class PlexusModuleConnector implements ModuleConnector {
 						bundle.uninstall();
 					} catch (BundleException e) {
 						if (logger.isDebugEnabled()) {
-							logger.warn("Can't uninstall bundle " + bundle.getSymbolicName(), e);
+							logger.warn("Cannot uninstall bundle " + bundle.getSymbolicName(), e);
 						} else {
-							logger.warn("Can't uninstall bundle " + bundle.getSymbolicName() + ": " + e);
+							logger.warn("Cannot uninstall bundle " + bundle.getSymbolicName() + ": " + e);
 						}
 					}
 				}
@@ -404,7 +404,7 @@ final class PlexusModuleConnector implements ModuleConnector {
 					map.put(split[0], start);
 				});
 			} catch (IOException e) {
-				logger.warn("Can't read bundle infos from url " + url);
+				logger.warn("Cannot read bundle infos from url " + url);
 			}
 		}
 	}

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/TychoCiFriendlyVersions.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/TychoCiFriendlyVersions.java
@@ -112,7 +112,7 @@ public class TychoCiFriendlyVersions extends DefaultModelVersionProcessor implem
 							timestampProvider.setQuiet(false);
 						}
 					} catch (ComponentLookupException | MojoExecutionException e) {
-						logger.warn("Can't use '" + provider
+						logger.warn("Cannot use '" + provider
 								+ "' as a timestamp provider for tycho-ci-friendly-versions (" + e + ")");
 					}
 

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
@@ -147,7 +147,7 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 			try {
 				dependencyClosure = dependencyProcessor.computeProjectDependencyClosure(projects, session);
 			} catch (CoreException e) {
-				log.error("Can't resolve projects", e);
+				log.error("Cannot resolve projects", e);
 				return Result.error(graph, toProblems(e.getStatus(), new ArrayList<>()));
 			}
 
@@ -217,7 +217,7 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 		}
 
 		try {
-			log.debug("=============== SELECTED PROJECTS ==================");
+			log.debug("=============== Selected Projects ==================");
 
 			selectedProjects.stream()
 					.sorted(Comparator.comparing(MavenProject::getGroupId, String.CASE_INSENSITIVE_ORDER)
@@ -225,7 +225,7 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 					.forEachOrdered(p -> log.debug(p.getId()));
 			return Result.success(new DefaultProjectDependencyGraph(projects, selectedProjects));
 		} catch (DuplicateProjectException | CycleDetectedException e) {
-			log.error("Can't compute project dependency graph", e);
+			log.error("Cannot compute project's dependency graph", e);
 			return Result.error(graph);
 		}
 	}

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/repository/LocalArtifactRepository.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/repository/LocalArtifactRepository.java
@@ -85,7 +85,7 @@ public class LocalArtifactRepository extends ArtifactRepositoryBaseImpl<GAVArtif
                 }
             } catch (IOException e) {
                 index.removeGav(gav);
-                localRepoIndices.getMavenContext().getLogger().debug("can't read stored meta-data", e);
+                localRepoIndices.getMavenContext().getLogger().debug("Cannot read stored metadata", e);
             }
         }
 

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/tools/publisher/ExpandedProduct.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/tools/publisher/ExpandedProduct.java
@@ -254,10 +254,10 @@ class ExpandedProduct implements IProductDescriptor {
                     }
                 }
                 logger.warn("Icon path " + path
-                        + " does not exist and can't be determined by tycho, make sure that either the icon path is relative to the product file, or denotes a folder in the parent path of the product! (current product path is "
+                        + " does not exist and cannot be determined by Tycho, make sure that either the icon path is relative to the product file, or denotes a folder in the parent path of the product (current product path is "
                         + productPath + ")");
             } catch (IOException e) {
-                logger.warn("can't guess icon path because of I/O problem", e);
+                logger.warn("Cannot guess icon path because of I/O problem", e);
             }
         }
         return path;

--- a/tycho-compiler-plugin/src/main/java/copied/org/apache/maven/plugin/AbstractCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/copied/org/apache/maven/plugin/AbstractCompilerMojo.java
@@ -342,7 +342,7 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
 
             if (compiler.getCompilerOutputStyle().equals(CompilerOutputStyle.ONE_OUTPUT_FILE_FOR_ALL_INPUT_FILES)
                     && !canUpdateTarget) {
-                getLog().info("RESCANNING!");
+                getLog().info("Rescanning");
                 // TODO: This second scan for source files is sub-optimal
                 String inputFileEnding = compiler.getInputFileEnding(compilerConfiguration);
 

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -622,7 +622,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
             String prefsFilePath = project.getBasedir() + File.separator + PREFS_FILE_PATH;
             if (!new File(prefsFilePath).exists()) {
                 getLog().warn("Parameter 'useProjectSettings' is set to true, but preferences file '" + prefsFilePath
-                        + "' could not be found!");
+                        + "' could not be found");
             } else {
                 // make sure that "-properties" is the first custom argument, otherwise it's not possible to override
                 // any project setting on the command line because the last argument wins.

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/ValidateClassPathMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/ValidateClassPathMojo.java
@@ -51,7 +51,7 @@ public class ValidateClassPathMojo extends AbstractMojo {
             if (TychoProjectUtils.getOptionalDependencyArtifacts(reactorProject).isPresent()) {
                 bundleProject.getClasspath(reactorProject);
             } else {
-                getLog().info("Skip classpath validation because project is currently not resolved.");
+                getLog().info("Skipped classpath validation as project is currently not resolved");
             }
         }
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentUtils.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentUtils.java
@@ -128,7 +128,7 @@ public class ExecutionEnvironmentUtils {
             for (String profileFile : listProps.getProperty("java.profiles").split(",")) {
                 Properties props = readProperties(findInSystemBundle(profileFile.trim()));
                 if (props == null) {
-                    logger.warn("can't read profile " + profileFile + " from system path");
+                    logger.warn("Cannot read profile " + profileFile + " from system path");
                     continue;
                 }
                 String name = props.getProperty(EquinoxConfiguration.PROP_OSGI_JAVA_PROFILE_NAME).trim();

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/ee/StandardExecutionEnvironment.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/ee/StandardExecutionEnvironment.java
@@ -138,7 +138,7 @@ public class StandardExecutionEnvironment implements Comparable<StandardExecutio
                         sb.append(System.lineSeparator());
                         sb.append(line);
                     }
-                    logger.debug("[ReadPackagesFromToolchains] Can't read java version for " + java
+                    logger.debug("[ReadPackagesFromToolchains] Cannot read java version for " + java
                             + ", full output was: " + sb);
                     return new JavaInfo(-1, List.of());
                 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependenciesResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependenciesResolver.java
@@ -119,7 +119,7 @@ public class MavenDependenciesResolver {
 
                 }
             } else {
-                logger.error("Can't resolve " + dependency);
+                logger.error("Cannot resolve " + dependency);
                 for (Exception e : ar.getExceptions()) {
                     logger.error("", e);
                 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -341,7 +341,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
         if (versionToProjectsMap.size() > 1) {
             List<String> versions = new ArrayList<>(versionToProjectsMap.keySet());
             Collections.sort(versions);
-            log.error("Several versions of tycho plugins are configured " + versions + ":");
+            log.error("Several versions of Tycho plugins are configured " + versions + ":");
             for (String version : versions) {
                 log.error(version + ":");
                 for (MavenProject project : versionToProjectsMap.get(version)) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoWorkspaceReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoWorkspaceReader.java
@@ -84,7 +84,7 @@ public class TychoWorkspaceReader implements MavenWorkspaceReader {
                         modelWriter.write(pomFile, new HashMap<>(), findModel);
                         return pomFile;
                     } catch (IOException e) {
-                        logger.debug("Can't write model!", e);
+                        logger.debug("Cannot write model", e);
                     }
                 }
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -649,7 +649,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
                         }
                     });
                 } catch (DependencyResolutionException | IllegalArtifactReferenceException e) {
-                    logger.debug("Can't find package " + annotationPackage + " in target platform");
+                    logger.debug("Cannot find package " + annotationPackage + " in target platform");
                 }
             }
         }

--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/configuration/DefaultMavenContext.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/configuration/DefaultMavenContext.java
@@ -153,7 +153,7 @@ public class DefaultMavenContext implements MavenContext {
 
     private Optional<MavenSession> getSession() {
         if (legacySupport == null) {
-            logger.warn("legacy support not available!");
+            logger.warn("Legacy support not available");
             return Optional.empty();
         }
         MavenSession session = legacySupport.getSession();
@@ -161,7 +161,7 @@ public class DefaultMavenContext implements MavenContext {
             if (logger.isDebugEnabled()) {
                 Thread.dumpStack();
             }
-            logger.warn("not called from a maven thread!");
+            logger.warn("Not called from a maven thread");
             return Optional.empty();
         }
         return Optional.of(session);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/AbstractSlicerResolutionStrategy.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/AbstractSlicerResolutionStrategy.java
@@ -167,7 +167,7 @@ abstract class AbstractSlicerResolutionStrategy extends AbstractResolutionStrate
                             extractName, version);
                     result.addProvidedCapabilities(Collections.singleton(providedCapability));
                 } catch (RuntimeException e) {
-                    logger.debug("can't convert requirement " + requirement + " to capability: " + e.toString(), e);
+                    logger.debug("Cannot convert requirement " + requirement + " to capability: " + e.toString(), e);
                 }
             } else if (requirement instanceof RequiredPropertiesMatch propertiesMatch) {
                 try {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolver.java
@@ -183,7 +183,7 @@ public final class TargetDefinitionResolver {
                         new LoggingProgressMonitor(logger));
                 unitResultSet.addAll(result);
                 if (logger.isDebugEnabled()) {
-                    logger.debug("The following artifacts where resolved from location " + location);
+                    logger.debug("The following artifacts were resolved from location " + location);
                     for (IInstallableUnit iu : result.toUnmodifiableSet()) {
                         logger.debug("\t" + iu);
                     }
@@ -324,7 +324,7 @@ public final class TargetDefinitionResolver {
         }
         //if we can't resolve this, we will return the original one as this might be intentional to not include the project in the build
         String defaultValue = "${project_loc:" + projectName + "}";
-        logger.warn("Can't resolve " + defaultValue + " target resoloution might be incomplete");
+        logger.warn("Cannot resolve " + defaultValue + " target resoloution might be incomplete");
         return defaultValue;
     }
 

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/ListDependenciesMojo.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/ListDependenciesMojo.java
@@ -55,7 +55,7 @@ public class ListDependenciesMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
-            getLog().info("Skipped");
+            getLog().info("Execution was skipped");
             return;
         }
         File outputFile = new File(project.getBuild().getDirectory(), "dependencies-list.txt");

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
@@ -237,7 +237,7 @@ public class JavadocMojo extends AbstractMojo {
 	public void execute() throws MojoExecutionException {
 		getLog().info("Scopes: " + this.scopes);
 		getLog().info("Output directory: " + this.outputDirectory);
-		getLog().info("BaseDir: " + this.basedir);
+		getLog().info("Basedir: " + this.basedir);
 
 		if (this.cleanFirst) {
 			getLog().info("Cleaning up first");

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocRunner.java
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocRunner.java
@@ -105,9 +105,9 @@ public class JavadocRunner {
 			final int rc = CommandLineUtils.executeCommandLine(cli, new DefaultConsumer(), new DefaultConsumer());
 			if (rc != 0) {
 				if (!this.options.isIgnoreError()) {
-					throw new MojoExecutionException("Failed to execute javadoc - rc = " + rc);
+					throw new MojoExecutionException("Failed to execute javadoc with return code: " + rc);
 				} else {
-					this.log.info("execution failed with rc = " + rc);
+					this.log.info("Execution failed with return code: " + rc);
 				}
 			}
 		}

--- a/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
@@ -280,7 +280,7 @@ public class EclipseRunMojo extends AbstractMojo {
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		if (skip) {
-			getLog().debug("skipping mojo execution");
+			getLog().info("Execution was skipped");
 			return;
 		}
 		EquinoxInstallation installation;

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -122,7 +122,7 @@ public class CompareWithBaselineMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
-            getLog().info("Skipped");
+            getLog().info("Execution was skipped");
             return;
         }
         ReactorProject reactorProject = DefaultReactorProject.adapt(project);

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
@@ -310,7 +310,7 @@ public abstract class AbstractTychoMapping implements Mapping, ModelReader {
                 return getEnhancementProperties(file.get());
             }
         } catch (IOException e) {
-            logger.warn("reading EnhancementProperties encountered a problem and was skipped for this reason", e);
+            logger.warn("Reading EnhancementProperties encountered a problem and was skipped for this reason", e);
         }
         return null;
     }

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoTargetMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoTargetMapping.java
@@ -60,9 +60,9 @@ public class TychoTargetMapping extends AbstractXMLTychoMapping {
                 return files.get(0);
             } else if (files.size() > 1) {
                 String sb = files.stream().map(File::getName).collect(Collectors.joining(", "));
-                throw new IllegalArgumentException("only one " + TARGET_EXTENSION
+                throw new IllegalArgumentException("Only one " + TARGET_EXTENSION
                         + " file is allowed per target project, or target must be named like the folder (<foldername>"
-                        + TARGET_EXTENSION + "), the following targets where found: " + sb);
+                        + TARGET_EXTENSION + "), the following targets were found: " + sb);
             }
         } catch (IOException e) { // ignore
         }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/limitations/MixedTychoVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/limitations/MixedTychoVersionsTest.java
@@ -31,7 +31,7 @@ public class MixedTychoVersionsTest extends AbstractTychoIntegrationTest {
             fail();
         } catch (VerificationException e) {
             // expected
-            verifier.verifyTextInLog("[ERROR] Several versions of tycho plugins are configured [0.13.0, 0.14.0, "
+            verifier.verifyTextInLog("[ERROR] Several versions of Tycho plugins are configured [0.13.0, 0.14.0, "
                     + TychoVersion.getTychoVersion() + "]:");
         }
     }

--- a/tycho-p2/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/DirectorMojo.java
+++ b/tycho-p2/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/DirectorMojo.java
@@ -115,7 +115,7 @@ public final class DirectorMojo extends AbstractProductMojo {
         synchronized (LOCK) {
             List<Product> products = getProductConfig().getProducts();
             if (products.isEmpty()) {
-                getLog().info("No product definitions found. Nothing to do.");
+                getLog().info("No product definitions found, nothing to do");
             }
             DirectorRuntime director = getDirectorRuntime();
             RepositoryReferences sources = getSourceRepositories();

--- a/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/BaselineValidator.java
+++ b/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/BaselineValidator.java
@@ -118,7 +118,7 @@ public class BaselineValidator {
                         File reactorFile = reactorMetadata.get(classifier).getLocation();
                         if (baseLineFile.isFile() && baseLineFile.length() == 0L) {
                             // workaround for possibly corrupted download - bug 484003
-                            log.error("baseline file " + baseLineFile.getAbsolutePath() + " is empty. Will not replace "
+                            log.error("Baseline file " + baseLineFile.getAbsolutePath() + " is empty. Will not replace "
                                     + reactorFile);
                         } else {
                             FileUtils.copyFile(baseLineFile, reactorFile);
@@ -150,7 +150,7 @@ public class BaselineValidator {
                                     MethodUtils.invokeMethod(project, true, "setAttachedArtifacts", list);
                                 } catch (ReflectiveOperationException ignored) {
                                     log.warn("The attached artifact " + classifier
-                                            + " is not present in the baseline but could not be removed!");
+                                            + " is not present in the baseline, but could not be removed");
                                 }
                             }
                             artifact.getLocation().delete();

--- a/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/DependenciesTreeMojo.java
+++ b/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/DependenciesTreeMojo.java
@@ -96,7 +96,7 @@ public class DependenciesTreeMojo extends AbstractMojo {
             printUnit(unit, null, units, projectMap, 0, i == size - 1);
         }
         if (!units.isEmpty()) {
-            getLog().info("---- units that can't be matched to any requirement ----");
+            getLog().info("Units that cannot be matched to any requirement:");
             for (IInstallableUnit unit : units) {
                 getLog().info(unit.toString());
             }

--- a/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
@@ -544,7 +544,7 @@ public class MavenP2SiteMojo extends AbstractMojo {
         String property = mavenProject.getProperties().getProperty("maven.deploy.skip");
         if (property != null) {
             boolean skip = Boolean.parseBoolean(property);
-            getLog().debug("deploy is " + (skip ? "" : "not") + " skipped in MavenProject " + mavenProject.getName()
+            getLog().debug("Deploy is " + (skip ? "" : "not") + " skipped in MavenProject " + mavenProject.getName()
                     + " because of property 'maven.deploy.skip'");
             return skip;
         }
@@ -552,14 +552,14 @@ public class MavenP2SiteMojo extends AbstractMojo {
         property = getPluginParameter(mavenProject, pluginId, "skip");
         if (property != null) {
             boolean skip = Boolean.parseBoolean(property);
-            getLog().debug("deploy is " + (skip ? "" : "not") + " skipped in MavenProject " + mavenProject.getName()
+            getLog().debug("Deploy is " + (skip ? "" : "not") + " skipped in MavenProject " + mavenProject.getName()
                     + " because of configuration of the plugin 'org.apache.maven.plugins:maven-deploy-plugin'");
             return skip;
         }
         if (mavenProject.getParent() != null) {
             return isSkippedDeploy(mavenProject.getParent());
         }
-        getLog().debug("not skipping deploy of MavenProject '" + mavenProject.getName() + "'");
+        getLog().debug("Not skipping deploy of MavenProject '" + mavenProject.getName() + "'");
         return false;
     }
 

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -273,7 +273,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 				// optimized archive creation not supported for now because of build qualifier
 				// mismatch issues
 				// see TYCHO-502
-				getLog().warn("ignoring unsupported archive forced = false parameter.");
+				getLog().warn("Ignoring unsupported archive 'forced = false' parameter");
 				archive.setForced(true);
 			}
 			archiver.createArchive(session, mavenProject, archive);

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
@@ -152,7 +152,7 @@ public class UpdateConsumerPomMojo extends AbstractMojo {
 			outputDirectory = project.getBasedir();
 		}
 		Log log = getLog();
-		log.debug("Generate pom descriptor with updated dependencies...");
+		log.debug("Generating pom descriptor with updated dependencies...");
 		Model projectModel;
 		try {
 			projectModel = modelReader.read(project.getFile(), null);
@@ -196,11 +196,11 @@ public class UpdateConsumerPomMojo extends AbstractMojo {
 			output.deleteOnExit();
 		}
 		if (p2Skipped.isEmpty()) {
-			log.info("All system scoped dependencies where mapped to maven artifacts.");
+			log.info("All system scoped dependencies were mapped to maven artifacts");
 		} else {
-			log.warn(resolved + " system scoped dependencies where mapped to maven artifacts, "
+			log.warn(resolved + " system scoped dependencies were mapped to maven artifacts, "
 					+ p2Skipped.size()
-					+ " where skipped!");
+					+ " were skipped");
 			if (log.isDebugEnabled()) {
 				for (String skipped : p2Skipped) {
 					log.debug("Skipped: " + skipped);

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/VerifyPomMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/VerifyPomMojo.java
@@ -83,7 +83,7 @@ public class VerifyPomMojo extends AbstractMojo {
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		if (skip) {
-			getLog().info("Execution was skipped.");
+			getLog().info("Execution was skipped");
 			return;
 		}
 		File pom;
@@ -93,7 +93,7 @@ public class VerifyPomMojo extends AbstractMojo {
 		if (isPlugin || isFeature) {
 			pom = project.getFile();
 		} else {
-			log.info("Skip project because of incompatible packaging type.");
+			log.info("Skipped project because of incompatible packaging type");
 			return;
 		}
 		try {
@@ -153,9 +153,9 @@ public class VerifyPomMojo extends AbstractMojo {
 						bundleMap.put(install, tracked);
 					} else {
 						// might not be an OSGi bundle... but maybe not an issue...
-						log.debug("Can't install resolved dependency " + tracked.id + " ("
+						log.debug("Cannot install resolved dependency " + tracked.id + " ("
 								+ tracked.file.getAbsolutePath()
-								+ ") for verification inside OSGi, maven compilation might still work!");
+								+ ") for verification inside OSGi, maven compilation might still work");
 					}
 				} catch (BundleException e) {
 					logError(tracked, e.getMessage(), pom);
@@ -163,7 +163,7 @@ public class VerifyPomMojo extends AbstractMojo {
 			}
 			Map<Bundle, String> resolveErrors = resolver.resolve();
 			if (resolveErrors.isEmpty()) {
-				log.info("No consistency errors found!");
+				log.info("No consistency errors found");
 			} else {
 				Iterator<Entry<Bundle, String>> iterator = resolveErrors.entrySet().stream()
 						.sorted(Comparator.comparing(Entry::getKey,

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/reverseresolve/MavenCentralArtifactCoordinateResolver.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/reverseresolve/MavenCentralArtifactCoordinateResolver.java
@@ -81,7 +81,7 @@ public class MavenCentralArtifactCoordinateResolver implements ArtifactCoordinat
 					}
 				}
 			} catch (Exception e) {
-				log.debug("Can't check " + path + " from central because of " + e, e);
+				log.debug("Cannot check " + path + " from central because of " + e, e);
 			}
 			return null;
 		});

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/reverseresolve/P2ArtifactCoordinateResolver.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/reverseresolve/P2ArtifactCoordinateResolver.java
@@ -73,7 +73,7 @@ public class P2ArtifactCoordinateResolver implements ArtifactCoordinateResolver 
 							return result;
 						}
 					} catch (Exception e) {
-						log.debug("Can't resolve from repository system because of " + e, e);
+						log.debug("Cannot resolve from repository system because of " + e, e);
 					}
 				}
 				return null;

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/reverseresolve/RepositoryArtifactCoordinateResolver.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/reverseresolve/RepositoryArtifactCoordinateResolver.java
@@ -102,7 +102,7 @@ public class RepositoryArtifactCoordinateResolver implements ArtifactCoordinateR
 				}
 
 			} catch (Exception e) {
-				log.debug("Can't process " + path + " because of " + e, e);
+				log.debug("Cannot process " + path + " because of " + e, e);
 			}
 
 			return Optional.empty();

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
@@ -259,7 +259,7 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
         }
 
         if (useDefaultManifestFile && defaultManifestFile.exists() && archive.getManifestFile() == null) {
-            getLog().info("Adding existing MANIFEST to archive. Found under: " + defaultManifestFile.getPath());
+            getLog().info("Adding existing MANIFEST.MF to archive. Found under: " + defaultManifestFile.getPath());
             archive.setManifestFile(defaultManifestFile);
         }
 
@@ -273,7 +273,7 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
             archive.setAddMavenDescriptor(false);
             if (!archive.isForced()) {
                 // optimized archive creation not supported for now because of build qualifier mismatch issues, see TYCHO-502
-                getLog().warn("ignoring unsupported archive forced = false parameter.");
+                getLog().warn("Ignoring unsupported archive 'forced = false' parameter");
                 archive.setForced(true);
             }
             archiver.createArchive(session, project, archive);
@@ -284,7 +284,7 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
         if (attach) {
             projectHelper.attachArtifact(project, getType(), getClassifier(), outputFile);
         } else {
-            getLog().info("NOT adding java-sources to attached artifacts list.");
+            getLog().info("NOT adding java-sources to attached artifacts list");
         }
     }
 

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
@@ -282,7 +282,7 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
             l10nPropsFile = new File(project.getBasedir(), bundleL10nBase + ".properties");
             if (!l10nPropsFile.isFile()) {
                 if (hasL10nProperty) {
-                    getLog().warn("bundle localization file " + l10nPropsFile + " not found");
+                    getLog().warn("Bundle localization file " + l10nPropsFile + " not found");
                 }
                 return null;
             }
@@ -346,7 +346,7 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
             mavenArchiveConfiguration.addManifestEntry(BUNDLE_VENDOR, I18N_KEY_PREFIX + I18N_KEY_BUNDLE_VENDOR);
             mavenArchiveConfiguration.addManifestEntry(BUNDLE_LOCALIZATION, MANIFEST_BUNDLE_LOCALIZATION_BASENAME);
         } else {
-            getLog().info("NOT adding source bundle manifest entries. Incomplete or no bundle information available.");
+            getLog().info("NOT adding source bundle MANIFEST.MF entries. Incomplete or no bundle information available.");
         }
     }
 

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -693,7 +693,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (!isCompatiblePackagingType(project.getPackaging())) {
-            getLog().debug("Skip because of incompatible packaging type: " + project.getPackaging());
+            getLog().debug("Execution was skipped because of incompatible packaging type: " + project.getPackaging());
             return;
         }
         if (shouldSkip()) {
@@ -737,7 +737,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
     protected boolean shouldSkip() {
         if (skip != null && skipTests != null && !skip.equals(skipTests)) {
             getLog().warn(
-                    "Both parameter 'skipTests' and 'maven.test.skip' are set, 'skipTests' has a higher priority!");
+                    "Both parameter 'skipTests' and 'maven.test.skip' are set, 'skipTests' has a higher priority");
         }
         if (skipTests != null) {
             return skipTests;
@@ -1055,7 +1055,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
             getLog().debug("Class " + clazz + " matches the current filter.");
         }
         if (classes.isEmpty()) {
-            getLog().debug("Nothing matches pattern = " + includeList + " excluding " + excludeList + " in "
+            getLog().debug("Nothing matches pattern " + includeList + ", excluding " + excludeList + " in "
                     + getTestClassesDirectory());
         }
         return scanResult;
@@ -1090,7 +1090,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
                 FileUtils.deleteDirectory(osgiDataDirectory);
             }
             cli = createCommandLine(testRuntime);
-            getLog().info("Executing Test Runtime with timeout " + forkedProcessTimeoutInSeconds
+            getLog().info("Executing test runtime with timeout " + forkedProcessTimeoutInSeconds
                     + ", logs (if any) will be placed at: " + logFile.getAbsolutePath());
             result = launcher.execute(cli, forkedProcessTimeoutInSeconds);
         } catch (Exception e) {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TestPluginMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TestPluginMojo.java
@@ -90,7 +90,7 @@ public class TestPluginMojo extends AbstractTestMojo {
 
     @Override
     protected void handleNoTestsFound() throws MojoFailureException {
-        String message = "No tests found.";
+        String message = "No tests found";
         if (failIfNoTests) {
             throw new MojoFailureException(message);
         } else {
@@ -101,7 +101,7 @@ public class TestPluginMojo extends AbstractTestMojo {
 
     @Override
     protected void handleSuccess() {
-        getLog().info("All tests passed!");
+        getLog().info("All tests passed");
     }
 
     @Override


### PR DESCRIPTION
Fixed some mistakes (e.g., `where` > `were`).  
Capitalized the first word when appropriate.  
Replaced informal/contracted form with formal variant.  
Removed redundant punctuation.