### PR TITLE
Support contribution of header values to the final manifest

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -857,7 +857,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
 
         try {
             pluginRealmHelper.visitPluginExtensions(project, session, ClasspathContributor.class, cpc -> {
-                List<ClasspathEntry> list = cpc.getAdditionalClasspathEntries(reactorProject, dependencyScope);
+                List<ClasspathEntry> list = cpc.getAdditionalClasspathEntries(project, dependencyScope);
                 if (list != null && !list.isEmpty()) {
                     classpath.addAll(list);
                 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractSpecificationClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractSpecificationClasspathContributor.java
@@ -25,12 +25,11 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ClasspathEntry;
+import org.eclipse.tycho.ClasspathEntry.AccessRule;
 import org.eclipse.tycho.DependencyResolutionException;
 import org.eclipse.tycho.IllegalArtifactReferenceException;
-import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.ResolvedArtifactKey;
 import org.eclipse.tycho.TargetPlatform;
-import org.eclipse.tycho.ClasspathEntry.AccessRule;
 import org.eclipse.tycho.classpath.ClasspathContributor;
 import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.maven.MavenDependenciesResolver;
@@ -78,10 +77,10 @@ public abstract class AbstractSpecificationClasspathContributor implements Class
     }
 
     @Override
-    public final List<ClasspathEntry> getAdditionalClasspathEntries(ReactorProject project, String scope) {
+    public final List<ClasspathEntry> getAdditionalClasspathEntries(MavenProject project, String scope) {
         Version specificationVersion = getSpecificationVersion(project);
         Version nextMajor = new Version(specificationVersion.getMajor() + 1, 0, 0);
-        TargetPlatform tp = TychoProjectUtils.getTargetPlatformIfAvailable(project);
+        TargetPlatform tp = TychoProjectUtils.getTargetPlatformIfAvailable(DefaultReactorProject.adapt(project));
         // try to resolve from TP first...
         if (tp != null) {
             try {
@@ -103,8 +102,7 @@ public abstract class AbstractSpecificationClasspathContributor implements Class
                 dependency.setArtifactId(mavenArtifactId);
                 dependency.setVersion(String.format("[%d.%d,%d)", specificationVersion.getMajor(),
                         specificationVersion.getMinor(), nextMajor.getMajor()));
-                Artifact artifact = dependenciesResolver.resolveHighestVersion(project.adapt(MavenProject.class),
-                        session, dependency);
+                Artifact artifact = dependenciesResolver.resolveHighestVersion(project, session, dependency);
                 ArtifactKey artifactKey = projectManager.getArtifactKey(artifact);
                 logger.debug("Resolved " + packageName + " to " + artifact.getId() + " @ " + artifact.getFile());
                 return List.of(
@@ -119,5 +117,5 @@ public abstract class AbstractSpecificationClasspathContributor implements Class
         return Collections.emptyList();
     }
 
-    protected abstract Version getSpecificationVersion(ReactorProject project);
+    protected abstract Version getSpecificationVersion(MavenProject project);
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/BundleAnnotationsClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/BundleAnnotationsClasspathContributor.java
@@ -16,8 +16,8 @@ import javax.inject.Inject;
 
 import org.apache.maven.SessionScoped;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
-import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.classpath.ClasspathContributor;
 import org.osgi.framework.Version;
 
@@ -36,7 +36,7 @@ public class BundleAnnotationsClasspathContributor extends AbstractSpecification
     }
 
     @Override
-    protected Version getSpecificationVersion(ReactorProject project) {
+    protected Version getSpecificationVersion(MavenProject project) {
         return VERSION;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/VersioningAnnotationsClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/VersioningAnnotationsClasspathContributor.java
@@ -16,8 +16,8 @@ import javax.inject.Inject;
 
 import org.apache.maven.SessionScoped;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
-import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.classpath.ClasspathContributor;
 import org.osgi.framework.Version;
 
@@ -36,7 +36,7 @@ public class VersioningAnnotationsClasspathContributor extends AbstractSpecifica
     }
 
     @Override
-    protected Version getSpecificationVersion(ReactorProject project) {
+    protected Version getSpecificationVersion(MavenProject project) {
         return VERSION;
     }
 

--- a/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/DeclarativeServicesClasspathContributor.java
+++ b/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/DeclarativeServicesClasspathContributor.java
@@ -18,9 +18,9 @@ import javax.inject.Inject;
 
 import org.apache.maven.SessionScoped;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.classpath.ClasspathContributor;
 import org.eclipse.tycho.core.DeclarativeServicesConfiguration;
 import org.eclipse.tycho.core.osgitools.AbstractSpecificationClasspathContributor;
@@ -45,7 +45,7 @@ public class DeclarativeServicesClasspathContributor extends AbstractSpecificati
 	}
 
 	@Override
-	protected Version getSpecificationVersion(ReactorProject project) {
+	protected Version getSpecificationVersion(MavenProject project) {
 		try {
 			DeclarativeServicesConfiguration configuration = configurationReader.getConfiguration(project);
 			if (configuration != null) {

--- a/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/HeaderConfiguration.java
+++ b/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/HeaderConfiguration.java
@@ -8,21 +8,21 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    Christoph Läubrich - initial API and implementation
+ *     Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.tycho.classpath;
+package org.eclipse.tycho.ds;
 
-import java.util.List;
-
-import org.apache.maven.project.MavenProject;
-import org.eclipse.tycho.ClasspathEntry;
-
-/**
- * A {@link ClasspathContributor} can contribute additional items to the compile classpath of a
- * project
- *
- */
-public interface ClasspathContributor {
-
-    List<ClasspathEntry> getAdditionalClasspathEntries(MavenProject project, String scope);
+public enum HeaderConfiguration {
+	/**
+	 * If the header is not present, it is added, otherwise it is kept as is
+	 */
+	auto,
+	/**
+	 * Keep the header and never change it
+	 */
+	keep,
+	/**
+	 * Replace the header regardless of current manifest state
+	 */
+	replace;
 }

--- a/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/ServiceComponentManifestProcessor.java
+++ b/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/ServiceComponentManifestProcessor.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.ds;
+
+import java.util.jar.Manifest;
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.ReactorProject;
+import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
+import org.eclipse.tycho.packaging.ManifestProcessor;
+
+@Component(role = ManifestProcessor.class)
+public class ServiceComponentManifestProcessor implements ManifestProcessor {
+
+	@Override
+	public void processManifest(MavenProject mavenProject, Manifest manifest) {
+		ReactorProject project = DefaultReactorProject.adapt(mavenProject);
+		String header = (String) project.getContextValue(DeclarativeServicesMojo.CONTEXT_KEY_MANIFEST_HEADER);
+		if (header != null) {
+			manifest.getMainAttributes().putValue(DeclarativeServicesMojo.SERVICE_COMPONENT_HEADER, header);
+		}
+	}
+
+}

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/ListDependenciesMojo.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/ListDependenciesMojo.java
@@ -95,8 +95,7 @@ public class ListDependenciesMojo extends AbstractMojo {
 
                 try {
                     pluginRealmHelper.visitPluginExtensions(project, session, ClasspathContributor.class, cpc -> {
-                        List<ClasspathEntry> list = cpc.getAdditionalClasspathEntries(reactorProject,
-                                Artifact.SCOPE_COMPILE);
+                        List<ClasspathEntry> list = cpc.getAdditionalClasspathEntries(project, Artifact.SCOPE_COMPILE);
                         if (list != null && !list.isEmpty()) {
                             for (ClasspathEntry entry : list) {
                                 for (File locations : entry.getLocations()) {

--- a/tycho-spi/src/main/java/org/eclipse/tycho/packaging/ManifestProcessor.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/packaging/ManifestProcessor.java
@@ -10,19 +10,16 @@
  * Contributors:
  *    Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.tycho.classpath;
+package org.eclipse.tycho.packaging;
 
-import java.util.List;
+import java.util.jar.Manifest;
 
 import org.apache.maven.project.MavenProject;
-import org.eclipse.tycho.ClasspathEntry;
 
 /**
- * A {@link ClasspathContributor} can contribute additional items to the compile classpath of a
- * project
- *
+ * A manifest processor can process manifest entries before they are packaged
  */
-public interface ClasspathContributor {
+public interface ManifestProcessor {
 
-    List<ClasspathEntry> getAdditionalClasspathEntries(MavenProject project, String scope);
+    void processManifest(MavenProject mavenProject, Manifest manifest);
 }


### PR DESCRIPTION
Currently the manifest is modified by the packaging-plugin and all code needs to be centralized there and knows about how to handle things.

This adds a new SPI interface that allows other plugins to contribute own manifest processings.

the ds-plugin uses this to contribute the Service-Component header if missing or configured to replace it.