### PR TITLE
Propagate log to ProxySignerWithPublicKeyAccess

### DIFF
--- a/tycho-gpg-plugin/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojoExtension.java
+++ b/tycho-gpg-plugin/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojoExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2022 Red Hat Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,9 @@ public abstract class AbstractGpgMojoExtension extends AbstractGpgMojo {
     @Override
     protected ProxySignerWithPublicKeyAccess newSigner(MavenProject project)
             throws MojoExecutionException, MojoFailureException {
-        return new ProxySignerWithPublicKeyAccess(super.newSigner(project));
+        ProxySignerWithPublicKeyAccess signer = new ProxySignerWithPublicKeyAccess(super.newSigner(project));
+        signer.setLog(getLog());
+        return signer;
     }
 
 }


### PR DESCRIPTION
Fixes nasty:
```
[ERROR] Failed to execute goal
org.eclipse.tycho:tycho-gpg-plugin:4.0.0-SNAPSHOT:sign-p2-artifacts
(pgpsigner) on project org.eclipse.linuxtools.releng-site: Execution
pgpsigner of goal
org.eclipse.tycho:tycho-gpg-plugin:4.0.0-SNAPSHOT:sign-p2-artifacts
failed: Cannot invoke
"org.apache.maven.plugin.logging.Log.info(java.lang.CharSequence)"
because the return value of
"org.apache.maven.plugins.gpg.ProxySignerWithPublicKeyAccess.getLog()"
is null -> [Help 1]
```