### PR TITLE
Mark Mojos threadsafe

### DIFF
--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -39,9 +39,9 @@ import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult;
+import org.eclipse.tycho.core.resolver.P2ResolutionResult.Entry;
 import org.eclipse.tycho.core.resolver.P2Resolver;
 import org.eclipse.tycho.core.resolver.P2ResolverFactory;
-import org.eclipse.tycho.core.resolver.P2ResolutionResult.Entry;
 import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.osgi.adapters.MavenLoggerAdapter;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
@@ -63,7 +63,7 @@ import org.osgi.framework.Version;
  * 
  * @author mistria
  */
-@Mojo(defaultPhase = LifecyclePhase.VERIFY, requiresProject = false, name = "compare-version-with-baselines")
+@Mojo(defaultPhase = LifecyclePhase.VERIFY, requiresProject = false, name = "compare-version-with-baselines", threadSafe = true)
 public class CompareWithBaselineMojo extends AbstractMojo {
 
     public static enum ReportBehavior {

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
@@ -46,7 +46,7 @@ import org.eclipse.tycho.p2tools.RepositoryReferenceTool;
  * "https://help.eclipse.org/indigo/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fp2_repositorytasks.htm"
  * >p2.mirror ant task</a>.
  */
-@Mojo(name = "mirror")
+@Mojo(name = "mirror", threadSafe = true)
 public class MirrorMojo extends AbstractMojo {
 
     @Parameter(property = "project", readonly = true)

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/PublishFeaturesAndBundlesMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/PublishFeaturesAndBundlesMojo.java
@@ -35,7 +35,7 @@ import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
  * 
  * @see https://wiki.eclipse.org/Equinox/p2/Publisher#Features_And_Bundles_Publisher_Application
  */
-@Mojo(name = "publish-features-and-bundles")
+@Mojo(name = "publish-features-and-bundles", threadSafe = true)
 public class PublishFeaturesAndBundlesMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
actually maven do not do any special action for mojos not marked thread safe... if we find problem we should fix them but marking them as not threadsafe only emits useless warning messages.