### PR TITLE
Source header mojo enhancements

### DIFF
--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.source;
 
-import static java.util.Collections.singletonList;
 import static org.osgi.framework.Constants.BUNDLE_LOCALIZATION;
 import static org.osgi.framework.Constants.BUNDLE_LOCALIZATION_DEFAULT_BASENAME;
 import static org.osgi.framework.Constants.BUNDLE_MANIFESTVERSION;
@@ -22,10 +21,12 @@ import static org.osgi.framework.Constants.BUNDLE_VENDOR;
 import static org.osgi.framework.Constants.BUNDLE_VERSION;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.UnaryOperator;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
@@ -41,6 +44,7 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -70,8 +74,7 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
 
     static final String MANIFEST_HEADER_ECLIPSE_SOURCE_BUNDLE = "Eclipse-SourceBundle";
     private static final String MANIFEST_BUNDLE_LOCALIZATION_BASENAME = BUNDLE_LOCALIZATION_DEFAULT_BASENAME + "-src";
-    private static final String MANIFEST_BUNDLE_LOCALIZATION_FILENAME = MANIFEST_BUNDLE_LOCALIZATION_BASENAME
-            + ".properties";
+    static final String MANIFEST_BUNDLE_LOCALIZATION_FILENAME = MANIFEST_BUNDLE_LOCALIZATION_BASENAME + ".properties";
     private static final String I18N_KEY_PREFIX = "%";
     private static final String I18N_KEY_BUNDLE_VENDOR = "bundleVendor";
     private static final String I18N_KEY_BUNDLE_NAME = "bundleName";
@@ -227,7 +230,10 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
             }
         }
         if (!srcIncludesList.contains(MANIFEST_BUNDLE_LOCALIZATION_FILENAME)) {
-            resources.add(generateL10nFile());
+            OsgiManifest manifest = bundleReader.loadManifest(project.getBasedir());
+            Path basedir = project.getBasedir().toPath();
+            String bsn = manifest.getBundleSymbolicName();
+            resources.add(generateL10nFile(project, basedir, manifest::getValue, bsn, getLog()));
         }
         return resources;
     }
@@ -247,19 +253,19 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
         return resource;
     }
 
