### PR TITLE
Detect JUnit Framework from the maven dependencies

### DIFF
--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -773,8 +773,8 @@ public abstract class AbstractTestMojo extends AbstractMojo {
             return null;
         }
         TestFrameworkProvider provider = providerHelper.selectProvider(
-                getProjectType().getClasspath(DefaultReactorProject.adapt(project)), getMergedProviderProperties(),
-                providerHint);
+                project, getProjectType().getClasspath(DefaultReactorProject.adapt(project)),
+                getMergedProviderProperties(), providerHint);
         try {
             PropertiesWrapper wrapper = createSurefireProperties(provider, scanResult);
             storeProperties(wrapper.getProperties(), surefireProperties);
@@ -834,8 +834,8 @@ public abstract class AbstractTestMojo extends AbstractMojo {
             return null;
         }
         TestFrameworkProvider provider = providerHelper.selectProvider(
-                getProjectType().getTestClasspath(DefaultReactorProject.adapt(project)), getMergedProviderProperties(),
-                providerHint);
+                project, getProjectType().getTestClasspath(DefaultReactorProject.adapt(project)),
+                getMergedProviderProperties(), providerHint);
         DependencyResolver platformResolver = dependencyResolverLocator.lookupDependencyResolver(project);
         final List<ArtifactKey> extraDependencies = getExtraDependencies();
         List<ReactorProject> reactorProjects = getReactorProjects();

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit47Provider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit47Provider.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.surefire.api.booter.ProviderParameterNames;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ClasspathEntry;
@@ -36,14 +37,14 @@ public class JUnit47Provider extends AbstractJUnitProvider {
     private static final Version VERSION = Version.parseVersion("4.7.0");
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
         if (hasGroups(surefireProperties)) {
             return true;
         }
         if (!isParallelEnabled(surefireProperties)) {
             return false;
         }
-        return super.isEnabled(testBundleClassPath, surefireProperties);
+        return super.isEnabled(project, testBundleClassPath, surefireProperties);
     }
 
     private boolean hasGroups(Properties providerProperties) {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit57Provider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit57Provider.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
@@ -58,8 +59,8 @@ public class JUnit57Provider extends AbstractJUnitProvider {
     }
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
-        return super.isEnabled(testBundleClassPath, surefireProperties)
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+        return super.isEnabled(project, testBundleClassPath, surefireProperties)
                 && !new JUnit47Provider().containsJunitInClasspath(testBundleClassPath);
     }
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit57WithVintageProvider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit57WithVintageProvider.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
@@ -58,8 +59,8 @@ public class JUnit57WithVintageProvider extends AbstractJUnitProvider {
     }
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
-        return super.isEnabled(testBundleClassPath, surefireProperties)
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+        return super.isEnabled(project, testBundleClassPath, surefireProperties)
                 && new JUnit47Provider().containsJunitInClasspath(testBundleClassPath);
     }
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit58Provider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit58Provider.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
@@ -58,8 +59,8 @@ public class JUnit58Provider extends AbstractJUnitProvider {
     }
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
-        return super.isEnabled(testBundleClassPath, surefireProperties)
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+        return super.isEnabled(project, testBundleClassPath, surefireProperties)
                 && !new JUnit47Provider().containsJunitInClasspath(testBundleClassPath);
     }
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit58WithVintageProvider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit58WithVintageProvider.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
@@ -58,8 +59,8 @@ public class JUnit58WithVintageProvider extends AbstractJUnitProvider {
     }
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
-        return super.isEnabled(testBundleClassPath, surefireProperties)
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+        return super.isEnabled(project, testBundleClassPath, surefireProperties)
                 && new JUnit47Provider().containsJunitInClasspath(testBundleClassPath);
     }
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit59Provider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit59Provider.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
@@ -58,8 +59,8 @@ public class JUnit59Provider extends AbstractJUnitProvider {
     }
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
-        return super.isEnabled(testBundleClassPath, surefireProperties)
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+        return super.isEnabled(project, testBundleClassPath, surefireProperties)
                 && !new JUnit47Provider().containsJunitInClasspath(testBundleClassPath);
     }
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit59WithVintageProvider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit59WithVintageProvider.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
@@ -58,8 +59,8 @@ public class JUnit59WithVintageProvider extends AbstractJUnitProvider {
     }
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
-        return super.isEnabled(testBundleClassPath, surefireProperties)
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+        return super.isEnabled(project, testBundleClassPath, surefireProperties)
                 && new JUnit47Provider().containsJunitInClasspath(testBundleClassPath);
     }
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/NoopTestFrameworkProvider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/NoopTestFrameworkProvider.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
 import org.osgi.framework.Version;
