### PR TITLE
Allow specifying additional filesets for feature's packaging

### DIFF
--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/AbstractTychoPackagingMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/AbstractTychoPackagingMojo.java
@@ -69,6 +69,29 @@ public abstract class AbstractTychoPackagingMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     protected boolean strictBinIncludes;
 
+    /**
+     * Additional files to be included in the final <code>.jar</code>.
+     * <p>
+     * A typical usage might be when <code>bin.includes</code> in <code>build.properties</code>
+     * is not flexible enough, e.g., for generated files, as when conflicting additional files
+     * win over <code>bin.includes</code>.
+     * <p>
+     * Example:
+     * <pre>
+     * &lt;additionalFileSets&gt;
+     *  &lt;fileSet&gt;
+     *   &lt;directory&gt;${project.build.directory}/mytool-gen/&lt;/directory&gt;
+     *   &lt;includes&gt;
+     *    &lt;include&gt;&#42;&#42;/*&lt;/include&gt;
+     *   &lt;/includes&gt;
+     *  &lt;/fileSet&gt;
+     * &lt;/additionalFileSets&gt;
+     * </pre>
+     * Note: currently, additional file sets are not used for the <code>package-iu</code> goal.
+     */
+    @Parameter
+    protected DefaultFileSet[] additionalFileSets;
+
     @Component
     protected PlexusContainer plexus;
 

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
@@ -168,6 +168,18 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
             jarArchiver.setDestFile(outputJar);
 
             try {
+                // Additional file sets win over bin.includes ones, so we add them first
+                if (additionalFileSets != null) {
+                    for (final var fileSet : additionalFileSets) {
+                        final var directory = fileSet.getDirectory();
+
+                        // noinspection ConstantConditions
+                        if (directory != null && directory.isDirectory()) {
+                            archiver.getArchiver().addFileSet(fileSet);
+                        }
+                    }
+                }
+
                 archiver.getArchiver().addFileSet(getManuallyIncludedFiles(buildProperties));
                 if (licenseFeature != null) {
                     archiver.getArchiver()

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -72,28 +72,6 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 	private JarArchiver jarArchiver;
 
 	/**
-	 * Additional files to be included in the bundle jar. This can be used when
-	 * <tt>bin.includes</tt> in build.properties is not flexible enough , e.g. for
-	 * generated files. If conflicting, additional files win over
-	 * <tt>bin.includes</tt><br/>
-	 * Example:<br/>
-	 * 
-	 * <pre>
-	 * &lt;additionalFileSets&gt;
-	 *  &lt;fileSet&gt;
-	 *   &lt;directory&gt;${project.build.directory}/mytool-gen/&lt;/directory&gt;
-	 *   &lt;includes&gt;
-	 *    &lt;include&gt;&#42;&#42;/*&lt;/include&gt;
-	 *   &lt;/includes&gt;
-	 *  &lt;/fileSet&gt;     
-	 * &lt;/additionalFileSets&gt;
-	 * </pre>
-	 * 
-	 */
-	@Parameter
-	private DefaultFileSet[] additionalFileSets;
-
-	/**
 	 * Name of the generated JAR.
 	 */
 	@Parameter(property = "project.build.finalName", alias = "jarName", required = true)


### PR DESCRIPTION
Closes #1869.

I have also aligned the plugin/feature `additionalFileSets` javadoc.