### PR TITLE
Support PDE BUNDLE_ROOT_PATH settings

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/BundleReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/BundleReader.java
@@ -13,6 +13,7 @@
 package org.eclipse.tycho.core.osgitools;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * Cache for OSGi manifest files and bundle classpath entries.
@@ -33,8 +34,8 @@ public interface BundleReader {
      * @throws InvalidOSGiManifestException
      *             if valid MANIFEST is found but it does not have valid mandatory OSGi headers
      */
-    public OsgiManifest loadManifest(File bundleLocation) throws OsgiManifestParserException,
-            InvalidOSGiManifestException;
+    public OsgiManifest loadManifest(File bundleLocation)
+            throws OsgiManifestParserException, InvalidOSGiManifestException;
 
     /**
      * Returns bundle entry with given path or <code>null</code> if no such entry exists. If bundle
@@ -47,4 +48,6 @@ public interface BundleReader {
      * 
      */
     public File getEntry(File bundleLocation, String path);
+
+    File getManifestLocation(File directory) throws IOException;
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiManifest.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiManifest.java
@@ -130,6 +130,10 @@ public class OsgiManifest {
         return executionEnvironments;
     }
 
+    public String getLocation() {
+        return location;
+    }
+
     /**
      * Returns true if Eclipse-BundleShape header is set to dir.
      * 

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -49,6 +49,7 @@ import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.core.BundleProject;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.TychoProjectManager;
+import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.osgitools.OsgiBundleProject;
 import org.eclipse.tycho.core.osgitools.project.BuildOutputJar;
@@ -147,6 +148,9 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 
 	@Component
 	TychoProjectManager projectManager;
+
+	@Component
+	private BundleReader bundleReader;
 
 	@Override
 	public void execute() throws MojoExecutionException {
@@ -304,10 +308,9 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 		final File archiveManifestFile = archive.getManifestFile();
 		final File manifestFile = archiveManifestFile != null
 				? archiveManifestFile
-				: new File(project.getBasedir(), "META-INF/MANIFEST.MF");
+				: bundleReader.getManifestLocation(project.getBasedir());
 
 		Manifest mf;
-
 		try (final InputStream is = new FileInputStream(manifestFile)) {
 			mf = new Manifest(is);
 		}


### PR DESCRIPTION
One can change the root of the bundle (for example)

BUNDLE_ROOT_PATH=src/main/resources

in org.eclipse.pde.core.prefs but then Tycho fails as it search for the manifest always at the root.

This enhances the BundleReader and PackagePluginMojo to support this configuration preference.

Fix https://github.com/eclipse-tycho/tycho/issues/1516