### PR TITLE
Enable async processing of file fetches

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactDescriptor.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactDescriptor.java
@@ -14,6 +14,7 @@ package org.eclipse.tycho;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 
@@ -35,6 +36,16 @@ public interface ArtifactDescriptor {
      *         succeds; <code>null</code> otherwise.
      */
     public File getLocation(boolean fetch);
+
+    /**
+     * Fetch the artifact in a possibly asynchronous way, that is returning a
+     * {@link CompletableFuture} that is either already completed (e.g. because the file is already
+     * available), failed (e.g because the fetching of the file itself failed) or will be complete
+     * sometime later on when the file is ready to be accessed.
+     * 
+     * @return a {@link CompletableFuture} that represents the current state of fetching this file
+     */
+    CompletableFuture<File> fetchArtifact();
 
     /**
      * ReactorProject corresponding to the artifact or null if the artifact does not come from a

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactDescriptor.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactDescriptor.java
@@ -43,7 +43,13 @@ public interface ArtifactDescriptor {
             return location.get();
         }
         if (fetch) {
-            return fetchArtifact().join();
+            try {
+                return fetchArtifact().get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                //do nothing... thats actually bad but it seems sometimes desired!
+            }
         }
         return null;
     }

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactDescriptor.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactDescriptor.java
@@ -14,6 +14,7 @@ package org.eclipse.tycho;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
@@ -35,7 +36,26 @@ public interface ArtifactDescriptor {
      * @return the artifact location if already available or if <code>fetch=true</code> and fetching
      *         succeds; <code>null</code> otherwise.
      */
-    public File getLocation(boolean fetch);
+    @Deprecated
+    default File getLocation(boolean fetch) {
+        Optional<File> location = getLocation();
+        if (location.isPresent()) {
+            return location.get();
+        }
+        if (fetch) {
+            return fetchArtifact().join();
+        }
+        return null;
+    }
+
+    /**
+     * Gets the location of the artifact if already know, if you really like to fetch the artifact
+     * and make is available use {@link #fetchArtifact()} instead.
+     * 
+     * @return an empty optional if the file is not currently available or an optional describing
+     *         the location of that file
+     */
+    Optional<File> getLocation();
 
     /**
      * Fetch the artifact in a possibly asynchronous way, that is returning a

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
@@ -400,6 +401,11 @@ public final class MavenDependencyInjector {
         @Override
         public File getLocation(boolean fetch) {
             return getDescriptor().getLocation(fetch);
+        }
+
+        @Override
+        public CompletableFuture<File> fetchArtifact() {
+            return getDescriptor().fetchArtifact();
         }
 
         @Override

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -401,6 +402,11 @@ public final class MavenDependencyInjector {
         @Override
         public File getLocation(boolean fetch) {
             return getDescriptor().getLocation(fetch);
+        }
+
+        @Override
+        public Optional<File> getLocation() {
+            return getDescriptor().getLocation();
         }
 
         @Override

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultArtifactDescriptor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultArtifactDescriptor.java
@@ -13,6 +13,7 @@
 package org.eclipse.tycho.core.osgitools;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
@@ -85,6 +86,7 @@ public class DefaultArtifactDescriptor implements ArtifactDescriptor {
         }
         if (locationSupplier != null) {
             CompletableFuture<File> future = new CompletableFuture<>();
+            FileNotFoundException exception = new FileNotFoundException("File for artifact " + key + " not found!");
             TychoRepositoryTransport.getDownloadExecutor().execute(() -> {
                 try {
                     File file = locationSupplier.get();
@@ -94,7 +96,8 @@ public class DefaultArtifactDescriptor implements ArtifactDescriptor {
                         }
                         future.complete(ArtifactCollection.normalizeLocation(file));
                     } else {
-                        future.cancel(true);
+                        // future.cancel(true);
+                        future.completeExceptionally(exception);
                     }
                 } catch (RuntimeException e) {
                     future.completeExceptionally(e);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultArtifactDescriptor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultArtifactDescriptor.java
@@ -15,6 +15,8 @@ package org.eclipse.tycho.core.osgitools;
 import java.io.File;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
@@ -22,15 +24,16 @@ import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.core.osgitools.targetplatform.ArtifactCollection;
+import org.eclipse.tycho.p2maven.transport.TychoRepositoryTransport;
 
 public class DefaultArtifactDescriptor implements ArtifactDescriptor {
 
     private final ArtifactKey key;
 
     private Function<ArtifactDescriptor, File> locationSupplier;
-    private File location;
+    private volatile CompletableFuture<File> location;
 
-    private ReactorProject project;
+    private volatile ReactorProject project;
 
     private final String classifier;
 
@@ -39,7 +42,7 @@ public class DefaultArtifactDescriptor implements ArtifactDescriptor {
     public DefaultArtifactDescriptor(ArtifactKey key, File location, ReactorProject project, String classifier,
             Collection<IInstallableUnit> installableUnits) {
         this.key = key;
-        this.location = ArtifactCollection.normalizeLocation(location);
+        this.location = CompletableFuture.completedFuture(ArtifactCollection.normalizeLocation(location));
         this.project = project;
         this.classifier = classifier;
         this.installableUnits = installableUnits;
@@ -60,20 +63,74 @@ public class DefaultArtifactDescriptor implements ArtifactDescriptor {
     }
 
     @Override
-    public File getLocation(boolean fetch) {
+    public synchronized File getLocation(boolean fetch) {
         if (project != null) {
             File basedir = project.getBasedir();
             if (basedir != null) {
                 return basedir;
             }
         }
-        if (fetch && locationSupplier != null && (location == null || !location.exists())) {
-            File file = locationSupplier.apply(this);
-            if (file != null) {
-                location = ArtifactCollection.normalizeLocation(file);
+        if (isValid(location)) {
+            if (fetch) {
+                return location.join();
+            }
+            //the download was already initiated but fetch is not required, so get what is available right now
+            return location.getNow(null);
+        }
+        if (fetch) {
+            return fetchArtifact().join();
+        }
+        return null;
+    }
+
+    @Override
+    public synchronized CompletableFuture<File> fetchArtifact() {
+        if (project != null) {
+            File basedir = project.getBasedir();
+            if (basedir != null) {
+                return CompletableFuture.completedFuture(basedir);
             }
         }
-        return location;
+        if (isValid(location)) {
+            return location;
+        }
+        if (locationSupplier != null) {
+            CompletableFuture<File> future = new CompletableFuture<>();
+            TychoRepositoryTransport.getDownloadExecutor().execute(() -> {
+                try {
+                    File file = locationSupplier.apply(this);
+                    if (file != null) {
+                        future.complete(ArtifactCollection.normalizeLocation(file));
+                    } else {
+                        future.cancel(true);
+                    }
+                } catch (RuntimeException e) {
+                    future.completeExceptionally(e);
+                }
+            });
+            return location = future;
+        }
+        return CompletableFuture.failedFuture(new IllegalStateException("can't fetch artifact :: " + key));
+    }
+
+    private boolean isValid(CompletableFuture<File> f) {
+        if (f == null) {
+            return false;
+        }
+        if (f.isCompletedExceptionally()) {
+            return false;
+        }
+        if (f.isDone()) {
+            try {
+                return f.get().exists();
+            } catch (InterruptedException e) {
+                return false;
+            } catch (ExecutionException e) {
+                return false;
+            }
+        }
+        //it has no errors (yet) but is also not done so lets assume it is valid...
+        return true;
     }
 
     @Override
@@ -125,11 +182,12 @@ public class DefaultArtifactDescriptor implements ArtifactDescriptor {
                 && Objects.equals(installableUnits, other.installableUnits);
     }
 
-    public void resolve(File newLocation) {
-        location = newLocation;
+    public synchronized void resolve(File newLocation) {
+        Objects.requireNonNull(newLocation);
+        location = CompletableFuture.completedFuture(newLocation);
     }
 
-    public void setMavenProject(ReactorProject mavenProject) {
+    public synchronized void setMavenProject(ReactorProject mavenProject) {
         project = mavenProject;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultArtifactDescriptor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultArtifactDescriptor.java
@@ -59,7 +59,11 @@ public class DefaultArtifactDescriptor implements ArtifactDescriptor {
     @Override
     public synchronized Optional<File> getLocation() {
         if (project != null) {
-            //TODO better project.getArtifact getfile??
+            File artifact = project.getArtifact();
+            if (artifact != null && artifact.isFile()) {
+                return Optional.of(artifact);
+            }
+            //FIXME this do not look right!
             File basedir = project.getBasedir();
             if (basedir != null) {
                 return Optional.of(basedir);
@@ -75,7 +79,11 @@ public class DefaultArtifactDescriptor implements ArtifactDescriptor {
     @Override
     public synchronized CompletableFuture<File> fetchArtifact() {
         if (project != null) {
-            //TODO better project.getArtifact getfile??
+            File artifact = project.getArtifact();
+            if (artifact != null && artifact.isFile()) {
+                return CompletableFuture.completedFuture(artifact);
+            }
+            //FIXME this do not look right!
             File basedir = project.getBasedir();
             if (basedir != null) {
                 return CompletableFuture.completedFuture(basedir);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultFeatureDescription.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultFeatureDescription.java
@@ -29,7 +29,11 @@ public class DefaultFeatureDescription extends DefaultArtifactDescriptor impleme
 
     public DefaultFeatureDescription(ArtifactKey key, File location, ReactorProject project, String classifier,
             Feature feature, FeatureRef featureRef, Collection<IInstallableUnit> installableUnits) {
-        super(key, location, project, classifier, installableUnits);
+        super(key, classifier, installableUnits);
+        setMavenProject(project);
+        if (location != null) {
+            resolve(location);
+        }
         this.feature = feature;
         this.featureRef = featureRef;
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultPluginDescription.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultPluginDescription.java
@@ -27,7 +27,11 @@ public class DefaultPluginDescription extends DefaultArtifactDescriptor implemen
 
     public DefaultPluginDescription(ArtifactKey key, File location, ReactorProject project, String classifier,
             PluginRef pluginRef, Collection<IInstallableUnit> installableUnits) {
-        super(key, location, project, classifier, installableUnits);
+        super(key, classifier, installableUnits);
+        setMavenProject(project);
+        if (location != null) {
+            resolve(location);
+        }
         this.pluginRef = pluginRef;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/DefaultDependencyArtifacts.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/DefaultDependencyArtifacts.java
@@ -98,7 +98,7 @@ public class DefaultDependencyArtifacts extends ArtifactCollection implements De
     }
 
     public void addFragment(ArtifactKey key, Supplier<File> location, Set<IInstallableUnit> installableUnits) {
-        fragments.add(new DefaultArtifactDescriptor(key, whatever -> location.get(), null, null, installableUnits));
+        fragments.add(DefaultArtifactDescriptor.create(key, location, installableUnits));
     }
 
     @Override

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/test/DefaultDependencyArtifactsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/test/DefaultDependencyArtifactsTest.java
@@ -36,9 +36,14 @@ import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.osgitools.targetplatform.DefaultDependencyArtifacts;
 import org.eclipse.tycho.core.osgitools.targetplatform.MultiEnvironmentDependencyArtifacts;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class DefaultDependencyArtifactsTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     static IInstallableUnit unit(String id) {
         InstallableUnitDescription desc = new InstallableUnitDescription();
@@ -98,8 +103,8 @@ public class DefaultDependencyArtifactsTest {
     public void testRelativePath() throws IOException {
         DefaultDependencyArtifacts tp = new DefaultDependencyArtifacts();
 
-        File relative = new File("relative.xml");
-        File canonical = new File("canonical.xml");
+        File relative = temporaryFolder.newFile("relative.xml");
+        File canonical = temporaryFolder.newFile("canonical.xml");
 
         tp.addArtifactFile(new DefaultArtifactKey("foo", "relative", "1"), relative, null);
         tp.addArtifactFile(new DefaultArtifactKey("foo", "canonical", "1"), canonical.getAbsoluteFile(), null);
@@ -176,7 +181,7 @@ public class DefaultDependencyArtifactsTest {
     }
 
     @Test
-    public void testDoNotCacheArtifactsThatRepresentReactorProjects() {
+    public void testDoNotCacheArtifactsThatRepresentReactorProjects() throws IOException {
         // IInstallableUnit #hashCode and #equals methods only use (version,id) tuple to determine IU equality
         // Reactor projects are expected to produce different IUs potentially with the same (version,id) during the build
         // This test verifies that different DefaultTargetPlatform can have the same reactor project with different IUs
@@ -184,13 +189,13 @@ public class DefaultDependencyArtifactsTest {
 
         ReactorProject project = new DefaultReactorProject(new MavenProject());
         ArtifactKey key = new DefaultArtifactKey("type", "id", "version");
-        File location = new File("location");
+        File location = temporaryFolder.newFile();
 
         DefaultDependencyArtifacts tp1 = new DefaultDependencyArtifacts();
-        tp1.addArtifact(new DefaultArtifactDescriptor(key, location, project, null, Set.of(unit("a"))));
+        tp1.addArtifact(DefaultArtifactDescriptor.create(key, location, project, null, Set.of(unit("a"))));
 
         DefaultDependencyArtifacts tp2 = new DefaultDependencyArtifacts();
-        tp2.addArtifact(new DefaultArtifactDescriptor(key, location, project, null, Set.of(unit("b"))));
+        tp2.addArtifact(DefaultArtifactDescriptor.create(key, location, project, null, Set.of(unit("b"))));
 
         Assert.assertEquals(unit("a"), //
                 getArtifactMapForLocation(location, tp1).get(null).getInstallableUnits().iterator().next());

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -145,7 +146,7 @@ public class UpdateConsumerPomMojo extends AbstractMojo {
 	@Parameter(defaultValue = "local,p2,central")
 	private String resolver;
 
-	private Map<String, Optional<Dependency>> resolvedDependencies = new HashMap<>();
+	private Map<String, Optional<Dependency>> resolvedDependencies = new ConcurrentHashMap<>();
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
@@ -176,9 +176,10 @@ public class UpdateConsumerPomMojo extends AbstractMojo {
 				CompletableFuture<File> future = getFileFuture(dep);
 				futures.add(future.thenAccept(file -> {
 					if (!handleSystemScopeDependency(copy)) {
-						p2Skipped.add(dep.getManagementKey() + " @ "
-								+ Optional.ofNullable(file)
-								.map(String::valueOf).orElse(dep.getSystemPath()));
+						synchronized (p2Skipped) {
+							p2Skipped.add(dep.getManagementKey() + " @ "
+									+ Optional.ofNullable(file).map(String::valueOf).orElse(dep.getSystemPath()));
+						}
 						// skip this ...
 						return;
 					}


### PR DESCRIPTION
Currently files are always fetched in sync with the caller, but sometimes it is not desirable (or necessary) to process the result right now.

For this cases we now enable a way to lazy consume a location through ArtifactDescriptor.fetchArtifact() method that returns a CompletableFuture that could be used by the caller to delay some actions and possibly enable the download of other files in parallel.