### PR TITLE
Add includeAllSources to target-platform-configuration

### DIFF
--- a/tycho-embedder-api/META-INF/MANIFEST.MF
+++ b/tycho-embedder-api/META-INF/MANIFEST.MF
@@ -1,0 +1,23 @@
+Manifest-Version: 1.0
+Bnd-LastModified: 1664886812981
+Build-Jdk-Spec: 18
+Bundle-Description: Tycho integrates Maven with Eclipse and OSGi
+Bundle-DocURL: https://www.eclipse.org/
+Bundle-License: https://www.eclipse.org/legal/epl-v20.html
+Bundle-ManifestVersion: 2
+Bundle-Name: Tycho Embedder API
+Bundle-SymbolicName: org.eclipse.tycho.embedder-api
+Bundle-Vendor: Eclipse Foundation
+Bundle-Version: 3.1.0.SNAPSHOT
+Created-By: Apache Maven Bundle Plugin 5.1.8
+Export-Package: org.eclipse.tycho.build;version="0.11.0";uses:="org.apac
+ he.maven.execution,org.apache.maven.plugin,org.apache.maven.project",or
+ g.eclipse.tycho.classpath;version="0.11.0";uses:="org.apache.maven.plug
+ in,org.eclipse.tycho",org.eclipse.tycho.resolver;version="0.11.0";uses:
+ ="org.apache.maven.execution,org.apache.maven.project,org.eclipse.tycho
+ ",org.eclipse.tycho.runtime;version="0.11.0"
+Import-Package: java.io,java.lang,java.util,org.apache.maven.execution,o
+ rg.apache.maven.plugin,org.apache.maven.project,org.eclipse.tycho;versi
+ on="[3.1,4)"
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
+Tool: Bnd-6.3.1.202206071316

--- a/tycho-its/projects/p2Repository.includeAllSources/Maven.target
+++ b/tycho-its/projects/p2Repository.includeAllSources/Maven.target
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="Maven" sequenceNumber="1">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/eclipse/updates/4.25/R-4.25-202208311800"/>
+			<unit id="org.apache.batik.css" version="0.0.0"/>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/p2Repository.includeAllSources/category.xml
+++ b/tycho-its/projects/p2Repository.includeAllSources/category.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <bundle id="org.apache.batik.css"/>
+</site>

--- a/tycho-its/projects/p2Repository.includeAllSources/pom.xml
+++ b/tycho-its/projects/p2Repository.includeAllSources/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.tycho.test</groupId>
+	<artifactId>testIncludeAllSources</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>eclipse-repository</packaging>
+	<properties>
+		<tycho.version>4.0.0-SNAPSHOT</tycho.version>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<target>
+						<file>Maven.target</file>
+					</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<compress>false</compress>
+					<includeAllDependencies>true</includeAllDependencies>
+					<includeAllSources>true</includeAllSources>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/IncludeAllSourcesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/IncludeAllSourcesTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.test.p2Repository;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.eclipse.tycho.test.util.P2RepositoryTool;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class IncludeAllSourcesTest extends AbstractTychoIntegrationTest {
+
+	private static Verifier verifier;
+	private static P2RepositoryTool p2Repo;
+
+	@BeforeClass
+	public static void executeBuild() throws Exception {
+		verifier = new IncludeAllSourcesTest().getVerifier("/p2Repository.includeAllSources", false);
+		verifier.executeGoal("verify");
+		// Missing source should never trigger an error
+		verifier.verifyErrorFreeLog();
+		p2Repo = P2RepositoryTool.forEclipseRepositoryModule(new File(verifier.getBasedir()));
+	}
+
+	@Test
+	public void testSourceInclusionDirectlyReferenced() throws Exception {
+		assertNotNull(p2Repo.getUniqueIU("org.apache.batik.css.source"));
+	}
+
+	@Test
+	public void testSourceInclusionTransitiveDeps() throws Exception {
+		assertNotNull(p2Repo.getUniqueIU("org.w3c.css.sac.source"));
+	}
+
+	@Test(expected = AssertionError.class)
+	public void testAllowMissingSource() throws Exception {
+		p2Repo.getUniqueIU("org.apache.commons.commons-io.source");
+	}
+}

--- a/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -25,12 +26,18 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.DefaultArtifactKey;
+import org.eclipse.tycho.DependencyResolutionException;
+import org.eclipse.tycho.IllegalArtifactReferenceException;
 import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.DependencyResolver;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.osgitools.EclipseRepositoryProject;
 import org.eclipse.tycho.core.resolver.shared.DependencySeed;
+import org.eclipse.tycho.core.resolver.target.P2TargetPlatform;
 import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.model.Category;
 import org.eclipse.tycho.p2.tools.DestinationRepositoryDescriptor;
@@ -38,6 +45,7 @@ import org.eclipse.tycho.p2.tools.FacadeException;
 import org.eclipse.tycho.p2.tools.RepositoryReference;
 import org.eclipse.tycho.p2.tools.RepositoryReferences;
 import org.eclipse.tycho.p2.tools.mirroring.facade.MirrorApplicationService;
+import org.eclipse.tycho.p2resolver.P2DependencyResolver;
 import org.eclipse.tycho.p2tools.RepositoryReferenceTool;
 
 /**
@@ -193,6 +201,9 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
     @Component(role = TychoProject.class, hint = PackagingType.TYPE_ECLIPSE_REPOSITORY)
     private EclipseRepositoryProject eclipseRepositoryProject;
 
+    @Component(role = DependencyResolver.class, hint = P2DependencyResolver.ROLE_HINT)
+    private DependencyResolver dependencyResolver;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         synchronized (LOCK) {
@@ -206,6 +217,28 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
                 if (projectSeeds.isEmpty()) {
                     getLog().warn("No content specified for p2 repository");
                     return;
+                }
+                if (includeAllSources && TychoProjectUtils
+                        .getTargetPlatform(getReactorProject()) instanceof P2TargetPlatform p2TargetPlatform) {
+                    TychoProjectUtils.getDependencyArtifacts(getReactorProject()).getArtifacts().stream()
+                            .flatMap(dep -> dep.getInstallableUnits().stream()).map(iu -> {
+                                String sourceId = iu.getId().endsWith(".feature.group")
+                                        ? iu.getId().replaceAll(".feature.group", ".source")
+                                        : iu.getId() + ".source";
+                                String sourceType = iu.getId().endsWith(".feature.group")
+                                        ? ArtifactType.TYPE_ECLIPSE_FEATURE
+                                        : ArtifactType.TYPE_ECLIPSE_PLUGIN;
+                                try {
+                                    return new DependencySeed(sourceType, sourceId,
+                                            p2TargetPlatform.resolveUnit(sourceType, sourceId, iu.getVersion()));
+                                } catch (DependencyResolutionException | IllegalArtifactReferenceException e) {
+                                    return null;
+                                }
+                            }).filter(Objects::nonNull) //
+                            .filter(sourceBundleSeed -> p2TargetPlatform.getArtifactLocation(
+                                    new DefaultArtifactKey(sourceBundleSeed.getType(), sourceBundleSeed.getId(),
+                                            sourceBundleSeed.getInstallableUnit().getVersion().toString())) != null)
+                            .forEach(projectSeeds::add);
                 }
 
                 reactorProject.setContextValue(TychoConstants.CTX_METADATA_ARTIFACT_LOCATION, categoriesDirectory);


### PR DESCRIPTION
For includeAllSources to work as expected during assemble-repository, the sources must first be included in the resolution. An includeAllSources flag is added to target-platform-configuration to instruct Tycho to add into resulting resolved TP all available source bundles it's aware of from the dependency sources.