### PR TITLE
Normalize the host bundle symbolic name

### DIFF
--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
@@ -220,7 +220,7 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
                     Analyzer analyzer = new Analyzer(jar)) {
                 Manifest bundleManifest = mainArtifact.getManifest();
                 String hostVersion = bundleManifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-                String hostSymbolicName = bundleManifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME);
+                String hostSymbolicName = getHostSymbolicName(bundleManifest);
                 analyzer.setProperty(Constants.BUNDLE_VERSION, hostVersion);
                 analyzer.setProperty(Constants.BUNDLE_SYMBOLICNAME, hostSymbolicName + "." + uuid);
                 analyzer.setProperty(Constants.FRAGMENT_HOST,
@@ -262,6 +262,18 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
                 .setRemoteRepositories(
                         Stream.concat(pluginRemoteRepositories.stream(), projectRemoteRepositories.stream()).toList());
         return repositorySystem.resolve(request);
+    }
+
+    /**
+     * Returns a normalized host bundle Bundle-SymbolicName.
+     * This means any metadata apart from the name itself is removed.
+     */
+    private String getHostSymbolicName(final Manifest manifest) {
+        final var value = manifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME);
+        final var separatorIndex = value.indexOf(';');
+        return separatorIndex > -1
+                ? value.substring(0, separatorIndex)
+                : value;
     }
 
     private static final class ProviderDependencyArtifactFilter implements ArtifactFilter {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
@@ -13,12 +13,12 @@
 package org.eclipse.tycho.surefire;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.artifact.Artifact;
@@ -28,7 +28,6 @@ import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -37,7 +36,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.surefire.api.util.ScanResult;
 import org.apache.maven.surefire.booter.PropertiesWrapper;
 import org.eclipse.sisu.equinox.launching.EquinoxInstallationDescription;
-import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.classpath.ClasspathEntry;
@@ -50,9 +48,7 @@ import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Jar;
 
 /**
- * <p>
  * Executes integration-tests in an OSGi runtime.
- * </p>
  * <p>
  * The goal launches an OSGi runtime and executes the project's integration-tests (default patterns
  * are <code>PluginTest*.class, *IT.class</code>) in that runtime. The "test runtime" consists of
@@ -67,21 +63,20 @@ import aQute.bnd.osgi.Jar;
  * This goal adopts the maven-failsafe paradigm, that works in the following way:
  * <ol>
  * <li><code>pre-integration-test</code> phase could be used to prepare any prerequisite (e.g.
- * starting web-server, files, ...)</li>
+ * starting a web-server, creating files, etc.)</li>
  * <li><code>integration-test</code> phase does not fail the build if there are test failures but a
  * summary file is written</li>
  * <li><code>post-integration-test</code> could be used to cleanup/tear down any resources from the
- * <code>pre-integration-test</code> phase
+ * <code>pre-integration-test</code> phase</li>
  * <li>test outcome is checked in the <code>verify</code> phase that might fail the build if there
- * are test failures
+ * are test failures</li>
  * </ol>
  * </p>
- * summary files are generated according to the default maven-surefire-plugin for integration with
- * tools that already work with maven-surefire-plugin (e.g. CI servers)
+ * Summary files are generated according to the default maven-surefire-plugin for integration with
+ * tools that already work with maven-surefire-plugin (e.g. CI servers).
  */
 @Mojo(name = "plugin-test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class TychoIntegrationTestMojo extends AbstractTestMojo {
-
     /**
      * The directory containing generated test classes of the project being tested.
      */
@@ -115,7 +110,7 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
     }
 
     @Override
-    protected boolean isCompatiblePackagingType(String packaging) {
+    protected boolean isCompatiblePackagingType(final String packaging) {
         return PackagingType.TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging());
     }
 
@@ -135,156 +130,180 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
     }
 
     @Override
