### PR TITLE
Execute the plugin-package mojo with m2e

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -37,7 +37,6 @@ public interface TychoConstants {
      * Stores test-specific dependencies (usually derived from .classpath)
      */
     static final String CTX_TEST_DEPENDENCY_ARTIFACTS = CTX_BASENAME + "/testDependencyArtifacts";
-    static final String CTX_ECLIPSE_PLUGIN_PROJECT = CTX_BASENAME + "/eclipsePluginProject";
     static final String CTX_ECLIPSE_PLUGIN_TEST_CLASSPATH = CTX_BASENAME + "/eclipsePluginTestClasspath";
     static final String CTX_ECLIPSE_PLUGIN_TEST_EXTRA_CLASSPATH = CTX_BASENAME + "/eclipsePluginTestClasspathExtra";
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/BundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/BundleProject.java
@@ -19,6 +19,7 @@ import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.classpath.ClasspathEntry;
 import org.eclipse.tycho.classpath.ClasspathEntry.AccessRule;
+import org.eclipse.tycho.core.osgitools.project.EclipsePluginProject;
 
 public interface BundleProject extends TychoProject {
     public List<ClasspathEntry> getClasspath(ReactorProject project);
@@ -42,5 +43,7 @@ public interface BundleProject extends TychoProject {
     public List<ClasspathEntry> getTestClasspath(ReactorProject project);
 
     public List<ClasspathEntry> getTestClasspath(ReactorProject project, boolean complete);
+
+    public EclipsePluginProject getEclipsePluginProject(ReactorProject otherProject);
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -108,6 +108,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
     private static final String CTX_OSGI_BUNDLE_BASENAME = TychoConstants.CTX_BASENAME + "/osgiBundle";
     private static final String CTX_ARTIFACT_KEY = CTX_OSGI_BUNDLE_BASENAME + "/artifactKey";
     private static final String CTX_CLASSPATH = CTX_OSGI_BUNDLE_BASENAME + "/classPath";
+    static final String CTX_ECLIPSE_PLUGIN_PROJECT = CTX_OSGI_BUNDLE_BASENAME + "/eclipsePluginProject";
 
     @Requirement
     private BundleReader bundleReader;
@@ -395,7 +396,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
     }
 
     private void addPDESourceRoots(MavenProject project) {
-        EclipsePluginProjectImpl eclipsePluginProject = getEclipsePluginProject(DefaultReactorProject.adapt(project));
+        EclipsePluginProject eclipsePluginProject = getEclipsePluginProject(DefaultReactorProject.adapt(project));
         for (BuildOutputJar outputJar : eclipsePluginProject.getOutputJars()) {
             for (File sourceFolder : outputJar.getSourceFolders()) {
                 removeDuplicateTestCompileRoot(sourceFolder, project.getTestCompileSourceRoots());
@@ -430,9 +431,9 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
         }
     }
 
-    public EclipsePluginProjectImpl getEclipsePluginProject(ReactorProject otherProject) {
+    public EclipsePluginProject getEclipsePluginProject(ReactorProject otherProject) {
         EclipsePluginProjectImpl pdeProject = (EclipsePluginProjectImpl) otherProject
-                .getContextValue(TychoConstants.CTX_ECLIPSE_PLUGIN_PROJECT);
+                .getContextValue(CTX_ECLIPSE_PLUGIN_PROJECT);
         if (pdeProject == null) {
             try {
                 pdeProject = new EclipsePluginProjectImpl(otherProject, buildPropertiesParser.parse(otherProject),
@@ -440,7 +441,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
                 if (otherProject instanceof DefaultReactorProject defaultReactorProject) {
                     populateProperties(defaultReactorProject.project.getProperties(), pdeProject);
                 }
-                otherProject.setContextValue(TychoConstants.CTX_ECLIPSE_PLUGIN_PROJECT, pdeProject);
+                otherProject.setContextValue(CTX_ECLIPSE_PLUGIN_PROJECT, pdeProject);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/tycho-packaging-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-packaging-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -5,7 +5,6 @@
 			<pluginExecutionFilter>
 				<goals>
 					<goal>build-qualifier-aggregator</goal>
-					<goal>package-plugin</goal>
 					<goal>package-feature</goal>
 					<goal>package-iu</goal>
 					<goal>update-consumer-pom</goal>
@@ -22,6 +21,7 @@
 					<goal>build-qualifier</goal>
 					<goal>validate-id</goal>
 					<goal>validate-version</goal>
+					<goal>package-plugin</goal>
 				</goals>
 			</pluginExecutionFilter>
 			<action>


### PR DESCRIPTION
Currently the plugin-package mojo is not executed what results in mojos
failing that want to work on the packaged version of the artifact, this
enables the packaging for m2e to produce the final jar.

This should also allow for platform to get rid of some ant-tasks that currently generate jar files as part of the platform build when running in an IDE, but this is just a guess and not tested or further investigated.

Currently this change will not completely work as expected due to
- https://github.com/eclipse-m2e/m2e-core/issues/1126

but I have tested it with a local m2e version where I disabled the offending mapping.