### PR TITLE
issue #1689: avoid file writing when no changes

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/repository/FileBasedTychoRepositoryIndex.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/repository/FileBasedTychoRepositoryIndex.java
@@ -110,6 +110,10 @@ public class FileBasedTychoRepositoryIndex implements TychoRepositoryIndex {
 
     @Override
     public synchronized void save() throws IOException {
+        if (addedGavs.isEmpty() && removedGavs.isEmpty() && indexFile.isFile()) {
+            // avoid touching the file on disk if saving is a no-op
+            return;
+        }
         File parentDir = indexFile.getParentFile();
         if (!parentDir.isDirectory()) {
             parentDir.mkdirs();


### PR DESCRIPTION
I don't really have an idea whether that is actually possible in practice or not. However, given that this method will update the file on disk in every case, we should avoid that if the old and new file content would be the same.
And even if this is theoretically not possible, the code should be merged to my mind.