### PR TITLE
Report download speed to the caller

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/DefaultHttpCacheConfig.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/DefaultHttpCacheConfig.java
@@ -27,6 +27,7 @@ public class DefaultHttpCacheConfig implements HttpCacheConfig, Initializable {
 
 	private boolean offline;
 	private boolean update;
+	private boolean interactive;
 
 	@Requirement
 	private LegacySupport legacySupport;
@@ -40,10 +41,12 @@ public class DefaultHttpCacheConfig implements HttpCacheConfig, Initializable {
 			repoDir = RepositorySystem.defaultUserLocalRepository;
 			offline = false;
 			update = false;
+			interactive = false;
 		} else {
 			offline = session.isOffline();
 			repoDir = new File(session.getLocalRepository().getBasedir());
 			update = session.getRequest().isUpdateSnapshots();
+			interactive = session.getRequest().isInteractiveMode();
 		}
 
 		cacheLocation = new File(repoDir, ".cache/tycho");
@@ -58,6 +61,11 @@ public class DefaultHttpCacheConfig implements HttpCacheConfig, Initializable {
 	@Override
 	public boolean isUpdate() {
 		return update;
+	}
+
+	@Override
+	public boolean isInteractive() {
+		return interactive;
 	}
 
 	@Override

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/DownloadStatusOutputStream.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/DownloadStatusOutputStream.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.transport;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.internal.p2.repository.DownloadStatus;
+
+public class DownloadStatusOutputStream extends OutputStream {
+	private final long startTime = System.currentTimeMillis();
+	private final OutputStream delegate;
+	private long bytesWritten;
+	private long endTime;
+	private IOException exception;
+	private String message;
+
+	public DownloadStatusOutputStream(OutputStream out, String message) {
+		this.delegate = out;
+		this.message = message;
+	}
+
+	public DownloadStatus getStatus() {
+		DownloadStatus status = new DownloadStatus(exception == null ? IStatus.OK : IStatus.ERROR, "org.eclipse.tycho",
+				message, exception);
+		if (bytesWritten > 0) {
+			status.setFileSize(bytesWritten);
+			long stopTime;
+			if (endTime > 0) {
+				stopTime = endTime;
+			} else {
+				stopTime = System.currentTimeMillis();
+			}
+			status.setTransferRate(bytesWritten / Math.max((stopTime - startTime), 1) * 1000);
+		}
+		return status;
+	}
+
+	@Override
+	public void write(int val) throws IOException {
+		try {
+			delegate.write(val);
+		} catch (IOException e) {
+			exception = e;
+			throw e;
+		}
+		bytesWritten++;
+	}
+
+	@Override
+	public void write(byte[] buf, int off, int len) throws IOException {
+		try {
+			delegate.write(buf, off, len);
+			bytesWritten += len;
+		} catch (IOException e) {
+			exception = e;
+			throw e;
+		}
+	}
+
+	@Override
+	public void flush() throws IOException {
+		try {
+			delegate.flush();
+		} catch (IOException e) {
+			exception = e;
+			throw e;
+		}
+	}
+
+	@Override
+	public void write(byte[] b) throws IOException {
+		try {
+			delegate.write(b);
+			bytesWritten += b.length;
+		} catch (IOException e) {
+			exception = e;
+			throw e;
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			delegate.close();
+		} catch (IOException e) {
+			exception = e;
+			throw e;
+		}
+		endTime = System.currentTimeMillis();
+	}
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/HttpCacheConfig.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/HttpCacheConfig.java
@@ -20,5 +20,7 @@ public interface HttpCacheConfig {
 
 	boolean isUpdate();
 
+	boolean isInteractive();
+
 	File getCacheLocation();
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransport.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransport.java
@@ -34,6 +34,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.repository.AuthenticationFailedException;
+import org.eclipse.equinox.internal.p2.repository.DownloadStatus;
 import org.eclipse.equinox.internal.provisional.p2.repository.IStateful;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
@@ -74,9 +75,15 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 
     @Override
     public IStatus download(URI toDownload, OutputStream target, IProgressMonitor monitor) {
-        try {
-            IOUtils.copy(stream(toDownload, monitor), target);
-            return reportStatus(Status.OK_STATUS, target);
+		if (httpCache.getCacheConfig().isInteractive()) {
+			logger.info("Downloading " + toDownload + "...");
+		}
+		try {
+			DownloadStatusOutputStream statusOutputStream = new DownloadStatusOutputStream(target,
+					"Download of " + toDownload);
+			IOUtils.copy(stream(toDownload, monitor), statusOutputStream);
+			DownloadStatus downloadStatus = statusOutputStream.getStatus();
+			return reportStatus(downloadStatus, target);
         } catch (AuthenticationFailedException e) {
             return new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
                     "authentication failed for " + toDownload, e);


### PR DESCRIPTION
Currently Tycho do not report download statistics, but this can badly affect download performance because the P2 MirrorSelector heavily depends on this information to choose the next mirror to use for downloads.

This adds the necessary pieces to report proper download status.

Fix https://github.com/eclipse-tycho/tycho/issues/1631