### PR TITLE
[API-Generation] Improve handling of extraManifests/extraSourceLocations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,11 @@ Any baseline problems will then be reported to the build:
 
 ![grafik](https://user-images.githubusercontent.com/1331477/205283998-484c6a13-0a66-4b34-9386-599a27bff53e.png)
 
+### Parameter enhancements for tycho-apitools-plugin:generate goal
+
+The parameters of the `tycho-apitools-plugin:generate` goal have been completed and improved.
+
+
 ### Migration guide 3.x > 4.x
 
 #### Choosable HTTP transports

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java
@@ -13,7 +13,9 @@
 package org.eclipse.tycho.apitools;
 
 import java.io.File;
+import java.util.List;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -67,20 +69,21 @@ public class ApiFileGenerationMojo extends AbstractMojo {
 	 * @Since 3.1.0
 	 */
 	@Parameter
-	protected String extraManifests;
+	protected List<File> extraManifests = List.of();
 
 	/**
 	 * @Since 3.1.0
 	 */
 	@Parameter
-	protected String extraSourceLocations;
+	protected List<File> extraSourceLocations = List.of();
 
 	@Parameter(defaultValue = "false", property = "tycho.apitools.generate.skip")
 	private boolean skip;
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		if (new File(project.getBasedir(), JarFile.MANIFEST_NAME).isFile()) {
+		if (new File(project.getBasedir(), JarFile.MANIFEST_NAME).isFile()
+				|| extraManifests.stream().anyMatch(File::isFile)) {
 			synchronized (ApiFileGenerationMojo.class) {
 				// TODO check if the generator is thread safe, then we can remove this!
 				if (!binaryLocations.exists()) {
@@ -94,11 +97,16 @@ public class ApiFileGenerationMojo extends AbstractMojo {
 				generator.allowNonApiProject = allowNonApiProject;
 				generator.encoding = encoding;
 				generator.debug = debug;
-				generator.manifests = extraManifests;
-				generator.sourceLocations = extraSourceLocations;
+				generator.manifests = join(extraManifests);
+				generator.sourceLocations = join(extraSourceLocations);
 				generator.generateAPIFile();
 			}
 		}
+	}
+
+	private String join(List<File> list) {
+		return list.isEmpty() ? null // join the elements so that the APIFileGenerator splits it correspondingly
+				: list.stream().map(File::toString).collect(Collectors.joining(File.pathSeparator));
 	}
 
 }


### PR DESCRIPTION
The META-INF/MANIFEST.MF file may not be rooted in the project's basedir but for example in target/classes if it is generated. The APIFileGenerator can be told to use that using the extraManifests property. Therefore those files have to be considered too, when deciding to execute the mojo.

Additionally convert the 'extraManifests' and 'extraSourceLocations' to fields of `List<File>`. This has the advantage that, if a specified element is relative, it is automatically resolved against the project's basedir by Maven when the mojo is configured. Furthermore it allows to abstract away the platform-specific path separation that is required to prepare the `APIFileGenerator` properly. Therefore without this change this Mojo is effectively platform-dependend.

The `APIFileGenerator` should be adjusted to accept List of files, but for now we have to do it this way.