### PR TITLE
Inform the user about possible candidates in the reactor

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/InstallableUnitGenerator.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/InstallableUnitGenerator.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
@@ -252,6 +253,11 @@ public class InstallableUnitGenerator {
 		default:
 		}
 		return actions;
+	}
+
+	public Stream<IInstallableUnit> getInstallableUnits(MavenProject project) {
+		return Stream.concat(Stream.of(project.getArtifact()), project.getAttachedArtifacts().stream())
+				.flatMap(a -> getInstallableUnits(a).stream());
 	}
 
 	public Collection<IInstallableUnit> getInstallableUnits(Artifact artifact) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverFactoryImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverFactoryImpl.java
@@ -31,6 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.LegacySupport;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -56,6 +58,7 @@ import org.eclipse.tycho.p2.repository.LocalRepositoryP2Indices;
 import org.eclipse.tycho.p2.repository.LocalRepositoryReader;
 import org.eclipse.tycho.p2.repository.RepositoryReader;
 import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
+import org.eclipse.tycho.p2maven.InstallableUnitGenerator;
 
 @Component(role = P2ResolverFactory.class)
 public class P2ResolverFactoryImpl implements P2ResolverFactory {
@@ -83,6 +86,11 @@ public class P2ResolverFactoryImpl implements P2ResolverFactory {
 
     @Requirement
     private Logger logger;
+
+    @Requirement
+    private LegacySupport legacySupport;
+    @Requirement
+    private InstallableUnitGenerator generator;
 
     private synchronized LocalMetadataRepository getLocalMetadataRepository(MavenContext context,
             LocalRepositoryP2Indices localRepoIndices) {
@@ -278,5 +286,14 @@ public class P2ResolverFactoryImpl implements P2ResolverFactory {
 
     public TychoProjectManager getProjectManager() {
         return projectManager;
+    }
+
+    public MavenSession getSession() {
+        return legacySupport.getSession();
+    }
+
+    public InstallableUnitGenerator getInstallableUnitGenerator() {
+        return generator;
+
     }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomInstallableUnitStore.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomInstallableUnitStore.java
@@ -19,8 +19,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.apache.maven.artifact.Artifact;
@@ -60,6 +62,7 @@ class PomInstallableUnitStore implements IQueryable<IInstallableUnit> {
     private ArtifactHandlerManager artifactHandlerManager;
     private Logger logger;
     private TargetPlatformConfiguration configuration;
+    private Set<IQuery<IInstallableUnit>> missedQueries = new LinkedHashSet<>();
 
     public PomInstallableUnitStore(TychoProject tychoProject, ReactorProject reactorProject,
             InstallableUnitGenerator generator, ArtifactHandlerManager artifactHandlerManager, Logger logger,
@@ -81,6 +84,10 @@ class PomInstallableUnitStore implements IQueryable<IInstallableUnit> {
             return EMPTY_RESULT;
         }
         IQueryResult<IInstallableUnit> result = getPomIUs().query(query, monitor);
+        if (result.isEmpty()) {
+            missedQueries.add(query);
+            return EMPTY_RESULT;
+        }
         for (IInstallableUnit unit : result) {
             PomDependency pomDependency = installableUnitLookUp.get(unit);
             if (pomDependency == null) {
@@ -195,6 +202,10 @@ class PomInstallableUnitStore implements IQueryable<IInstallableUnit> {
 
     Collection<PomDependency> getGatheredDependencies() {
         return gatheredDependencies;
+    }
+
+    Collection<IQuery<IInstallableUnit>> getMissedQueries() {
+        return missedQueries;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomUnits.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomUnits.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
@@ -24,6 +25,7 @@ import org.codehaus.plexus.logging.Logger;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.publisher.IPublisherAdvice;
 import org.eclipse.equinox.p2.query.CollectionResult;
+import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryable;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
@@ -74,6 +76,14 @@ public class PomUnits {
             return new PomInstallableUnitStore(tychoProject.get(), reactorProject, generator, artifactHandlerManager,
                     logger, configuration);
         });
+    }
+
+    public Collection<IQuery<IInstallableUnit>> getMissedQueries(ReactorProject reactorProject) {
+        Object contextValue = reactorProject.getContextValue(KEY);
+        if (contextValue instanceof PomInstallableUnitStore store) {
+            return store.getMissedQueries();
+        }
+        return Collections.emptyList();
     }
 
     public void addCollectedUnits(PomDependencyCollector collector, ReactorProject reactorProject) {


### PR DESCRIPTION
With the new resolver pom declared dependencies are easier to use and mixed reactor builds are now possible.

One problem that remains is, that it is sometimes hard to guess why a dependency resolution is failing, because the error can reference packages or capabilities and one need to find out where they are provided.

This adds a very basic search to find if a reactor project maybe provide something that is missing and print a hint to the log.