@@ -39,7 +40,7 @@ public final class NoopTestFrameworkProvider implements TestFrameworkProvider {
     }
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties providerProperties) {
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties providerProperties) {
         return false;
     }
 

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/ProviderHelper.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/ProviderHelper.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.tycho.ClasspathEntry;
@@ -42,8 +43,8 @@ public class ProviderHelper {
 
     private static final Comparator<TestFrameworkProvider> VERSION_COMPARATOR = (p1, p2) -> p1.getVersion().compareTo(p2.getVersion());
 
-    public TestFrameworkProvider selectProvider(List<ClasspathEntry> classpath, Properties providerProperties,
-            String providerHint) throws MojoExecutionException {
+    public TestFrameworkProvider selectProvider(MavenProject project, List<ClasspathEntry> classpath,
+            Properties providerProperties, String providerHint) throws MojoExecutionException {
         if (providerHint != null) {
             TestFrameworkProvider provider = providers.get(providerHint);
             if (provider == null) {
@@ -55,7 +56,7 @@ public class ProviderHelper {
         }
         List<TestFrameworkProvider> candidates = new ArrayList<>();
         for (TestFrameworkProvider provider : providers.values()) {
-            if (provider.isEnabled(classpath, providerProperties)) {
+            if (provider.isEnabled(project, classpath, providerProperties)) {
                 candidates.add(provider);
             }
         }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/TestNGProvider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/TestNGProvider.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ClasspathEntry;
@@ -47,7 +48,7 @@ public class TestNGProvider implements TestFrameworkProvider {
     }
 
     @Override
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
         for (ClasspathEntry classpathEntry : testBundleClassPath) {
             ArtifactKey artifactKey = classpathEntry.getArtifactKey();
             if (TESTNG_BSN.equals(artifactKey.getId())) {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/spi/TestFrameworkProvider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/spi/TestFrameworkProvider.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.ClasspathEntry;
 import org.osgi.framework.Version;
@@ -48,13 +49,13 @@ public interface TestFrameworkProvider {
     /**
      * Whether this provider should be enabled for the given test bundle classpath and surefire
      * properties.
-     * 
+     * @param project TODO
      * @param testBundleClassPath
      *            classpath of the test bundle
      * @param providerProperties
      *            surefire provider properties
      */
-    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties providerProperties);
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties providerProperties);
 
     /**
      * The list of OSGi bundles required by the test framework provider as maven artifacts. The

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/Junit3ProviderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/Junit3ProviderTest.java
@@ -24,16 +24,16 @@ public class Junit3ProviderTest extends AbstractJUnitProviderTest {
 
     @Test
     public void testEnabled() throws Exception {
-        assertTrue(junitProvider.isEnabled(classPath("org.junit:3.8.0"), new Properties()));
-        assertTrue(junitProvider.isEnabled(classPath("org.junit:3.8.0", "org.junit:4.5.0"), new Properties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit:3.8.0"), new Properties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit:3.8.0", "org.junit:4.5.0"), new Properties()));
     }
 
     @Test
     public void testDisabled() throws Exception {
-        assertFalse(junitProvider.isEnabled(classPath("foo:1.0"), new Properties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit:4.0.0"), new Properties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit:3.7"), new Properties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit4:3.8"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("foo:1.0"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:4.0.0"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:3.7"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit4:3.8"), new Properties()));
     }
 
     @Override

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/Junit47ProviderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/Junit47ProviderTest.java
@@ -24,20 +24,21 @@ public class Junit47ProviderTest extends AbstractJUnitProviderTest {
 
     @Test
     public void testEnabled() throws Exception {
-        assertTrue(junitProvider.isEnabled(classPath("org.junit:4.7"), parallelProperties()));
-        assertTrue(junitProvider.isEnabled(classPath("org.junit4:4.8.1"), parallelProperties()));
-        assertTrue(junitProvider.isEnabled(classPath("org.junit:3.8.2", "org.junit:4.7.0"), parallelProperties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit:4.7"), parallelProperties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit4:4.8.1"), parallelProperties()));
+        assertTrue(
+                junitProvider.isEnabled(null, classPath("org.junit:3.8.2", "org.junit:4.7.0"), parallelProperties()));
     }
 
     @Test
     public void testDisabled() throws Exception {
-        assertFalse(junitProvider.isEnabled(classPath(), parallelProperties()));
-        assertFalse(junitProvider.isEnabled(classPath("foo:1.0"), parallelProperties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit:3.8.2"), parallelProperties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit:4.5.0"), parallelProperties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit:5.0"), parallelProperties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit4:5.1"), parallelProperties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit:4.8.1"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath(), parallelProperties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("foo:1.0"), parallelProperties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:3.8.2"), parallelProperties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:4.5.0"), parallelProperties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:5.0"), parallelProperties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit4:5.1"), parallelProperties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:4.8.1"), new Properties()));
     }
 
     private Properties parallelProperties() {

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/Junit4ProviderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/Junit4ProviderTest.java
@@ -24,18 +24,18 @@ public class Junit4ProviderTest extends AbstractJUnitProviderTest {
 
     @Test
     public void testEnabled() throws Exception {
-        assertTrue(junitProvider.isEnabled(classPath("org.junit:4.0"), new Properties()));
-        assertTrue(junitProvider.isEnabled(classPath("org.junit4:4.8.1"), new Properties()));
-        assertTrue(junitProvider.isEnabled(classPath("org.junit:3.8.2", "org.junit:4.5.0"), new Properties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit:4.0"), new Properties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit4:4.8.1"), new Properties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit:3.8.2", "org.junit:4.5.0"), new Properties()));
     }
 
     @Test
     public void testDisabled() throws Exception {
-        assertFalse(junitProvider.isEnabled(classPath(), new Properties()));
-        assertFalse(junitProvider.isEnabled(classPath("foo:1.0"), new Properties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit:3.8.2"), new Properties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit:5.0"), new Properties()));
-        assertFalse(junitProvider.isEnabled(classPath("org.junit4:5.1"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath(), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("foo:1.0"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:3.8.2"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:5.0"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit4:5.1"), new Properties()));
     }
 
     @Override

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/ProviderHelperTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/ProviderHelperTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
@@ -53,15 +54,15 @@ public class ProviderHelperTest extends TychoPlexusTestCase {
 
     @Test
     public void testSelectJunit3() throws Exception {
-        TestFrameworkProvider provider = providerHelper.selectProvider(classPath("org.junit:3.8"), new Properties(),
-                null);
+        TestFrameworkProvider provider = providerHelper.selectProvider(null, classPath("org.junit:3.8"),
+                new Properties(), null);
         assertEquals(JUnit3Provider.class, provider.getClass());
     }
 
     @Test
     public void testSelectJunit4() throws Exception {
-        TestFrameworkProvider provider = providerHelper.selectProvider(classPath("org.junit:4.8.1"), new Properties(),
-                null);
+        TestFrameworkProvider provider = providerHelper.selectProvider(null, classPath("org.junit:4.8.1"),
+                new Properties(), null);
         assertEquals(JUnit4Provider.class, provider.getClass());
     }
 
@@ -69,63 +70,63 @@ public class ProviderHelperTest extends TychoPlexusTestCase {
     public void testSelectJunit47() throws Exception {
         Properties providerProperties = new Properties();
         providerProperties.setProperty("parallel", "classes");
-        TestFrameworkProvider provider = providerHelper.selectProvider(classPath("org.junit:3.8.2", "org.junit4:4.8.1"),
-                providerProperties, null);
+        TestFrameworkProvider provider = providerHelper.selectProvider(null,
+                classPath("org.junit:3.8.2", "org.junit4:4.8.1"), providerProperties, null);
         assertEquals(JUnit47Provider.class, provider.getClass());
     }
 
     @Test
     public void testSelectJunit5WithJUnitFromOrbit() throws Exception {
-        TestFrameworkProvider provider = providerHelper.selectProvider(classPath("org.junit.jupiter.api:5.0.0"),
+        TestFrameworkProvider provider = providerHelper.selectProvider(null, classPath("org.junit.jupiter.api:5.0.0"),
                 new Properties(), null);
         assertEquals(JUnit5Provider.class, provider.getClass());
     }
 
     @Test
     public void testSelectJunit5() throws Exception {
-        TestFrameworkProvider provider = providerHelper.selectProvider(classPath("junit-jupiter-api:5.0.0"),
+        TestFrameworkProvider provider = providerHelper.selectProvider(null, classPath("junit-jupiter-api:5.0.0"),
                 new Properties(), null);
         assertEquals(JUnit5Provider.class, provider.getClass());
     }
 
     @Test
     public void testSelectJunit5WithJUnit4Present() throws Exception {
-        TestFrameworkProvider provider = providerHelper
-                .selectProvider(classPath("org.junit:4.12", "org.junit.jupiter.api:5.0.0"), new Properties(), null);
+        TestFrameworkProvider provider = providerHelper.selectProvider(null,
+                classPath("org.junit:4.12", "org.junit.jupiter.api:5.0.0"), new Properties(), null);
         assertEquals(JUnit5Provider.class, provider.getClass());
     }
 
     @Test
     public void testSelectJunit4WithJunit3Present() throws Exception {
-        TestFrameworkProvider provider = providerHelper.selectProvider(classPath("org.junit:3.8.1", "org.junit:4.8.1"),
-                new Properties(), null);
+        TestFrameworkProvider provider = providerHelper.selectProvider(null,
+                classPath("org.junit:3.8.1", "org.junit:4.8.1"), new Properties(), null);
         assertEquals(JUnit4Provider.class, provider.getClass());
     }
 
     @Test
     public void testForceJunit3WithHint() throws Exception {
-        TestFrameworkProvider provider = providerHelper.selectProvider(classPath("org.junit:3.8.1", "org.junit:4.8.1"),
-                new Properties(), "junit3");
+        TestFrameworkProvider provider = providerHelper.selectProvider(null,
+                classPath("org.junit:3.8.1", "org.junit:4.8.1"), new Properties(), "junit3");
         assertEquals(JUnit3Provider.class, provider.getClass());
     }
 
     @Test
     public void testSelectTestNG() throws Exception {
-        TestFrameworkProvider provider = providerHelper.selectProvider(classPath("org.testng:6.9.12"), new Properties(),
-                null);
+        TestFrameworkProvider provider = providerHelper.selectProvider(null, classPath("org.testng:6.9.12"),
+                new Properties(), null);
         assertEquals(TestNGProvider.class, provider.getClass());
     }
 
     @Test
     public void testSelectWithNonExistingHint() {
         assertThrows(MojoExecutionException.class,
-                () -> providerHelper.selectProvider(classPath(), new Properties(), "NON_EXISTING"));
+                () -> providerHelper.selectProvider(null, classPath(), new Properties(), "NON_EXISTING"));
     }
 
     @Test
     public void testNoProviderFound() {
         assertThrows(MojoExecutionException.class,
-                () -> providerHelper.selectProvider(classPath("foo:1.0", "test:2.0"), new Properties(), null));
+                () -> providerHelper.selectProvider(null, classPath("foo:1.0", "test:2.0"), new Properties(), null));
     }
 
     @Test
@@ -133,7 +134,7 @@ public class ProviderHelperTest extends TychoPlexusTestCase {
         Properties providerProperties = new Properties();
         providerProperties.setProperty("parallel", "methods");
         assertThrows(MojoExecutionException.class,
-                () -> providerHelper.selectProvider(classPath("org.junit:4.6"), providerProperties, null));
+                () -> providerHelper.selectProvider(null, classPath("org.junit:4.6"), providerProperties, null));
     }
 
     @Test
@@ -141,7 +142,7 @@ public class ProviderHelperTest extends TychoPlexusTestCase {
         TestFrameworkProvider anotherProvider = new TestFrameworkProvider() {
 
             @Override
-            public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
+            public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath, Properties surefireProperties) {
                 return true;
             }
 
@@ -175,7 +176,7 @@ public class ProviderHelperTest extends TychoPlexusTestCase {
         ProviderHelper providerSelector = container.lookup(ProviderHelper.class);
         try {
             assertThrows(MojoExecutionException.class,
-                    () -> providerSelector.selectProvider(classPath("org.junit:4.8.1"), new Properties(), null));
+                    () -> providerSelector.selectProvider(null, classPath("org.junit:4.8.1"), new Properties(), null));
         } finally {
             container.release(anotherProvider);
         }


### PR DESCRIPTION
Currently the JUnit providers are only able to detect if the resolved OSGi dependencies contain the junit version but a dependency can also be declared in the pom.xml dependencies.

This adds a very simply first approach to find the junit dependencies in the maven artifacts as well.