### PR TITLE
Extract the RepositoryIdManager into an own component

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultRepositoryIdManager.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultRepositoryIdManager.java
@@ -22,8 +22,6 @@ import java.util.stream.Stream;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
-import org.eclipse.equinox.p2.core.IProvisioningAgent;
-import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
 import org.eclipse.tycho.IRepositoryIdManager;
 import org.eclipse.tycho.MavenRepositoryLocation;
 import org.eclipse.tycho.MavenRepositorySettings;
@@ -33,8 +31,8 @@ import org.eclipse.tycho.p2maven.helper.P2PasswordUtil;
  * Helper class for the Remote*RepositoryManagers taking care of mapping repository URLs to the
  * settings.xml-configured mirrors and setting passwords.
  */
-@Component(role = IAgentServiceFactory.class, hint = IRepositoryIdManager.SERVICE_NAME)
-public class RemoteRepositoryLoadingHelper implements IRepositoryIdManager, IAgentServiceFactory {
+@Component(role = IRepositoryIdManager.class)
+public class DefaultRepositoryIdManager implements IRepositoryIdManager {
 
 	@Requirement
 	private MavenRepositorySettings settings;
@@ -146,11 +144,5 @@ public class RemoteRepositoryLoadingHelper implements IRepositoryIdManager, IAge
         return knownMavenRepositoryIds.entrySet().stream()
                 .map(e -> new MavenRepositoryLocation(e.getValue(), e.getKey()));
     }
-
-	@Override
-	public Object createService(IProvisioningAgent agent) {
-		// this don't care about different agents
-		return this;
-	}
 
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/RepositoryIdManagerAgentFactory.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/RepositoryIdManagerAgentFactory.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
+import org.eclipse.tycho.IRepositoryIdManager;
+
+@Component(role = IAgentServiceFactory.class, hint = IRepositoryIdManager.SERVICE_NAME)
+public class RepositoryIdManagerAgentFactory implements IAgentServiceFactory {
+
+	@Requirement
+	IRepositoryIdManager manager;
+
+	@Override
+	public Object createService(IProvisioningAgent agent) {
+		return manager;
+	}
+
+}


### PR DESCRIPTION
Currently the RepositoryIdManager can only be fetched as an agent service but not with plexus.

This renames and extracts the former RemoteRepositoryLoadingHelper into a dedicated component so it can be used directly in maven components as it is not dependent on the agent actually.