### PR TITLE
Add support for more than one comparison type and compare textfiles

### DIFF
--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ClassfileComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ClassfileComparator.java
@@ -75,4 +75,9 @@ public class ClassfileComparator implements ContentsComparator {
         }
         return buffer.toString();
     }
+
+    @Override
+    public boolean matches(String extension) {
+        return TYPE.equalsIgnoreCase(extension);
+    }
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ContentsComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ContentsComparator.java
@@ -22,6 +22,17 @@ import org.eclipse.tycho.artifactcomparator.ComparatorInputStream;
 public interface ContentsComparator {
 
     /**
+     * System property that control if a detailed diff is desired or not (default = off)
+     */
+    static final boolean NO_DIFF_DETAILS = Boolean.getBoolean("tycho.comparator.noDiff");
+
+    /**
+     * System property that controls the threshold size where a direct byte compare is performed
+     * (default 5 mb)
+     */
+    static final int THRESHOLD = Integer.getInteger("tycho.comparator.threshold", 1024 * 1024 * 5);
+
+    /**
      * Computes the delta for the given {@link InputStream}s, the streams passed will support
      * mark/reset for repeated reads.
      * 
@@ -36,4 +47,13 @@ public interface ContentsComparator {
      */
     public ArtifactDelta getDelta(ComparatorInputStream baseline, ComparatorInputStream reactor, ComparisonData data)
             throws IOException;
+
+    /**
+     * Check if this comparator matches the given extension
+     * 
+     * @param extension
+     *            the extension to match
+     * @return <code>true</code> if this comparator matches, <code>false</code> otherwhise
+     */
+    boolean matches(String extension);
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/DefaultContentsComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/DefaultContentsComparator.java
@@ -30,4 +30,9 @@ public class DefaultContentsComparator implements ContentsComparator {
         return baseline.compare(reactor);
     }
 
+    @Override
+    public boolean matches(String extension) {
+        return false;
+    }
+
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ManifestComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ManifestComparator.java
@@ -94,4 +94,9 @@ public class ManifestComparator implements ContentsComparator {
         }
         return result;
     }
+
+    @Override
+    public boolean matches(String extension) {
+        return TYPE.equalsIgnoreCase(extension);
+    }
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/NestedZipComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/NestedZipComparator.java
@@ -46,4 +46,9 @@ public class NestedZipComparator implements ContentsComparator {
         }
     }
 
+    @Override
+    public boolean matches(String extension) {
+        return TYPE.equalsIgnoreCase(extension);
+    }
+
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/PropertiesComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/PropertiesComparator.java
@@ -72,4 +72,9 @@ public class PropertiesComparator implements ContentsComparator {
             }
         }
     }
