### PR TITLE
Fix warning from deploy plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
 				branch deployBranch
 			}
 			steps {
-				sh 'mvn --batch-mode -V deploy -DskipTests -DaltDeploymentRepository=repo.eclipse.org::default::https://repo.eclipse.org/content/repositories/tycho-snapshots/'
+				sh 'mvn --batch-mode -V deploy -DskipTests -DaltDeploymentRepository=repo.eclipse.org::https://repo.eclipse.org/content/repositories/tycho-snapshots/'
 			}
 		}
 		stage('Deploy sitedocs') {


### PR DESCRIPTION
Namely: 
```
[WARNING] Using legacy syntax for alternative repository. Use "repo.eclipse.org::https://repo.eclipse.org/content/repositories/tycho-snapshots/" instead.
```