-    private Resource generateL10nFile() throws MojoExecutionException {
-        OsgiManifest origManifest = bundleReader.loadManifest(project.getBasedir());
-        Properties l10nProps = readL10nProps(origManifest);
-        String bundleName = getL10nResolvedValue(origManifest, BUNDLE_NAME, l10nProps);
+    static Resource generateL10nFile(MavenProject project, Path basedir, UnaryOperator<String> manifest, String bsn,
+            Log log) throws MojoExecutionException {
+        Properties l10nProps = readL10nProps(manifest, basedir, log);
+        String bundleName = getL10nResolvedValue(manifest, BUNDLE_NAME, l10nProps);
         if (bundleName == null) {
-            getLog().warn("Bundle-Name header not found in " + new File(project.getBasedir(), JarFile.MANIFEST_NAME)
+            log.warn("Bundle-Name header not found in " + basedir.resolve(JarFile.MANIFEST_NAME)
                     + ", fallback to Bundle-SymbolicName for source bundle");
-            bundleName = origManifest.getBundleSymbolicName();
+            bundleName = bsn;
         }
         String sourceBundleName = bundleName + " Source";
-        String bundleVendor = getL10nResolvedValue(origManifest, BUNDLE_VENDOR, l10nProps);
+        String bundleVendor = getL10nResolvedValue(manifest, BUNDLE_VENDOR, l10nProps);
         if (bundleVendor == null) {
-            getLog().warn("Bundle-Vendor header not found in " + new File(project.getBasedir(), JarFile.MANIFEST_NAME)
+            log.warn("Bundle-Vendor header not found in " + basedir.resolve(JarFile.MANIFEST_NAME)
                     + ", fallback to 'unknown' for source bundle");
             bundleVendor = "unknown";
         }
@@ -276,29 +282,34 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
         }
         Resource l10nResource = new Resource();
         l10nResource.setDirectory(l10nOutputDir.getAbsolutePath());
-        l10nResource.setIncludes(singletonList(MANIFEST_BUNDLE_LOCALIZATION_FILENAME));
+        l10nResource.setIncludes(List.of(MANIFEST_BUNDLE_LOCALIZATION_FILENAME));
         return l10nResource;
     }
 
     protected Properties readL10nProps(OsgiManifest manifest) throws MojoExecutionException {
-        String bundleL10nBase = manifest.getValue(BUNDLE_LOCALIZATION);
+        return readL10nProps(manifest::getValue, project.getBasedir().toPath(), getLog());
+    }
+
+    protected static Properties readL10nProps(UnaryOperator<String> getManifestHeaderValue, Path basedir, Log log)
+            throws MojoExecutionException {
+        String bundleL10nBase = getManifestHeaderValue.apply(BUNDLE_LOCALIZATION);
         boolean hasL10nProperty = bundleL10nBase != null;
         if (bundleL10nBase == null) {
             bundleL10nBase = BUNDLE_LOCALIZATION_DEFAULT_BASENAME;
         }
-        File l10nPropsFile = new File(project.getBasedir(), bundleL10nBase + ".properties");
-        if (!l10nPropsFile.isFile()) {
+        Path l10nPropsFile = basedir.resolve(bundleL10nBase + ".properties");
+        if (!Files.isRegularFile(l10nPropsFile)) {
             bundleL10nBase = "plugin";
-            l10nPropsFile = new File(project.getBasedir(), bundleL10nBase + ".properties");
-            if (!l10nPropsFile.isFile()) {
+            l10nPropsFile = basedir.resolve(bundleL10nBase + ".properties");
+            if (!Files.isRegularFile(l10nPropsFile)) {
                 if (hasL10nProperty) {
-                    getLog().warn("Bundle localization file " + l10nPropsFile + " not found");
+                    log.warn("Bundle localization file " + l10nPropsFile + " not found");
                 }
                 return null;
             }
         }
         Properties l10nProps = new Properties();
-        try (FileInputStream in = new FileInputStream(l10nPropsFile)) {
+        try (InputStream in = Files.newInputStream(l10nPropsFile)) {
             l10nProps.load(in);
         } catch (IOException e) {
             throw new MojoExecutionException("error loading " + l10nPropsFile, e);
@@ -306,8 +317,9 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
         return l10nProps;
     }
 
-    private String getL10nResolvedValue(OsgiManifest manifest, String manifestHeaderKey, Properties l10nProps) {
-        String value = manifest.getValue(manifestHeaderKey);
+    private static String getL10nResolvedValue(UnaryOperator<String> getManifestHeaderValue, String manifestHeaderKey,
+            Properties l10nProps) {
+        String value = getManifestHeaderValue.apply(manifestHeaderKey);
         if (value == null || !value.startsWith("%") || l10nProps == null) {
             return value;
         }
@@ -348,13 +360,17 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
             mavenArchiveConfiguration.addManifestEntry(MANIFEST_HEADER_ECLIPSE_SOURCE_BUNDLE, symbolicName
                     + ";version=\"" + expandedVersion + "\";roots:=\"" + getEclipseHeaderSourceRoots() + "\"");
 
-            mavenArchiveConfiguration.addManifestEntry(BUNDLE_NAME, I18N_KEY_PREFIX + I18N_KEY_BUNDLE_NAME);
-            mavenArchiveConfiguration.addManifestEntry(BUNDLE_VENDOR, I18N_KEY_PREFIX + I18N_KEY_BUNDLE_VENDOR);
-            mavenArchiveConfiguration.addManifestEntry(BUNDLE_LOCALIZATION, MANIFEST_BUNDLE_LOCALIZATION_BASENAME);
+            addLocalicationHeaders(mavenArchiveConfiguration::addManifestEntry);
         } else {
             getLog().info(
                     "NOT adding source bundle MANIFEST.MF entries. Incomplete or no bundle information available.");
         }
+    }
+
+    static void addLocalicationHeaders(BiConsumer<String, String> manifest) {
+        manifest.accept(BUNDLE_NAME, I18N_KEY_PREFIX + I18N_KEY_BUNDLE_NAME);
+        manifest.accept(BUNDLE_VENDOR, I18N_KEY_PREFIX + I18N_KEY_BUNDLE_VENDOR);
+        manifest.accept(BUNDLE_LOCALIZATION, MANIFEST_BUNDLE_LOCALIZATION_BASENAME);
     }
 
     private String getEclipseHeaderSourceRoots() {

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/PDESourceBundleMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/PDESourceBundleMojo.java
@@ -57,10 +57,9 @@ public class PDESourceBundleMojo extends AbstractMojo {
                     File sourceFile = artifact.getFile();
                     try (Jar hostBundle = new Jar(project.getArtifact().getFile());
                             Jar sourceJar = new Jar(sourceFile)) {
-                        Attributes hostMain = hostBundle.getManifest().getMainAttributes();
                         Attributes sourceMain = sourceJar.getManifest().getMainAttributes();
-                        String hostName = hostMain.getValue(BUNDLE_SYMBOLICNAME);
-                        String hostVersion = hostMain.getValue(BUNDLE_VERSION);
+                        String hostName = hostBundle.getBsn();
+                        String hostVersion = hostBundle.getVersion();
                         sourceMain.putValue(BUNDLE_MANIFESTVERSION, "2");
                         sourceMain.putValue(BUNDLE_SYMBOLICNAME, hostName + sourceBundleSuffix);
                         sourceMain.putValue(BUNDLE_VERSION, hostVersion);
@@ -76,7 +75,6 @@ public class PDESourceBundleMojo extends AbstractMojo {
                 }
             }
         }
-
     }
 
 }


### PR DESCRIPTION
This PR contains two enhancements of the `generate-pde-source-header` goal/mojo.

1. Use only main value of 'Bundle-SymbolicName' in pde-source-header mojo
2. Adda Bundle-locations file+header based on the values from the main artifact, just like the `plugin-source` goal does.