### PR TITLE
Support alternative bundle location in P2GeneratorImpl

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/publisher/BundleDependenciesAction.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/publisher/BundleDependenciesAction.java
@@ -48,8 +48,8 @@ public class BundleDependenciesAction extends BundlesAction {
      */
     private final OptionalResolutionAction optionalAction;
 
-    public BundleDependenciesAction(File location, OptionalResolutionAction optionalAction) {
-        super(new File[] { location });
+    public BundleDependenciesAction(BundleDescription description, OptionalResolutionAction optionalAction) {
+        super(new BundleDescription[] { description });
         this.optionalAction = optionalAction;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -485,9 +485,11 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
         for (ProjectClasspathEntry entry : pdeProject.getClasspathEntries()) {
             if (entry instanceof LibraryClasspathEntry libraryClasspathEntry) {
                 File path = libraryClasspathEntry.getLibraryPath();
-                classpath.add(new DefaultClasspathEntry(null,
-                        readOrCreateArtifactKey(path, () -> new DefaultArtifactKey("jar", path.getAbsolutePath())),
-                        Collections.singletonList(path), null));
+                if (path.exists()) {
+                    classpath.add(new DefaultClasspathEntry(null,
+                            readOrCreateArtifactKey(path, () -> new DefaultArtifactKey("jar", path.getAbsolutePath())),
+                            Collections.singletonList(path), null));
+                }
             }
         }
         //Fragments are like embedded dependencies...


### PR DESCRIPTION
Currently P2GeneratorImpl only supports the default location, this adds support for BUNDLE_ROOT and resource located manifests.