### PR TITLE
Support compilation without build.properties

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/BundleReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/BundleReader.java
@@ -15,6 +15,8 @@ package org.eclipse.tycho.core.osgitools;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.maven.project.MavenProject;
+
 /**
  * Cache for OSGi manifest files and bundle classpath entries.
  */
@@ -34,7 +36,10 @@ public interface BundleReader {
      * @throws InvalidOSGiManifestException
      *             if valid MANIFEST is found but it does not have valid mandatory OSGi headers
      */
-    public OsgiManifest loadManifest(File bundleLocation)
+    OsgiManifest loadManifest(File bundleLocation)
+            throws OsgiManifestParserException, InvalidOSGiManifestException;
+
+    OsgiManifest loadManifest(MavenProject mavenProject)
             throws OsgiManifestParserException, InvalidOSGiManifestException;
 
     /**
@@ -47,7 +52,7 @@ public interface BundleReader {
      *            path relative to the bundle root. Paths starting with "external:" are ignored
      * 
      */
-    public File getEntry(File bundleLocation, String path);
+    File getEntry(File bundleLocation, String path);
 
-    File getManifestLocation(File directory) throws IOException;
+    File getManifestLocation(MavenProject mavenProject) throws IOException;
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -50,6 +50,7 @@ import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.ClasspathEntry;
+import org.eclipse.tycho.ClasspathEntry.AccessRule;
 import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.DependencyArtifacts;
 import org.eclipse.tycho.PackagingType;
@@ -58,7 +59,6 @@ import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.TychoConstants;
-import org.eclipse.tycho.ClasspathEntry.AccessRule;
 import org.eclipse.tycho.core.ArtifactDependencyVisitor;
 import org.eclipse.tycho.core.ArtifactDependencyWalker;
 import org.eclipse.tycho.core.BundleProject;
@@ -186,7 +186,11 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
     }
 
     private OsgiManifest getManifest(ReactorProject project) {
-        return bundleReader.loadManifest(project.getBasedir());
+        MavenProject mavenProject = project.adapt(MavenProject.class);
+        if (mavenProject == null) {
+            return bundleReader.loadManifest(project.getBasedir());
+        }
+        return bundleReader.loadManifest(mavenProject);
     }
 
     private BundleClassPath resolveClassPath(MavenSession session, MavenProject project) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/BuildPropertiesParserImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/BuildPropertiesParserImplTest.java
@@ -55,13 +55,13 @@ public class BuildPropertiesParserImplTest {
     @Test
     public void testReadPropertiesFileWithExistingFile() throws IOException {
         File baseDir = TestUtil.getBasedir("buildproperties");
-        Properties properties = BuildPropertiesParserImpl.readProperties(new File(baseDir, "build.properties"));
+        Properties properties = BuildPropertiesParserImpl.readProperties(new File(baseDir, "build.properties"), null);
         Assert.assertEquals(3, properties.size());
     }
 
     @Test
     public void testReadPropertiesWithNonExistingFile() {
-        Properties properties = BuildPropertiesParserImpl.readProperties(new File("MISSING_FILE"));
+        Properties properties = BuildPropertiesParserImpl.readProperties(new File("MISSING_FILE"), null);
         Assert.assertEquals(0, properties.size());
     }
 

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -227,7 +227,10 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 				if (binIncludesList.contains(jarName) && outputJar.isDirClasspathEntry()) {
 					binIncludesIgnoredForValidation.add(jarName);
 					String prefix = ".".equals(jarName) ? "" : jarName;
-					archiver.getArchiver().addDirectory(outputJar.getOutputDirectory(), prefix);
+					File outputDirectory = outputJar.getOutputDirectory();
+					if (outputDirectory.isDirectory()) {
+						archiver.getArchiver().addDirectory(outputDirectory, prefix);
+					}
 				}
 			}
 			// 3. handle nested jars and included resources
@@ -308,7 +311,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 		final File archiveManifestFile = archive.getManifestFile();
 		final File manifestFile = archiveManifestFile != null
 				? archiveManifestFile
-				: bundleReader.getManifestLocation(project.getBasedir());
+				: bundleReader.getManifestLocation(project);
 
 		Manifest mf;
 		try (final InputStream is = new FileInputStream(manifestFile)) {


### PR DESCRIPTION
Currently a build.properties file is mandatory for compilation, but actually we can derive all necessary information from the maven model.

This adjust the BuildPropertiesParser and BundleReader to extract the necessary information from the model if the build.properties file is absent.