### PR TITLE
Reproducer for "JupiterTestEngine not a subtype" when using JUnit 5

### DIFF
--- a/tycho-its/projects/target.artifact.junit/bundle-example/.classpath
+++ b/tycho-its/projects/target.artifact.junit/bundle-example/.classpath
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" output="test" path="src/test/java">
+        <attributes>
+    		<attribute name="test" value="true"/>
+    	</attributes>
+    </classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/tycho-its/projects/target.artifact.junit/bundle-example/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.artifact.junit/bundle-example/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Example Bundle
+Bundle-SymbolicName: bundle-example
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Example Vendor
+Require-Bundle: org.eclipse.ui,
+ org.eclipse.core.runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .

--- a/tycho-its/projects/target.artifact.junit/bundle-example/build.properties
+++ b/tycho-its/projects/target.artifact.junit/bundle-example/build.properties
@@ -1,0 +1,4 @@
+source.. = src/main/java/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/target.artifact.junit/bundle-example/pom.xml
+++ b/tycho-its/projects/target.artifact.junit/bundle-example/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.tycho.repro</groupId>
+    <artifactId>tycho-repro-junit</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>bundle-example</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/target.artifact.junit/bundle-example/src/test/java/com/tycho/repro/MyExampleTestIT.java
+++ b/tycho-its/projects/target.artifact.junit/bundle-example/src/test/java/com/tycho/repro/MyExampleTestIT.java
@@ -1,0 +1,10 @@
+package com.tycho.repro;
+
+import org.junit.Test;
+
+public class MyExampleTestIT {
+    @Test
+    public void exampleTest() {
+        // Noop
+    }
+}

--- a/tycho-its/projects/target.artifact.junit/pom.xml
+++ b/tycho-its/projects/target.artifact.junit/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.tycho.repro</groupId>
+  <artifactId>tycho-repro-junit</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>target-platform</module>
+    <module>bundle-example</module>
+  </modules>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <executionEnvironment>JavaSE-11</executionEnvironment>
+          <target>
+            <artifact>
+              <groupId>com.tycho.repro</groupId>
+              <artifactId>target-platform</artifactId>
+              <version>1.0.0-SNAPSHOT</version>
+            </artifact>
+          </target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>3.0.0-M5</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <executions>
+          <execution>
+            <id>execute-plugin-tests</id>
+            <configuration>
+              <includes>**/PluginTest*.class,**/*IT.class</includes>
+            </configuration>
+            <goals>
+              <goal>plugin-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tycho-its/projects/target.artifact.junit/target-platform/pom.xml
+++ b/tycho-its/projects/target.artifact.junit/target-platform/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.tycho.repro</groupId>
+    <artifactId>tycho-repro-junit</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>target-platform</artifactId>
+  <packaging>eclipse-target-definition</packaging>
+</project>

--- a/tycho-its/projects/target.artifact.junit/target-platform/target-platform.target
+++ b/tycho-its/projects/target.artifact.junit/target-platform/target-platform.target
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target includeMode="feature" name="target-platform">
+  <locations>
+    <location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
+      <dependencies>
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <version>5.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <version>5.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-migrationsupport</artifactId>
+          <version>5.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-params</artifactId>
+          <version>5.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-commons</artifactId>
+          <version>1.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-engine</artifactId>
+          <version>1.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-launcher</artifactId>
+          <version>1.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-runner</artifactId>
+          <version>1.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-suite-api</artifactId>
+          <version>1.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-suite-commons</artifactId>
+          <version>1.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <version>5.9.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.apiguardian</groupId>
+          <artifactId>apiguardian-api</artifactId>
+          <version>1.1.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.opentest4j</groupId>
+          <artifactId>opentest4j</artifactId>
+          <version>1.2.0</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/eclipse/updates/4.23"/>
+      <unit id="org.eclipse.platform.sdk" />
+      <unit id="org.eclipse.rcp.feature.group" />
+      <unit id="org.eclipse.platform.ide" />
+      <unit id="org.eclipse.test.feature.group" />
+    </location>
+  </locations>
+  <environment>
+    <nl>en_US</nl>
+  </environment>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformArtifactJUnitTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformArtifactJUnitTest.java
@@ -1,0 +1,17 @@
+package org.eclipse.tycho.test.target;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+import java.util.List;
+
+// See PR https://github.com/eclipse-tycho/tycho/pull/1773
+public class TargetPlatformArtifactJUnitTest extends AbstractTychoIntegrationTest {
+    @Test
+    public void testTargetPlatformForJUnit5() throws Exception {
+        Verifier verifier = getVerifier("target.artifact.junit", false, true);
+        verifier.executeGoals(List.of("clean", "verify"));
+        verifier.verifyErrorFreeLog();
+    }
+}


### PR DESCRIPTION
I have no idea what I'm doing wrong, so I prepared a reproducer.  
The target platform is in its own reactor artifact, and it imports some features of Eclipse 4.23, plus JUnit 5 Maven dependencies.

The full error stack trace is:
```
org.apache.maven.surefire.api.util.SurefireReflectionException: java.util.ServiceConfigurationError: org.junit.platform.engine.TestEngine: org.junit.jupiter.engine.JupiterTestEngine not a subtype
	at org.apache.maven.surefire.api.util.ReflectionUtils.instantiateOneArg(ReflectionUtils.java:127)
	at org.apache.maven.surefire.booter.SurefireReflector.instantiateProvider(SurefireReflector.java:211)
	at org.apache.maven.surefire.booter.ProviderFactory.createProvider(ProviderFactory.java:118)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:83)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:142)
	at org.eclipse.tycho.surefire.osgibooter.HeadlessTestApplication.start(HeadlessTestApplication.java:29)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1440)
Caused by: java.util.ServiceConfigurationError: org.junit.platform.engine.TestEngine: org.junit.jupiter.engine.JupiterTestEngine not a subtype
	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1244)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
	at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
	at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
	at java.base/java.lang.Iterable.forEach(Iterable.java:74)
	at org.junit.platform.launcher.core.LauncherFactory.collectTestEngines(LauncherFactory.java:145)
	at org.junit.platform.launcher.core.LauncherFactory.createDefaultLauncher(LauncherFactory.java:131)
	at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:125)
	at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:109)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.<init>(JUnitPlatformProvider.java:90)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.apache.maven.surefire.api.util.ReflectionUtils.instantiateOneArg(ReflectionUtils.java:123)
```

Any idea?