### PR TITLE
disable failing VerifierServiceImplTest

### DIFF
--- a/tycho-p2/tycho-p2-repository-plugin/src/test/java/org/eclipse/tycho/p2/tools/verfier/VerifierServiceImplTest.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/test/java/org/eclipse/tycho/p2/tools/verfier/VerifierServiceImplTest.java
@@ -30,6 +30,7 @@ import org.eclipse.tycho.p2.tools.FacadeException;
 import org.eclipse.tycho.p2.tools.RepositoryReferences;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -73,6 +74,7 @@ public class VerifierServiceImplTest extends TychoPlexusTestCase {
     }
 
     @Test
+    @Ignore("fails on Windows")
     public void testFileRepositoryWithTamperedArtifact() throws Exception {
         final RepositoryReferences repositories = sourceRepos("tampered_file");
         assertEquals(false, verify(repositories));


### PR DESCRIPTION
Every PR fails with that one test on Windows, and everyone must scan the logs to see whether it is that "known failure". Better disable it, if there is no fix on the horizon.