### PR TITLE
Convert the MavenDependencyInjector into a plexus-component

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/DependencyResolver.java
@@ -17,11 +17,9 @@ import java.util.List;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.logging.Logger;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.artifacts.DependencyArtifacts;
-import org.eclipse.tycho.core.osgitools.AbstractTychoProject;
 import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
 
 /**
@@ -45,6 +43,4 @@ public interface DependencyResolver {
             TargetPlatform targetPlatform, List<ReactorProject> reactorProjects,
             DependencyResolverConfiguration resolverConfiguration);
 
-    public void injectDependenciesIntoMavenModel(MavenProject project, AbstractTychoProject projectType,
-            DependencyArtifacts resolvedDependencies, DependencyArtifacts testDepedencyArtifacts, Logger logger);
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyCollector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyCollector.java
@@ -35,16 +35,20 @@ import org.eclipse.tycho.model.PluginRef;
 public class MavenDependencyCollector extends ArtifactDependencyVisitor {
 
     private MavenDependencyInjector injector;
-    private final Logger logger;
+    private MavenProject project;
+    private Logger logger;
 
     public MavenDependencyCollector(MavenProject project, BundleReader bundleReader, Logger logger) {
-        this.injector = new MavenDependencyInjector(project, bundleReader, null, logger);
+        this.project = project;
         this.logger = logger;
+        this.injector = new MavenDependencyInjector();
+        injector.logger = logger;
+        injector.bundleReader = bundleReader;
     }
 
     @Override
     public boolean visitFeature(FeatureDescription feature) {
-        injector.addDependency(feature, Artifact.SCOPE_SYSTEM);
+        injector.addDependency(feature, Artifact.SCOPE_SYSTEM, project);
         return true; // keep visiting
     }
 
@@ -52,9 +56,9 @@ public class MavenDependencyCollector extends ArtifactDependencyVisitor {
     public void visitPlugin(PluginDescription plugin) {
         ReactorProject mavenProject = plugin.getMavenProject();
         if (mavenProject == null) {
-            injector.addDependency(plugin, Artifact.SCOPE_SYSTEM);
+            injector.addDependency(plugin, Artifact.SCOPE_SYSTEM, project);
         } else {
-            injector.addDependency(plugin, Artifact.SCOPE_COMPILE);
+            injector.addDependency(plugin, Artifact.SCOPE_COMPILE, project);
         }
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/LocalDependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/LocalDependencyResolver.java
@@ -261,7 +261,6 @@ public class LocalDependencyResolver extends AbstractLogEnabled implements Depen
         layout.setLocation(location.getAbsoluteFile());
     }
 
-    @Override
     public void injectDependenciesIntoMavenModel(MavenProject project, AbstractTychoProject projectType,
             DependencyArtifacts targetPlatform, DependencyArtifacts testTargetPlatform, Logger logger) {
         // TODO testTargetPlatform is ignored for this local resolved. Is this OK?

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTychoResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTychoResolver.java
@@ -41,6 +41,7 @@ import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.ee.ExecutionEnvironmentConfigurationImpl;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
+import org.eclipse.tycho.core.maven.MavenDependencyInjector;
 import org.eclipse.tycho.core.osgitools.AbstractTychoProject;
 import org.eclipse.tycho.core.osgitools.DebugUtils;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
@@ -65,6 +66,9 @@ public class DefaultTychoResolver implements TychoResolver {
 
     @Requirement
     private ToolchainManager toolchainManager;
+
+    @Requirement
+    private MavenDependencyInjector dependencyInjector;
 
     public static final String TYCHO_ENV_OSGI_WS = "tycho.env.osgi.ws";
     public static final String TYCHO_ENV_OSGI_OS = "tycho.env.osgi.os";
@@ -176,8 +180,7 @@ public class DefaultTychoResolver implements TychoResolver {
             dr.setTestDependencyArtifacts(session, reactorProject,
                     Objects.requireNonNullElse(testDependencyArtifacts, new DefaultDependencyArtifacts()));
         }
-
-        resolver.injectDependenciesIntoMavenModel(project, dr, dependencyArtifacts, testDependencyArtifacts, logger);
+        dependencyInjector.injectMavenDependencies(project, dependencyArtifacts, testDependencyArtifacts);
 
         if (logger.isDebugEnabled() && DebugUtils.isDebugEnabled(session, project)) {
             StringBuilder sb = new StringBuilder(threadMarker);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -46,7 +46,6 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.ComponentDependency;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
-import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 import org.eclipse.equinox.p2.core.spi.IAgentService;
@@ -72,8 +71,6 @@ import org.eclipse.tycho.core.DependencyResolverConfiguration;
 import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
-import org.eclipse.tycho.core.maven.MavenDependencyInjector;
-import org.eclipse.tycho.core.osgitools.AbstractTychoProject;
 import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.DebugUtils;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
@@ -428,11 +425,4 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
     public void initialize() throws InitializationException {
     }
 
-    @Override
-    public void injectDependenciesIntoMavenModel(MavenProject project, AbstractTychoProject projectType,
-            DependencyArtifacts dependencyArtifacts, DependencyArtifacts testDependencyArtifacts, Logger logger) {
-        MavenDependencyInjector.injectMavenDependencies(project, dependencyArtifacts, testDependencyArtifacts,
-                bundleReader, resolverFactory::resolveDependencyDescriptor, logger, repositorySystem,
-                context.getSession().getSettings());
-    }
 }


### PR DESCRIPTION
Currently a lot of parameters a passed through deep call chains because of the previous split between Maven/OSGi world. This is no longer required and we can decouple the code here to be more flexible.

This depends on
-  https://github.com/eclipse-tycho/tycho/pull/1695