-    protected PropertiesWrapper createSurefireProperties(TestFrameworkProvider provider, ScanResult scanResult)
-            throws MojoExecutionException {
-        PropertiesWrapper properties = super.createSurefireProperties(provider, scanResult);
+    protected PropertiesWrapper createSurefireProperties(final TestFrameworkProvider provider,
+            final ScanResult scanResult) throws MojoExecutionException {
+        final var properties = super.createSurefireProperties(provider, scanResult);
         properties.setProperty("failifnotests", String.valueOf(false));
         properties.setProperty("failsafe", summaryFile.getAbsolutePath());
         return properties;
     }
 
     @Override
-    protected void handleNoTestsFound() throws MojoFailureException {
+    protected void handleNoTestsFound() {
         getLog().info("No tests found");
     }
 
     @Override
     protected void handleSuccess() {
-        //nothing to do will be handled in verify phase
+        // Nothing to do. Will be handled in the verify phase
     }
 
     @Override
-    protected void handleTestFailures() throws MojoFailureException {
-        //nothing to do will be handled in verify phase
+    protected void handleTestFailures() {
+        // Nothing to do. Will be handled in the verify phase
     }
 
     @Override
-    protected void setupTestBundles(TestFrameworkProvider provider, EquinoxInstallationDescription testRuntime)
-            throws MojoExecutionException {
-        List<Dependency> dependencies = pluginDescriptor.getPlugin().getDependencies();
+    protected void setupTestBundles(final TestFrameworkProvider provider,
+            final EquinoxInstallationDescription testRuntime) throws MojoExecutionException {
+        final var dependencies = pluginDescriptor.getPlugin().getDependencies();
+
         if (dependencies.isEmpty()) {
             super.setupTestBundles(provider, testRuntime);
         } else {
             super.setupTestBundles(new NoopTestFrameworkProvider(), testRuntime);
-            for (Dependency dependency : dependencies) {
-                ArtifactResolutionResult resolveArtifact = resolveDependency(dependency);
-                for (Artifact artifact : resolveArtifact.getArtifacts()) {
-                    File file = artifact.getFile();
+
+            for (final var dependency : dependencies) {
+                final var resolveArtifact = resolveDependency(dependency);
+
+                for (final var artifact : resolveArtifact.getArtifacts()) {
+                    final var file = artifact.getFile();
+
                     if (file != null) {
                         testRuntime.addDevEntries("org.eclipse.tycho.surefire.osgibooter", file.getAbsolutePath());
                     }
                 }
             }
         }
-        ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-        File testPluginJar = createTestPluginJar(reactorProject);
-        ArtifactKey bundleArtifactKey = getBundleArtifactKey(testPluginJar);
+
+        final var reactorProject = DefaultReactorProject.adapt(project);
+        final File testPluginJar;
+
+        try {
+            testPluginJar = createTestPluginJar(reactorProject);
+        } catch (final Exception e) {
+            throw new MojoExecutionException("Error assembling test fragment JAR", e);
+        }
+
+        final var bundleArtifactKey = getBundleArtifactKey(testPluginJar);
         testRuntime.addBundle(bundleArtifactKey.getId(), bundleArtifactKey.getVersion(), testPluginJar);
-        String bsn = bundleArtifactKey.getId();
-        List<ClasspathEntry> testClasspath = osgiBundle.getTestClasspath(reactorProject, false);
-        //here we add the whole (test) classpath as a dev-entry to the runtime fragment, this is required to optionally load any test-scoped class that is not imported and not available as an OSGi bundle
-        String testDevEntries = testClasspath.stream().map(ClasspathEntry::getLocations).flatMap(Collection::stream)
+
+        final var bsn = bundleArtifactKey.getId();
+        final var testClasspath = osgiBundle.getTestClasspath(reactorProject, false);
+
+        // Here we add the whole (test) classpath as a dev-entry to the runtime fragment.
+        // This is required to optionally load any test-scoped class that is not imported
+        // and not available as an OSGi bundle
+        final var testDevEntries = testClasspath.stream().map(ClasspathEntry::getLocations).flatMap(Collection::stream)
                 .map(File::getAbsolutePath).collect(Collectors.joining(","));
         testRuntime.addDevEntries(bsn, testDevEntries);
     }
 
     /**
-     * This generates a bundle that is a fragment to the host that enhances the original bundle by
-     * the following items:
+     * This generates a bundle that is a fragment to the host that enhances the original bundle by the
+     * following items:
      * <ol>
-     * <li>any 'additional bundle', even though this is not really meant to be used that way, is
-     * added as an optional dependency</li>
+     * <li>any 'additional bundle', even though this is not really meant to be used that way, is added
+     * as an optional dependency</li>
      * <li>a <code>DynamicImport-Package: *</code> is added to allow dynamic classloading from the
      * bundle classpath</li>
      * <li>computes package imports based on the generated test classes and add them as optional
      * imports, so that any class is consumed from the OSGi runtime before the inner classes are
-     * searched.</li>
+     * searched</li>
      * </ol>
-     * 
-     * @param reactorProject
-     * @return
-     * @throws MojoExecutionException
      */
-    private File createTestPluginJar(ReactorProject reactorProject) throws MojoExecutionException {
-        try {
-            UUID uuid = UUID.randomUUID();
-            File fragmentFile = new File(project.getBuild().getDirectory(),
-                    FilenameUtils.getBaseName(reactorProject.getArtifact().getName()) + "_test_fragment_" + uuid
-                            + ".jar");
-            if (fragmentFile.exists()) {
-                fragmentFile.delete();
+    private File createTestPluginJar(final ReactorProject reactorProject) throws Exception {
+        final var uuid = UUID.randomUUID();
+        final var artifactBaseName = FilenameUtils.getBaseName(reactorProject.getArtifact().getName());
+        final var testJarName = artifactBaseName + "_test_fragment_" + uuid + ".jar";
+        final var fragmentFile = new File(project.getBuild().getDirectory(), testJarName);
+
+        if (fragmentFile.exists()) {
+            if (!fragmentFile.delete()) {
+                throw new IllegalStateException("Could not delete the existing fragment file " + fragmentFile);
             }
-            try (Jar mainArtifact = new Jar(reactorProject.getArtifact());
-                    Jar jar = new Jar(reactorProject.getName() + " test classes",
-                            new File(project.getBuild().getTestOutputDirectory()), null);
-                    Analyzer analyzer = new Analyzer(jar)) {
-                Manifest bundleManifest = mainArtifact.getManifest();
-                String hostVersion = bundleManifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-                String hostSymbolicName = getHostSymbolicName(bundleManifest);
-                analyzer.setProperty(Constants.BUNDLE_VERSION, hostVersion);
-                analyzer.setProperty(Constants.BUNDLE_SYMBOLICNAME, hostSymbolicName + "." + uuid);
-                analyzer.setProperty(Constants.FRAGMENT_HOST,
-                        hostSymbolicName + ";" + Constants.BUNDLE_VERSION_ATTRIBUTE + "=\"" + hostVersion + "\"");
-                analyzer.setProperty(Constants.BUNDLE_NAME, "Test Fragment for " + project.getGroupId() + ":"
-                        + project.getArtifactId() + ":" + project.getVersion());
-                analyzer.setProperty(Constants.IMPORT_PACKAGE, "*;resolution:=optional");
-                Collection<String> additionalBundles = reactorProject.getBuildProperties().getAdditionalBundles();
-                if (!additionalBundles.isEmpty()) {
-                    analyzer.setProperty(Constants.REQUIRE_BUNDLE, additionalBundles.stream()
-                            .map(b -> b + ";resolution:=optional").collect(Collectors.joining(",")));
-                }
-                analyzer.setProperty(Constants.DYNAMICIMPORT_PACKAGE, "*");
-                List<ClasspathEntry> testClasspath = osgiBundle.getTestClasspath(reactorProject);
-                for (ClasspathEntry classpathEntry : testClasspath) {
-                    for (File loc : classpathEntry.getLocations()) {
-                        analyzer.addClasspath(loc);
-                    }
-                }
-                analyzer.addClasspath(mainArtifact);
-                jar.setManifest(analyzer.calcManifest());
-                jar.write(fragmentFile);
-            }
-            return fragmentFile;
-        } catch (Exception e) {
-            throw new MojoExecutionException("Error assembling test fragment jar", e);
         }
 
+        final var outDir = new File(project.getBuild().getTestOutputDirectory());
+
+        try (final var mainArtifact = new Jar(reactorProject.getArtifact());
+                final var jar = new Jar(reactorProject.getName() + " test classes", outDir, null);
+                final var analyzer = new Analyzer(jar)) {
+            final var bundleManifest = mainArtifact.getManifest();
+            final var hostVersion = bundleManifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
+            final var hostSymbolicName = getHostSymbolicName(bundleManifest);
+            final var fragmentHost = "%s;%s=\"%s\"".formatted(hostSymbolicName, Constants.BUNDLE_VERSION_ATTRIBUTE,
+                    hostVersion);
+            final var bundleName = "Test fragment for %s:%s:%s".formatted(project.getGroupId(), project.getArtifactId(),
+                    project.getVersion());
+
+            analyzer.setProperty(Constants.BUNDLE_VERSION, hostVersion);
+            analyzer.setProperty(Constants.BUNDLE_SYMBOLICNAME, hostSymbolicName + "." + uuid);
+            analyzer.setProperty(Constants.FRAGMENT_HOST, fragmentHost);
+            analyzer.setProperty(Constants.BUNDLE_NAME, bundleName);
+            analyzer.setProperty(Constants.IMPORT_PACKAGE, "*;resolution:=optional");
+
+            final var additionalBundles = reactorProject.getBuildProperties().getAdditionalBundles();
+
+            if (!additionalBundles.isEmpty()) {
+                final var stringValue = additionalBundles.stream().map(b -> b + ";resolution:=optional")
+                        .collect(Collectors.joining(","));
+                analyzer.setProperty(Constants.REQUIRE_BUNDLE, stringValue);
+            }
+
+            analyzer.setProperty(Constants.DYNAMICIMPORT_PACKAGE, "*");
+
+            final var testClasspath = osgiBundle.getTestClasspath(reactorProject);
+
+            for (final var classpathEntry : testClasspath) {
+                for (final var location : classpathEntry.getLocations()) {
+                    analyzer.addClasspath(location);
+                }
+            }
+
+            analyzer.addClasspath(mainArtifact);
+            jar.setManifest(analyzer.calcManifest());
+            jar.write(fragmentFile);
+        }
+
+        return fragmentFile;
     }
 
-    private ArtifactResolutionResult resolveDependency(Dependency dependency) {
-        Artifact artifact = repositorySystem.createDependencyArtifact(dependency);
-        ArtifactResolutionRequest request = new ArtifactResolutionRequest()//
+    private ArtifactResolutionResult resolveDependency(final Dependency dependency) {
+        final var artifact = repositorySystem.createDependencyArtifact(dependency);
+        final var remoteRepositories = new ArrayList<ArtifactRepository>(32);
+        remoteRepositories.addAll(pluginRemoteRepositories);
+        remoteRepositories.addAll(projectRemoteRepositories);
+
+        final var request = new ArtifactResolutionRequest()//
                 .setOffline(session.isOffline())//
                 .setArtifact(artifact)//
                 .setLocalRepository(localRepository)//
                 .setResolveTransitively(true)//
                 .setCollectionFilter(new ProviderDependencyArtifactFilter())//
-                .setRemoteRepositories(
-                        Stream.concat(pluginRemoteRepositories.stream(), projectRemoteRepositories.stream()).toList());
+                .setRemoteRepositories(remoteRepositories);
         return repositorySystem.resolve(request);
     }
 
     /**
      * Returns a normalized host bundle Bundle-SymbolicName.
+     * <p>
      * This means any metadata apart from the name itself is removed.
      */
     private String getHostSymbolicName(final Manifest manifest) {
         final var value = manifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME);
         final var separatorIndex = value.indexOf(';');
-        return separatorIndex > -1
-                ? value.substring(0, separatorIndex)
-                : value;
+        return separatorIndex > -1 ? value.substring(0, separatorIndex) : value;
     }
 
     private static final class ProviderDependencyArtifactFilter implements ArtifactFilter {
-        private static final Collection<String> SCOPES = List.of(Artifact.SCOPE_COMPILE,
-                Artifact.SCOPE_COMPILE_PLUS_RUNTIME, Artifact.SCOPE_RUNTIME);
+        static final Collection<String> SCOPES = List.of(Artifact.SCOPE_COMPILE, Artifact.SCOPE_COMPILE_PLUS_RUNTIME,
+                Artifact.SCOPE_RUNTIME);
 
         @Override
-        public boolean include(Artifact artifact) {
-            String scope = artifact.getScope();
+        public boolean include(final Artifact artifact) {
+            final var scope = artifact.getScope();
             return !artifact.isOptional() && (scope == null || SCOPES.contains(scope));
         }
     }
-
 }


### PR DESCRIPTION
Fix #1769.

The first commit does the real thing.  
The second commit reformats the entire source file.

Kept them separate to ease reviewing.