+
+    @Override
+    public boolean matches(String extension) {
+        return TYPE.equalsIgnoreCase(extension) || "bnd".equalsIgnoreCase(extension);
+    }
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/TextComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/TextComparator.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.zipcomparator.internal;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
+import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
+import org.eclipse.tycho.artifactcomparator.ComparatorInputStream;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.UnifiedDiffUtils;
+import com.github.difflib.patch.Patch;
+
+/**
+ * Compares text-like files by ignoring there line ending styles
+ */
+@Component(role = ContentsComparator.class, hint = TextComparator.HINT)
+public class TextComparator implements ContentsComparator {
+
+    static final String HINT = "txt";
+
+    @Override
+    public ArtifactDelta getDelta(ComparatorInputStream baseline, ComparatorInputStream reactor, ComparisonData data)
+            throws IOException {
+        ByteIterator baselineIterator = new ByteIterator(baseline.asBytes());
+        ByteIterator reactorIterator = new ByteIterator(reactor.asBytes());
+        while (baselineIterator.hasNext() && reactorIterator.hasNext()) {
+            if (baselineIterator.next() != reactorIterator.next()) {
+                return createDelta(ArtifactDelta.DEFAULT.getMessage(), baseline, reactor);
+            }
+        }
+        //now both need to be at the end of the stream if they are the same!
+        if (baselineIterator.hasNext() || reactorIterator.hasNext()) {
+            return createDelta(ArtifactDelta.DEFAULT.getMessage(), baseline, reactor);
+        }
+        return ArtifactDelta.NO_DIFFERENCE;
+    }
+
+    private static final class ByteIterator {
+
+        private byte[] bytes;
+        private int index;
+
+        public ByteIterator(byte[] bytes) {
+            this.bytes = bytes;
+        }
+
+        byte next() throws EOFException {
+            if (hasNext()) {
+                byte b = bytes[index];
+                index++;
+                return b;
+            }
+            throw new EOFException();
+        }
+
+        boolean hasNext() {
+            skipNewLines();
+            return index < bytes.length;
+        }
+
+        private void skipNewLines() {
+            while (index < bytes.length) {
+                byte b = bytes[index];
+                if (b == '\n' || b == '\r') {
+                    index++;
+                    continue;
+                }
+                return;
+            }
+        }
+
+    }
+
+    @Override
+    public boolean matches(String extension) {
+        return HINT.equals(extension) ||
+        //TODO is there a way to compare java files? See https://github.com/eclipse-jdt/eclipse.jdt.core/discussions/628
+                "java".equalsIgnoreCase(extension) ||
+                //TODO is there a better way to compare html? See for example https://stackoverflow.com/questions/47310845/compare-two-html-documents-using-jsoup-java 
+                "html".equalsIgnoreCase(extension) || "htm".equalsIgnoreCase(extension);
+    }
+
+    public static ArtifactDelta createDelta(String message, ComparatorInputStream baseline,
+            ComparatorInputStream reactor) {
+        if (NO_DIFF_DETAILS) {
+            return ArtifactDelta.DEFAULT;
+        }
+        String detailed;
+        try {
+            List<String> source = IOUtils.readLines(baseline.asNewStream(), StandardCharsets.UTF_8);
+            List<String> target = IOUtils.readLines(reactor.asNewStream(), StandardCharsets.UTF_8);
+            Patch<String> patch = DiffUtils.diff(source, target);
+            List<String> unifiedDiffList = UnifiedDiffUtils.generateUnifiedDiff("baseline", "reactor", source, patch,
+                    0);
+            detailed = unifiedDiffList.stream().collect(Collectors.joining((System.lineSeparator())));
+        } catch (Exception e) {
+            detailed = message;
+        }
+        return new SimpleArtifactDelta(message, detailed, baseline.asString(StandardCharsets.UTF_8),
+                reactor.asString(StandardCharsets.UTF_8));
+    }
+
+}

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ZipComparatorImpl.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ZipComparatorImpl.java
@@ -106,7 +106,8 @@ public class ZipComparatorImpl implements ArtifactComparator {
                 return null;
             }
             ContentsComparator comparator = comparators.get(getContentType(name));
-            if (comparator != null) {
+            if (comparator != null && baselineBytes.length < ContentsComparator.THRESHOLD
+                    && reactorBytes.length < ContentsComparator.THRESHOLD) {
                 try {
                     return comparator.getDelta(new ComparatorInputStream(baselineBytes),
                             new ComparatorInputStream(reactorBytes), data);
@@ -144,7 +145,7 @@ public class ZipComparatorImpl implements ArtifactComparator {
             return ManifestComparator.TYPE;
         }
         if (name.endsWith(".xml")) {
-            return XmlComparator.XML;
+            return XmlComparator.HINT;
         }
         return DefaultContentsComparator.TYPE;
     }


### PR DESCRIPTION
This adds a method so ContentsComparators can state they match a given extension and add a new comparator that can compare text-like files by ignoring their line endings.

FYI @Bananeweizen  @HannesWell 
Fix https://github.com/eclipse-tycho/tycho/issues/1932