### PR TITLE
Support initializing bouncy castle signer by directly loaded secret keys

### DIFF
--- a/tycho-gpg-plugin/pom.xml
+++ b/tycho-gpg-plugin/pom.xml
@@ -61,13 +61,4 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.plexus</groupId>
-				<artifactId>plexus-component-metadata</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/tycho-gpg-plugin/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojoExtension.java
+++ b/tycho-gpg-plugin/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojoExtension.java
@@ -20,7 +20,7 @@ public abstract class AbstractGpgMojoExtension extends AbstractGpgMojo {
     @Override
     protected ProxySignerWithPublicKeyAccess newSigner(MavenProject project)
             throws MojoExecutionException, MojoFailureException {
-        return new ProxySignerWithPublicKeyAccess(super.newSigner(project), getSigner(), getPGPInfo());
+        return new ProxySignerWithPublicKeyAccess(super.newSigner(project), getSigner(), getPGPInfo(), getSecretKeys());
     }
 
     protected String getSigner() {
@@ -28,6 +28,10 @@ public abstract class AbstractGpgMojoExtension extends AbstractGpgMojo {
     }
 
     protected File getPGPInfo() {
+        return null;
+    }
+
+    protected File getSecretKeys() {
         return null;
     }
 }

--- a/tycho-gpg-plugin/src/main/java/org/eclipse/tycho/gpg/SignRepositoryArtifactsMojo.java
+++ b/tycho-gpg-plugin/src/main/java/org/eclipse/tycho/gpg/SignRepositoryArtifactsMojo.java
@@ -128,6 +128,13 @@ public class SignRepositoryArtifactsMojo extends AbstractGpgMojoExtension {
     private String signer;
 
     /**
+     * Configure the Bouncy Castle {@link #signer} to load the secret keys, stored in armored from,
+     * from the specified file. This avoids needing to import the keys into GnuPG's keybox.
+     */
+    @Parameter(property = "tycho.pgp.signer.bc.secretKeys")
+    private File secretKeys;
+
+    /**
      * Configured to specify artifacts that should be signed independently of other settings, e.g.,
      * {@link #skipIfJarsigned}, {@link #skipIfJarsignedAndAnchored}, and {@link #skipBinaries}.
      */
@@ -155,6 +162,11 @@ public class SignRepositoryArtifactsMojo extends AbstractGpgMojoExtension {
     protected File getPGPInfo() {
         var pgpInfo = System.getProperty("org.eclipse.tycho.test.pgp.info");
         return pgpInfo == null ? null : new File(pgpInfo);
+    }
+
+    @Override
+    protected File getSecretKeys() {
+        return secretKeys;
     }
 
     @Override


### PR DESCRIPTION
This avoids needing the native gpg keybox to be initialized by importing the secret keys file and then later fetching that information from gpg, simplifying configuration on a build server.

https://github.com/eclipse-tycho/tycho/issues/1724