### PR TITLE
avoid duplicate dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,9 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>
 					<execution>
@@ -426,6 +429,36 @@
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>bnd-maven-plugin</artifactId>
 					<version>6.3.1</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.1.0</version>
+					<executions>
+						<execution>
+							<id>no-duplicate-declared-dependencies</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<banDuplicatePomDependencyVersions/>
+									<requireJavaVersion>
+										<version>${min.jdk.version}</version>
+									</requireJavaVersion>
+									<requireMavenVersion>
+										<version>3.8.6</version>
+									</requireMavenVersion>
+									<requirePluginVersions/>
+								</rules>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-invoker-plugin</artifactId>
+					<version>3.3.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/tycho-bundles/org.eclipse.tycho.core.shared/pom.xml
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/pom.xml
@@ -138,11 +138,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
-			<artifactId>org.eclipse.equinox.p2.director</artifactId>
-			<version>2.5.400</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.equinox.p2.director.app</artifactId>
 			<version>1.2.200</version>
 		</dependency>


### PR DESCRIPTION
Since it's not the first time that Maven throws warnings because of duplicate dependencies in Tycho, we need more strict checks.