### PR TITLE
If passed parameter is null, return the empty optional

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
@@ -27,10 +27,16 @@ public class TychoProjectManager {
     Map<String, TychoProject> projectTypes;
 
     public Optional<TychoProject> getTychoProject(MavenProject project) {
+        if (project == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(projectTypes.get(project.getPackaging()));
     }
 
     public Optional<TychoProject> getTychoProject(ReactorProject project) {
+        if (project == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(projectTypes.get(project.getPackaging()));
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
@@ -227,7 +227,7 @@ public class P2ResolverImpl implements P2Resolver {
         strategy.setData(data);
         Collection<IInstallableUnit> newState;
         try {
-            if (pomDependencies != PomDependencies.ignore || !TychoConstants.USE_OLD_RESOLVER) {
+            if ((pomDependencies != PomDependencies.ignore || !TychoConstants.USE_OLD_RESOLVER) && project != null) {
                 data.setAdditionalUnitStore(p2ResolverFactoryImpl.getPomUnits().createPomQueryable(project));
             }
             newState = strategy.resolve(environment, monitor);


### PR DESCRIPTION
As per P2Resolver API it is allowed to pass a null reactor project, even though this is some rare case we probably better avoid it should not lead to a Nullpointer exception.