### PR TITLE
Use the BuildPropertiesParser as plexus component only

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/publisher/AbstractMetadataGenerator.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/publisher/AbstractMetadataGenerator.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.publisher;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -39,7 +38,6 @@ import org.eclipse.tycho.BuildProperties;
 import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.IDependencyMetadata.DependencyMetadataType;
-import org.eclipse.tycho.Interpolator;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TychoConstants;
@@ -65,9 +63,8 @@ public abstract class AbstractMetadataGenerator {
 
     protected abstract List<IPublisherAdvice> getPublisherAdvice(IArtifactFacade artifact, PublisherOptions options);
 
-    protected ICapabilityAdvice getExtraEntriesAdvice(IArtifactFacade artifact, Interpolator interpolator) {
-        final IRequirement[] extraRequirements = extractExtraEntriesAsIURequirement(artifact.getLocation(),
-                interpolator);
+    protected ICapabilityAdvice getExtraEntriesAdvice(IArtifactFacade artifact, BuildProperties buildProps) {
+        final IRequirement[] extraRequirements = extractExtraEntriesAsIURequirement(buildProps);
         return new ICapabilityAdvice() {
             @Override
             public boolean isApplicable(String configSpec, boolean includeDefault, String id, Version version) {
@@ -91,8 +88,8 @@ public abstract class AbstractMetadataGenerator {
         };
     }
 
-    private IRequirement[] extractExtraEntriesAsIURequirement(File location, Interpolator interpolator) {
-        BuildProperties buildProps = getBuildPropertiesParser().parse(location, interpolator);
+    private IRequirement[] extractExtraEntriesAsIURequirement(BuildProperties buildProps) {
+
         ArrayList<IRequirement> result = new ArrayList<>();
         for (Entry<String, List<String>> entry : buildProps.getJarToExtraClasspathMap().entrySet()) {
             createRequirementFromExtraClasspathProperty(result, entry.getValue());

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/publisher/rootfiles/FeatureRootAdvice.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/publisher/rootfiles/FeatureRootAdvice.java
@@ -27,7 +27,6 @@ import org.eclipse.equinox.p2.publisher.actions.IFeatureRootAdvice;
 import org.eclipse.tycho.BuildProperties;
 import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.IArtifactFacade;
-import org.eclipse.tycho.Interpolator;
 import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.p2.metadata.ReactorProjectFacade;
 
@@ -56,14 +55,17 @@ public class FeatureRootAdvice implements IFeatureRootAdvice {
      */
     public static IFeatureRootAdvice createRootFileAdvice(IArtifactFacade featureArtifact,
             BuildPropertiesParser buildPropertiesParser) {
-        Interpolator interpolator = featureArtifact instanceof ReactorProjectFacade reactorFacade
-                ? reactorFacade.getReactorProject().getInterpolator()
-                : null;
         File projectDir = getProjectBaseDir(featureArtifact);
-
         if (projectDir != null) {
-            FeatureRootAdvice result = new FeatureRootAdvice(buildPropertiesParser.parse(projectDir, interpolator),
-                    projectDir, featureArtifact.getArtifactId());
+
+            BuildProperties buildProperties;
+            if (featureArtifact instanceof ReactorProjectFacade reactorFacade) {
+                buildProperties = buildPropertiesParser.parse(reactorFacade.getReactorProject());
+            } else {
+                buildProperties = buildPropertiesParser.parse(projectDir, null);
+            }
+            FeatureRootAdvice result = new FeatureRootAdvice(buildProperties, projectDir,
+                    featureArtifact.getArtifactId());
             if (result.hasRootFiles()) {
                 return result;
             }

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/BuildPropertiesParser.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/BuildPropertiesParser.java
@@ -19,9 +19,7 @@ public interface BuildPropertiesParser {
 
     public static final String BUILD_PROPERTIES = "build.properties";
 
-    default BuildProperties parse(ReactorProject project) {
-        return parse(project.getBasedir(), project.getInterpolator());
-    }
+    BuildProperties parse(ReactorProject project);
 
     /**
      * Parse the file "build.properties" in baseDir. If the file does not exist or cannot be read,

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ReactorProject.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ReactorProject.java
@@ -14,7 +14,6 @@
 package org.eclipse.tycho;
 
 import java.io.File;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Supplier;
 
@@ -23,8 +22,6 @@ import java.util.function.Supplier;
  */
 public interface ReactorProject extends IDependencyMetadata {
 
-    static final String CTX_INTERPOLATOR = "tycho.project.interpolator";
-    static final String CTX_BUILDPROPERTIESPARSER = "tycho.project.buildpropertiesparser";
     static final String CTX_MERGED_PROPERTIES = "tycho.project.mergedProperties";
 
     /**
@@ -76,25 +73,6 @@ public interface ReactorProject extends IDependencyMetadata {
 
     default Properties getProperties() {
         return (Properties) getContextValue(CTX_MERGED_PROPERTIES);
-    }
-
-    // misc
-    /**
-     * 
-     * @return the Interpolator for this project that could be used to resolve maven variable
-     *         references
-     */
-    default Interpolator getInterpolator() {
-        return Objects.requireNonNull((Interpolator) getContextValue(CTX_INTERPOLATOR),
-                "No Interpolator found, has the TychoMavenLifecycleParticipant not run?");
-    }
-
-    default BuildProperties getBuildProperties() {
-        BuildPropertiesParser parser = Objects.requireNonNull(
-                (BuildPropertiesParser) getContextValue(CTX_BUILDPROPERTIESPARSER),
-                "No BuildPropertiesParser found, has the TychoMavenLifecycleParticipant not run?");
-        //we must always ask the parser here, it is expected that the parser caches the properties if the have not changed in the meanwhile
-        return parser.parse(this);
     }
 
     /**

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
@@ -49,6 +49,7 @@ import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.BuildProperties;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.DependencyArtifacts;
 import org.eclipse.tycho.MavenArtifactRepositoryReference;
 import org.eclipse.tycho.MavenDependencyDescriptor;
@@ -69,11 +70,12 @@ public final class MavenDependencyInjector {
      *            A project
      * @param dependencies
      *            The p2-resolved dependencies of the project.
+     * @param buildPropertiesParser
      */
     public static void injectMavenDependencies(MavenProject project, DependencyArtifacts dependencies,
             DependencyArtifacts testDependencies, BundleReader bundleReader,
             Function<ArtifactDescriptor, MavenDependencyDescriptor> descriptorMapping, Logger logger,
-            RepositorySystem repositorySystem, Settings settings) {
+            RepositorySystem repositorySystem, Settings settings, BuildPropertiesParser buildPropertiesParser) {
         MavenDependencyInjector generator = new MavenDependencyInjector(project, bundleReader, descriptorMapping,
                 logger);
         for (ArtifactDescriptor artifact : dependencies.getArtifacts()) {
@@ -85,7 +87,7 @@ public final class MavenDependencyInjector {
                     .forEach(descriptor -> generator.addDependency(descriptor, Artifact.SCOPE_TEST));
         }
         ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-        BuildProperties buildProperties = reactorProject.getBuildProperties();
+        BuildProperties buildProperties = buildPropertiesParser.parse(reactorProject);
         List<Dependency> extraJars = buildProperties.getJarsExtraClasspath().stream().map(extra -> {
             if (TychoConstants.PLATFORM_URL_PATTERN.matcher(extra).matches()) {
                 //this should already be handled as an extra requirement!

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -60,7 +60,6 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.sisu.equinox.EquinoxServiceFactory;
 import org.eclipse.tycho.BuildFailureException;
-import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.DependencyResolutionException;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TychoConstants;
@@ -98,9 +97,6 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
     private Logger log;
 
     @Requirement
-    private BuildPropertiesParser buildPropertiesParser;
-
-    @Requirement
     MavenProjectDependencyProcessor dependencyProcessor;
 
     @Requirement
@@ -135,9 +131,6 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
             for (MavenProject project : projects) {
                 ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-                reactorProject.setContextValue(ReactorProject.CTX_INTERPOLATOR,
-                        new TychoInterpolator(session, project));
-                reactorProject.setContextValue(ReactorProject.CTX_BUILDPROPERTIESPARSER, buildPropertiesParser);
                 resolver.setupProject(session, project, reactorProject);
             }
             if (TychoConstants.USE_OLD_RESOLVER) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -57,6 +57,7 @@ import org.eclipse.osgi.report.resolution.ResolutionReport.Entry;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.DependencyArtifacts;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetEnvironment;
@@ -91,6 +92,9 @@ public class EquinoxResolver {
 
     @Requirement
     private ToolchainManager toolchainManager;
+
+    @Requirement
+    private BuildPropertiesParser buildPropertiesParser;
 
     public ModuleContainer newResolvedState(ReactorProject project, MavenSession mavenSession, ExecutionEnvironment ee,
             DependencyArtifacts artifacts) throws BundleException {
@@ -352,7 +356,8 @@ public class EquinoxResolver {
             } else {
                 ReactorProject mavenProject = artifact.getMavenProject();
                 if (mavenProject != null) {
-                    Collection<String> additionalBundles = mavenProject.getBuildProperties().getAdditionalBundles();
+                    Collection<String> additionalBundles = buildPropertiesParser.parse(mavenProject)
+                            .getAdditionalBundles();
                     if (!additionalBundles.isEmpty()) {
                         List<String> reqb = new ArrayList<>();
                         String value = mf.getValue(Constants.REQUIRE_BUNDLE);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -52,6 +52,7 @@ import org.eclipse.osgi.internal.framework.FilterImpl;
 import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.DependencyArtifacts;
 import org.eclipse.tycho.DependencyResolutionException;
@@ -131,6 +132,9 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
 
     @Requirement
     private DeclarativeServiceConfigurationReader dsConfigReader;
+
+    @Requirement
+    private BuildPropertiesParser buildPropertiesParser;
 
     @Override
     public ArtifactDependencyWalker getDependencyWalker(ReactorProject project) {
@@ -431,7 +435,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
                 .getContextValue(TychoConstants.CTX_ECLIPSE_PLUGIN_PROJECT);
         if (pdeProject == null) {
             try {
-                pdeProject = new EclipsePluginProjectImpl(otherProject, otherProject.getBuildProperties(),
+                pdeProject = new EclipsePluginProjectImpl(otherProject, buildPropertiesParser.parse(otherProject),
                         classpathParser.parse(otherProject.getBasedir()));
                 if (otherProject instanceof DefaultReactorProject defaultReactorProject) {
                     populateProperties(defaultReactorProject.project.getProperties(), pdeProject);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/AdditionalBundleRequirementsInstallableUnitProvider.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/AdditionalBundleRequirementsInstallableUnitProvider.java
@@ -32,6 +32,7 @@ import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
 import org.eclipse.tycho.BuildProperties;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.core.BundleProject;
 import org.eclipse.tycho.core.TychoProject;
@@ -51,12 +52,15 @@ public class AdditionalBundleRequirementsInstallableUnitProvider implements Inst
     @Requirement(role = TychoProject.class)
     private Map<String, TychoProject> projectTypes;
 
+    @Requirement
+    private BuildPropertiesParser buildPropertiesParser;
+
     @Override
     public Collection<IInstallableUnit> getInstallableUnits(MavenProject project, MavenSession session)
             throws CoreException {
         if (projectTypes.get(project.getPackaging()) instanceof BundleProject) {
             ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-            BuildProperties buildProperties = reactorProject.getBuildProperties();
+            BuildProperties buildProperties = buildPropertiesParser.parse(reactorProject);
             List<IRequirement> additionalBundleRequirements = buildProperties.getAdditionalBundles().stream()
                     .map(bundleName -> MetadataFactory.createRequirement(BundlesAction.CAPABILITY_NS_OSGI_BUNDLE,
                             bundleName, VersionRange.emptyRange, null, true, true))

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -51,6 +51,7 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.BuildFailureException;
 import org.eclipse.tycho.BuildProperties;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.DependencyArtifacts;
 import org.eclipse.tycho.IDependencyMetadata;
@@ -125,6 +126,9 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
 
     @Requirement
     private LocalRepositoryP2Indices p2index;
+
+    @Requirement
+    private BuildPropertiesParser buildPropertiesParser;
 
     @Requirement
     private PomUnits pomUnits;
@@ -338,7 +342,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
             }
         }
 
-        BuildProperties buildProperties = DefaultReactorProject.adapt(project).getBuildProperties();
+        BuildProperties buildProperties = buildPropertiesParser.parse(DefaultReactorProject.adapt(project));
         Collection<String> additionalBundles = buildProperties.getAdditionalBundles();
         for (String additionalBundle : additionalBundles) {
             resolver.addAdditionalBundleDependency(additionalBundle);
@@ -422,6 +426,6 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
             DependencyArtifacts dependencyArtifacts, DependencyArtifacts testDependencyArtifacts, Logger logger) {
         MavenDependencyInjector.injectMavenDependencies(project, dependencyArtifacts, testDependencyArtifacts,
                 bundleReader, resolverFactory::resolveDependencyDescriptor, logger, repositorySystem,
-                context.getSession().getSettings());
+                context.getSession().getSettings(), buildPropertiesParser);
     }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
@@ -42,9 +42,9 @@ import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
 import org.eclipse.equinox.p2.publisher.eclipse.Feature;
 import org.eclipse.equinox.p2.publisher.eclipse.FeaturesAction;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.tycho.BuildProperties;
 import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.IArtifactFacade;
-import org.eclipse.tycho.Interpolator;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.TargetEnvironment;
@@ -312,12 +312,15 @@ public class P2GeneratorImpl extends AbstractMetadataGenerator implements P2Gene
 
     @Override
     protected List<IPublisherAdvice> getPublisherAdvice(IArtifactFacade artifact, PublisherOptions options) {
-        Interpolator interpolator = artifact instanceof ReactorProjectFacade reactorFacade
-                ? reactorFacade.getReactorProject().getInterpolator()
-                : null;
+        BuildProperties buildProperties;
+        if (artifact instanceof ReactorProjectFacade reactorFacade) {
+            buildProperties = buildPropertiesParser.parse(reactorFacade.getReactorProject());
+        } else {
+            buildProperties = buildPropertiesParser.parse(artifact.getLocation(), null);
+        }
         ArrayList<IPublisherAdvice> advice = new ArrayList<>();
         advice.add(new TychoMavenPropertiesAdvice(artifact, mavenContext));
-        advice.add(getExtraEntriesAdvice(artifact, interpolator));
+        advice.add(getExtraEntriesAdvice(artifact, buildProperties));
 
         if (options.generateDownloadStatsProperty) {
             advice.add(new DownloadStatsAdvice());

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/BuildPropertiesParserImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/BuildPropertiesParserImplTest.java
@@ -52,7 +52,7 @@ public class BuildPropertiesParserImplTest {
         when(project1.getBasedir()).thenReturn(new File("/bathToProject1"));
         when(project2.getBasedir()).thenReturn(new File("/bathToProject2"));
 
-        parser = new BuildPropertiesParserImpl(legacySupport, logger);
+        parser = new BuildPropertiesParserImpl();
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/BuildPropertiesParserForTesting.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/BuildPropertiesParserForTesting.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import org.eclipse.tycho.BuildProperties;
 import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.Interpolator;
+import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.core.shared.BuildPropertiesImpl;
 
 public class BuildPropertiesParserForTesting implements BuildPropertiesParser {
@@ -40,6 +41,11 @@ public class BuildPropertiesParserForTesting implements BuildPropertiesParser {
         } catch (IOException e) {
             // ignore
         }
+    }
+
+    @Override
+    public BuildProperties parse(ReactorProject project) {
+        return parse(project.getBasedir(), null);
     }
 
 }

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
@@ -31,6 +31,7 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.build.BuildTimestampProvider;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.shared.VersioningHelper;
@@ -117,6 +118,9 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
     @Component(role = BuildTimestampProvider.class)
     protected Map<String, BuildTimestampProvider> timestampProviders;
 
+	@Component
+	private BuildPropertiesParser buildPropertiesParser;
+
     // setter is needed to make sure we always use UTC
     public void setFormat(String formatString) {
         format = new SimpleDateFormat(formatString);
@@ -163,7 +167,7 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
 		String qualifier = forceContextQualifier;
 
         if (qualifier == null) {
-			qualifier = DefaultReactorProject.adapt(project).getBuildProperties().getForceContextQualifier();
+			qualifier = buildPropertiesParser.parse(DefaultReactorProject.adapt(project)).getForceContextQualifier();
         }
 
         if (qualifier == null) {

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.packaging;
 
+import static org.eclipse.tycho.model.Feature.FEATURE_XML;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -39,13 +41,12 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.util.IOUtil;
 import org.eclipse.tycho.BuildProperties;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.TargetPlatformService;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.model.Feature;
-
-import static org.eclipse.tycho.model.Feature.FEATURE_XML;
 
 @Mojo(name = "package-feature", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
@@ -120,6 +121,9 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
 	@Component
 	private TargetPlatformService platformService;
 
+	@Component
+	private BuildPropertiesParser buildPropertiesParser;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         synchronized (LOCK) {
@@ -149,7 +153,7 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
                 throw new MojoExecutionException("Error updating feature.xml", e);
             }
 
-			BuildProperties buildProperties = DefaultReactorProject.adapt(project).getBuildProperties();
+			BuildProperties buildProperties = buildPropertiesParser.parse(DefaultReactorProject.adapt(project));
             checkBinIncludesExist(buildProperties);
 
             File featureProperties = getFeatureProperties(licenseFeature, buildProperties);

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
@@ -49,6 +49,7 @@ import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.AbstractScanner;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.tycho.BuildProperties;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.core.osgitools.DebugUtils;
@@ -198,6 +199,9 @@ public class SourceFeatureMojo extends AbstractMojo {
     @Parameter
     private MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
 
+    @Component
+    private BuildPropertiesParser buildPropertiesParser;
+
     /**
      * The filename to be used for the generated archive file. For the source-feature goal,
      * "-sources-feature" is appended to this filename.
@@ -244,7 +248,7 @@ public class SourceFeatureMojo extends AbstractMojo {
                     archiver.getArchiver().addFileSet(templateFileSet);
                 }
 
-                BuildProperties buildProperties = DefaultReactorProject.adapt(project).getBuildProperties();
+                BuildProperties buildProperties = buildPropertiesParser.parse(DefaultReactorProject.adapt(project));
                 archiver.getArchiver().addFileSet(getManuallyIncludedFiles(project.getBasedir(), buildProperties));
 
                 archiver.getArchiver().addFile(sourceFeatureXml, Feature.FEATURE_XML);

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceInstallableUnitProvider.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceInstallableUnitProvider.java
@@ -33,6 +33,7 @@ import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
 import org.eclipse.equinox.p2.publisher.eclipse.FeaturesAction;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.tycho.ArtifactKey;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
@@ -56,6 +57,9 @@ public class SourceInstallableUnitProvider implements InstallableUnitProvider {
     @Requirement(role = TychoProject.class)
     private Map<String, TychoProject> projectTypes;
 
+    @Requirement
+    private BuildPropertiesParser buildPropertiesParser;
+
     @Override
     public Collection<IInstallableUnit> getInstallableUnits(MavenProject project, MavenSession session)
             throws CoreException {
@@ -73,7 +77,7 @@ public class SourceInstallableUnitProvider implements InstallableUnitProvider {
                 throw new CoreException(Status.error("Creating preliminary source feature failed", e));
             }
         }
-        if (OsgiSourceMojo.isRelevant(project)) {
+        if (OsgiSourceMojo.isRelevant(project, buildPropertiesParser)) {
             TychoProject projectType = projectTypes.get(project.getPackaging());
             ArtifactKey artifactKey = projectType.getArtifactKey(DefaultReactorProject.adapt(project));
             String symbolicName = artifactKey.getId();

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourcesP2MetadataProvider.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourcesP2MetadataProvider.java
@@ -22,6 +22,7 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.IDependencyMetadata;
 import org.eclipse.tycho.OptionalResolutionAction;
@@ -37,10 +38,13 @@ public class SourcesP2MetadataProvider implements P2MetadataProvider, Initializa
     @Requirement(hint = DependencyMetadataGenerator.SOURCE_BUNDLE)
     private DependencyMetadataGenerator sourcesGenerator;
 
+    @Requirement
+    private BuildPropertiesParser buildPropertiesParser;
+
     @Override
     public Map<String, IDependencyMetadata> getDependencyMetadata(MavenSession session, MavenProject project,
             List<TargetEnvironment> environments, OptionalResolutionAction optionalAction) {
-        if (OsgiSourceMojo.isRelevant(project)) {
+        if (OsgiSourceMojo.isRelevant(project, buildPropertiesParser)) {
             IArtifactFacade sourcesArtifact = new AttachedArtifact(project, project.getBasedir(), "sources");
             return Collections.singletonMap(sourcesArtifact.getClassifier(), sourcesGenerator
                     .generateMetadata(sourcesArtifact, null, OptionalResolutionAction.REQUIRE, new PublisherOptions()));

--- a/tycho-source-plugin/src/test/java/org/eclipse/tycho/source/OsgiSourceMojoTest.java
+++ b/tycho-source-plugin/src/test/java/org/eclipse/tycho/source/OsgiSourceMojoTest.java
@@ -36,9 +36,7 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.tycho.BuildPropertiesParser;
-import org.eclipse.tycho.Interpolator;
 import org.eclipse.tycho.ReactorProject;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.core.utils.TychoVersion;
 import org.eclipse.tycho.testing.AbstractTychoMojoTestCase;
@@ -52,6 +50,7 @@ public class OsgiSourceMojoTest extends AbstractTychoMojoTestCase {
     protected void setUp() throws Exception {
         super.setUp();
         mojo = new OsgiSourceMojo();
+        mojo.setBuildPropertiesParser(lookup(BuildPropertiesParser.class));
     }
 
     public void testIsRelevantProjectPackagingType() throws Exception {
@@ -172,15 +171,6 @@ public class OsgiSourceMojoTest extends AbstractTychoMojoTestCase {
             tychoSourcePlugin.setExecutions(asList(execution));
             build.setPlugins(asList(tychoSourcePlugin));
         }
-        ReactorProject project = DefaultReactorProject.adapt(stubProject);
-        project.setContextValue(ReactorProject.CTX_BUILDPROPERTIESPARSER, lookup(BuildPropertiesParser.class));
-        project.setContextValue(ReactorProject.CTX_INTERPOLATOR, new Interpolator() {
-
-            @Override
-            public String interpolate(String input) {
-                return input;
-            }
-        });
         stubProject.setFile(new File("src/test/resources/sourceMojo/" + testResourceFolder + "/pom.xml"));
         return stubProject;
     }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -36,6 +37,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.surefire.api.util.ScanResult;
 import org.apache.maven.surefire.booter.PropertiesWrapper;
 import org.eclipse.sisu.equinox.launching.EquinoxInstallationDescription;
+import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.classpath.ClasspathEntry;
@@ -103,6 +105,9 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
 
     @Parameter(defaultValue = "${localRepository}", required = true, readonly = true)
     private ArtifactRepository localRepository;
+
+    @Component
+    private BuildPropertiesParser buildPropertiesParser;
 
     @Override
     protected boolean shouldRun() {
@@ -200,11 +205,11 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
     }
 
     /**
-     * This generates a bundle that is a fragment to the host that enhances the original bundle by the
-     * following items:
+     * This generates a bundle that is a fragment to the host that enhances the original bundle by
+     * the following items:
      * <ol>
-     * <li>any 'additional bundle', even though this is not really meant to be used that way, is added
-     * as an optional dependency</li>
+     * <li>any 'additional bundle', even though this is not really meant to be used that way, is
+     * added as an optional dependency</li>
      * <li>a <code>DynamicImport-Package: *</code> is added to allow dynamic classloading from the
      * bundle classpath</li>
      * <li>computes package imports based on the generated test classes and add them as optional
@@ -243,7 +248,7 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
             analyzer.setProperty(Constants.BUNDLE_NAME, bundleName);
             analyzer.setProperty(Constants.IMPORT_PACKAGE, "*;resolution:=optional");
 
-            final var additionalBundles = reactorProject.getBuildProperties().getAdditionalBundles();
+            final var additionalBundles = buildPropertiesParser.parse(reactorProject).getAdditionalBundles();
 
             if (!additionalBundles.isEmpty()) {
                 final var stringValue = additionalBundles.stream().map(b -> b + ";resolution:=optional")


### PR DESCRIPTION
Currently we unnecessarily bind the build properties and interpolation to the init of the Tycho model, this simply limits it usage and enforce init of items that are probably never used.

This change the BuildProperties usage by a plexus component and remove the helper methods from the ReactorPorject