### PR TITLE
Test compile must take TestCompileSourceRoots into account

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiTestCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiTestCompilerMojo.java
@@ -71,8 +71,11 @@ public class OsgiTestCompilerMojo extends AbstractOsgiCompilerMojo {
     public List<SourcepathEntry> getSourcepath() throws MojoExecutionException {
         ReactorProject reactorProject = DefaultReactorProject.adapt(project);
         File testOutputDirectory = reactorProject.getBuildDirectory().getTestOutputDirectory();
-        return getSourceFolders().map(file -> new ClasspathSourcepathEntry(file, testOutputDirectory))
-                .collect(Collectors.toList());
+        Stream<File> mavenDirectories = project.getTestCompileSourceRoots().stream().map(dir -> new File(dir))
+                .filter(File::isDirectory);
+        Stream<File> sourceFolders = getSourceFolders();
+        return Stream.concat(mavenDirectories, sourceFolders).distinct()
+                .map(file -> new ClasspathSourcepathEntry(file, testOutputDirectory)).collect(Collectors.toList());
 
     }
 


### PR DESCRIPTION
Currently only declared (test)source folder are taken into account, but there might be additional ones defined in the maven model.

This adjust the OsgiTestCompilerMojo to take these test compile source roots into account.