### PR TITLE
Single commons-io version

### DIFF
--- a/p2-maven-plugin/pom.xml
+++ b/p2-maven-plugin/pom.xml
@@ -199,7 +199,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/sisu-osgi/sisu-osgi-connect/pom.xml
+++ b/sisu-osgi/sisu-osgi-connect/pom.xml
@@ -34,7 +34,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
 		</dependency>
   </dependencies>
   

--- a/tycho-bundles/org.eclipse.tycho.core.shared/pom.xml
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/pom.xml
@@ -44,7 +44,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>

--- a/tycho-core/pom.xml
+++ b/tycho-core/pom.xml
@@ -253,16 +253,13 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
 		</dependency>
-
 
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>1.15</version>
 		</dependency>
-
 
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
As it's managed version there is no point in setting the same version over and over.