### PR TITLE
Handle errors in artifact comparator more graceful

### DIFF
--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/artifactcomparator/ArtifactDelta.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/artifactcomparator/ArtifactDelta.java
@@ -12,11 +12,27 @@
  *******************************************************************************/
 package org.eclipse.tycho.artifactcomparator;
 
+import org.eclipse.tycho.zipcomparator.internal.SimpleArtifactDelta;
 
 /**
  * Represents both simple and compound artifact delta.
  */
 public interface ArtifactDelta {
+
+    /**
+     * a default instance that indicates there is a difference but can't tell any further details
+     */
+    public static final SimpleArtifactDelta DEFAULT = new SimpleArtifactDelta("different");
+
+    /**
+     * a default instance that indicate an item is only present in the baseline but no more details
+     */
+    public static final SimpleArtifactDelta BASELINE_ONLY = new SimpleArtifactDelta("present in baseline only");
+
+    /**
+     * a default instance that indicate an item is missing from what is found in the baseline
+     */
+    public static final SimpleArtifactDelta MISSING_FROM_BASELINE = new SimpleArtifactDelta("not present in baseline");
 
     /**
      * @return description of the delta, never null.

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/DefaultContentsComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/DefaultContentsComparator.java
@@ -27,7 +27,7 @@ public class DefaultContentsComparator implements ContentsComparator {
 
     @Override
     public ArtifactDelta getDelta(InputStream baseline, InputStream reactor, ComparisonData data) throws IOException {
-        return !IOUtil.contentEquals(baseline, reactor) ? new SimpleArtifactDelta("different") : null;
+        return !IOUtil.contentEquals(baseline, reactor) ? ArtifactDelta.DEFAULT : null;
     }
 
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/PropertiesComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/PropertiesComparator.java
@@ -44,13 +44,13 @@ public class PropertiesComparator implements ContentsComparator {
         for (String name : names) {
             String value = props.getProperty(name);
             if (value == null) {
-                result.put(name, new SimpleArtifactDelta("not present in baseline version"));
+                result.put(name, ArtifactDelta.MISSING_FROM_BASELINE);
                 continue;
             }
 
             String value2 = props2.getProperty(name);
             if (value2 == null) {
-                result.put(name, new SimpleArtifactDelta("present in baseline version only"));
+                result.put(name, ArtifactDelta.BASELINE_ONLY);
                 continue;
             }
 

--- a/tycho-artifactcomparator/src/test/java/org/eclipse/tycho/jarcomparator/tests/CompoundArtifactDeltaTest.java
+++ b/tycho-artifactcomparator/src/test/java/org/eclipse/tycho/jarcomparator/tests/CompoundArtifactDeltaTest.java
@@ -27,16 +27,16 @@ public class CompoundArtifactDeltaTest {
     @Test
     public void testGetDetailedMessage() {
         Map<String, ArtifactDelta> manifest = new TreeMap<>();
-        manifest.put("name1", new SimpleArtifactDelta("present in baseline only"));
+        manifest.put("name1", ArtifactDelta.BASELINE_ONLY);
 
         Map<String, ArtifactDelta> main = new TreeMap<>();
-        main.put("path/file1", new SimpleArtifactDelta("different"));
+        main.put("path/file1", ArtifactDelta.DEFAULT);
         main.put("path/file2", new SimpleArtifactDelta("not present in baseline"));
         main.put("META-INF/MANIFEST.MF", new CompoundArtifactDelta("different", manifest));
 
         Map<String, ArtifactDelta> delta = new TreeMap<>();
         delta.put("<main>", new CompoundArtifactDelta("different", main));
-        delta.put("sources", new SimpleArtifactDelta("different"));
+        delta.put("sources", ArtifactDelta.DEFAULT);
 
         ArtifactDelta subject = new CompoundArtifactDelta(
                 "Baseline and reactor artifacts have the same version but different contents", delta);


### PR DESCRIPTION
- only record full diff in XML if requested by the user
- if comparing zips fails, fall back to byte compare

FYI @akurtakov @HannesWell 

Closes https://github.com/eclipse-tycho/tycho/issues/1864