### PR TITLE
Add Text-File comparator to baseline compare to ignore lineending-diffs

### DIFF
--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/artifactcomparator/ArtifactComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/artifactcomparator/ArtifactComparator.java
@@ -19,22 +19,18 @@ import java.util.List;
 
 public interface ArtifactComparator {
 
-    public static class ComparisonData {
+    public static record ComparisonData(List<String> ignoredPattern, List<String> textFileExtensions,
+            boolean writeDelta) {
 
-        public ComparisonData(List<String> ignoredPattern, boolean writeDelta) {
+        public ComparisonData(List<String> ignoredPattern, List<String> textFileExtensions, boolean writeDelta) {
             this.ignoredPattern = ignoredPattern != null ? List.copyOf(ignoredPattern) : List.of();
             this.writeDelta = writeDelta;
+            this.textFileExtensions = textFileExtensions.stream().map(String::strip)
+                    .map(e -> e.startsWith(".") ? e : "." + e).toList();
         }
 
-        private final List<String> ignoredPattern;
-        private boolean writeDelta;
-
-        public List<String> ignoredPattern() {
-            return ignoredPattern;
-        }
-
-        public boolean writeDelta() {
-            return writeDelta;
+        public boolean isTextFile(String name) {
+            return textFileExtensions().stream().anyMatch(name::endsWith);
         }
     }
 

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/TextContentsComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/TextContentsComparator.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 Hannes Wellmann and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.zipcomparator.internal;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
+import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
+import org.eclipse.tycho.artifactcomparator.ComparatorInputStream;
+
+@Component(role = ContentsComparator.class, hint = TextContentsComparator.TYPE)
+public class TextContentsComparator implements ContentsComparator {
+
+    public static final String DEFAULT_TEXT_FILE_EXTENSIONS = "txt,java,html,xml,exsd";
+
+    public static final String TYPE = "text";
+
+    private static final char CR = '\r';
+    private static final char LF = '\n';
+
+    @Override
+    public ArtifactDelta getDelta(ComparatorInputStream baselineStream, ComparatorInputStream reactorStream,
+            ComparisonData data) throws IOException {
+        byte[] baseline = baselineStream.asBytes();
+        byte[] reactor = reactorStream.asBytes();
+
+        int bI = 0;
+        int rI = 0;
+        int mismatch = Arrays.mismatch(baseline, reactor);
+        while (mismatch >= 0) {
+            int baselineNewLine = newLineLength(baseline, bI + mismatch);
+            int reactorNewLine = newLineLength(reactor, rI + mismatch);
+            if (baselineNewLine < 0 || reactorNewLine < 0) {
+                return ArtifactDelta.DEFAULT;
+            }
+            bI += baselineNewLine;
+            rI += reactorNewLine;
+
+            mismatch = Arrays.mismatch(baseline, bI, baseline.length, reactor, rI, reactor.length);
+        }
+        return null;
+    }
+
+    private int newLineLength(byte[] bytes, int index) {
+        if (index < bytes.length) {
+            if (bytes[index] == LF) {
+                return 1;
+            } else if (bytes[index] == CR && index + 1 < bytes.length && bytes[index + 1] == LF) {
+                return 2;
+            }
+        }
+        return -1;
+    }
+
+}

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ZipComparatorImpl.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ZipComparatorImpl.java
@@ -105,7 +105,7 @@ public class ZipComparatorImpl implements ArtifactComparator {
                 //perfectly equal!
                 return null;
             }
-            ContentsComparator comparator = comparators.get(getContentType(name));
+            ContentsComparator comparator = comparators.get(getContentType(name, data));
             if (comparator != null) {
                 try {
                     return comparator.getDelta(new ComparatorInputStream(baselineBytes, name),
@@ -128,7 +128,7 @@ public class ZipComparatorImpl implements ArtifactComparator {
         }
     }
 
-    private String getContentType(String name) {
+    private String getContentType(String name, ComparisonData data) {
         name = name.toLowerCase(Locale.ENGLISH);
         if (name.endsWith(".class")) {
             return ClassfileComparator.TYPE;
@@ -145,6 +145,9 @@ public class ZipComparatorImpl implements ArtifactComparator {
         }
         if (name.endsWith(".xml")) {
             return XmlComparator.XML;
+        }
+        if (data.isTextFile(name)) {
+            return TextContentsComparator.TYPE;
         }
         return DefaultContentsComparator.TYPE;
     }

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BaselineContext.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BaselineContext.java
@@ -26,6 +26,8 @@ public interface BaselineContext {
 	void reportBaselineProblem(String message) throws MojoFailureException;
 
 	List<String> getIgnores();
+	
+	List<String> getTextFileExtensions();
 
 	List<String> getPackages();
 

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BaselineMojo.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BaselineMojo.java
@@ -41,6 +41,7 @@ import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.core.osgitools.OsgiManifestParserException;
 import org.eclipse.tycho.p2maven.repository.P2RepositoryManager;
+import org.eclipse.tycho.zipcomparator.internal.TextContentsComparator;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
@@ -101,6 +102,9 @@ public class BaselineMojo extends AbstractMojo implements BaselineContext {
 	@Parameter(property = "tycho.baseline.extensions", defaultValue = "false")
 	private boolean extensions;
 
+    @Parameter(property = "tycho.baseline.textfile.extensions", defaultValue = TextContentsComparator.DEFAULT_TEXT_FILE_EXTENSIONS)
+    private List<String> textFileExtensions;
+	
 	@Component
 	protected TychoProjectManager projectManager;
 	@Component
@@ -217,6 +221,14 @@ public class BaselineMojo extends AbstractMojo implements BaselineContext {
 			return List.of();
 		}
 		return ignores;
+	}
+	
+	@Override
+	public List<String> getTextFileExtensions() {
+		if (textFileExtensions == null) {
+			return List.of();
+		}
+		return textFileExtensions;
 	}
 
 	@Override

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BundleArtifactBaselineComparator.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BundleArtifactBaselineComparator.java
@@ -353,8 +353,8 @@ public class BundleArtifactBaselineComparator implements ArtifactBaselineCompara
 				try (InputStream baseStream = baseResource.openInputStream();
 						InputStream currentStream = currenttResource.openInputStream()) {
 					return comparator.getDelta(new ComparatorInputStream(baseStream, name),
-							new ComparatorInputStream(currentStream, name),
-							new ComparisonData(baselineContext.getIgnores(), false));
+							new ComparatorInputStream(currentStream, name), new ComparisonData(
+									baselineContext.getIgnores(), baselineContext.getTextFileExtensions(), false));
 				} catch (Exception e) {
 				}
 			}

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/FeatureBaselineComparator.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/FeatureBaselineComparator.java
@@ -334,7 +334,7 @@ public class FeatureBaselineComparator implements ArtifactBaselineComparator {
 			ignores.addAll(context.getIgnores());
 			ArtifactDelta artifactDelta = zipComparator.getDelta(getStream(baselineJarUnit, context),
 					new ComparatorInputStream(reactor, file.getAbsolutePath()),
-					new ComparisonData(ignores, false));
+					new ComparisonData(ignores, List.of(".xml"), false));
 			if (artifactDelta == null) {
 				return List.of();
 			}

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -45,6 +45,7 @@ import org.eclipse.tycho.core.resolver.P2ResolverFactory;
 import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.osgi.adapters.MavenLoggerAdapter;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
+import org.eclipse.tycho.zipcomparator.internal.TextContentsComparator;
 import org.osgi.framework.Version;
 
 /**
@@ -97,6 +98,9 @@ public class CompareWithBaselineMojo extends AbstractMojo {
      */
     @Parameter
     private List<String> ignoredPatterns;
+
+    @Parameter(property = "tycho.baseline.textfile.extensions", defaultValue = TextContentsComparator.DEFAULT_TEXT_FILE_EXTENSIONS)
+    private List<String> textFileExtensions;
 
     @Parameter(property = "skip")
     private boolean skip;
@@ -184,7 +188,7 @@ public class CompareWithBaselineMojo extends AbstractMojo {
                         } else {
                             reactorFile = reactorProject.getArtifact();
                         }
-                        ComparisonData data = new ComparisonData(ignoredPatterns, false);
+                        ComparisonData data = new ComparisonData(ignoredPatterns, textFileExtensions, false);
                         ArtifactDelta artifactDelta = this.artifactComparators.get(this.comparator)
                                 .getDelta(baselineFile, reactorFile, data);
                         String message = "Baseline and reactor have same fully qualified version, but with different content";

--- a/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/P2MetadataMojo.java
+++ b/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/P2MetadataMojo.java
@@ -46,6 +46,7 @@ import org.eclipse.tycho.p2.metadata.IP2Artifact;
 import org.eclipse.tycho.p2.metadata.P2Generator;
 import org.eclipse.tycho.p2.metadata.PublisherOptions;
 import org.eclipse.tycho.p2resolver.ArtifactFacade;
+import org.eclipse.tycho.zipcomparator.internal.TextContentsComparator;
 
 @Mojo(name = "p2-metadata", threadSafe = true)
 public class P2MetadataMojo extends AbstractMojo {
@@ -110,6 +111,9 @@ public class P2MetadataMojo extends AbstractMojo {
      */
     @Parameter
     private List<String> ignoredPatterns;
+
+    @Parameter(property = "tycho.baseline.textfile.extensions", defaultValue = TextContentsComparator.DEFAULT_TEXT_FILE_EXTENSIONS)
+    private List<String> textFileExtensions;
 
     /**
      * Weather or not detailed information about encountered differences is written in case the
@@ -191,7 +195,7 @@ public class P2MetadataMojo extends AbstractMojo {
                     new PublisherOptions(generateDownloadStatsProperty), targetDir);
 
             if (baselineMode != BaselineMode.disable) {
-                ComparisonData data = new ComparisonData(ignoredPatterns, writeComparatorDelta);
+                ComparisonData data = new ComparisonData(ignoredPatterns, textFileExtensions, writeComparatorDelta);
                 generatedMetadata = baselineValidator.validateAndReplace(project, data, generatedMetadata,
                         baselineRepositories, baselineMode, baselineReplace);
             }


### PR DESCRIPTION
This changes adds a text-file comparator that ignores differences in line-endings for text files.
Comparing text-files with a baseline is problematic when the text-files are build into the baseline jars with another (usually platform depended newline) than used on the current computer.
This often happens when projects are build on Jenkins and one wants to make a local build on Windows and git is configured to check-out text files Windows-style (but commit them Linux style).

This improves the experience with the `p2-metadata`, `compare-version-with-baselines` and `tycho-baseline` mojos in this regard.

Some tests would probably be good as well.