### PR TITLE
Fix #1789: Avoid wrong archive entry warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
 			<dependency>
 				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-archiver</artifactId>
-				<version>4.6.0</version>
+				<version>4.6.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Upgrade plexus archiver which contains a fix now.