### PR TITLE
Rename AbstractTestMojo to clarify that it is Eclipse based testing

### DIFF
--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -111,7 +111,7 @@ import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
 import org.eclipse.tycho.surefire.provisioning.ProvisionedInstallationBuilder;
 import org.eclipse.tycho.surefire.provisioning.ProvisionedInstallationBuilderFactory;
 
-public abstract class AbstractTestMojo extends AbstractMojo {
+public abstract class AbstractEclipseTestMojo extends AbstractMojo {
 
     private static final String SYSTEM_JDK = "jdk";
 
@@ -724,7 +724,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
             reactorProject.setContextValue(TychoConstants.CTX_METADATA_ARTIFACT_LOCATION, metadataDirectory);
 
             EquinoxInstallation equinoxTestRuntime;
-            synchronized (AbstractTestMojo.class) {
+            synchronized (AbstractEclipseTestMojo.class) {
                 if ("p2Installed".equals(testRuntime)) {
                     equinoxTestRuntime = createProvisionedInstallation();
                 } else if ("default".equals(testRuntime)) {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TestPluginMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TestPluginMojo.java
@@ -41,7 +41,7 @@ import org.eclipse.tycho.PackagingType;
  * </p>
  */
 @Mojo(name = "test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
-public class TestPluginMojo extends AbstractTestMojo {
+public class TestPluginMojo extends AbstractEclipseTestMojo {
 
     /**
      * The directory containing generated test classes of the project being tested.

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
@@ -79,7 +79,7 @@ import aQute.bnd.osgi.Jar;
  * tools that already work with maven-surefire-plugin (e.g. CI servers).
  */
 @Mojo(name = "plugin-test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
-public class TychoIntegrationTestMojo extends AbstractTestMojo {
+public class TychoIntegrationTestMojo extends AbstractEclipseTestMojo {
     /**
      * The directory containing generated test classes of the project being tested.
      */

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
@@ -39,7 +39,7 @@ public class TestMojoTest {
 
     @Test
     public void testSplitArgLineNull() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         String[] parts = testMojo.splitArgLine(null);
         assertNotNull(parts);
         assertEquals(0, parts.length);
@@ -47,7 +47,7 @@ public class TestMojoTest {
 
     @Test
     public void testSplitArgLineMultipleArgs() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         String[] parts = testMojo.splitArgLine(" -Dfoo=bar -Dkey2=value2 \"-Dkey3=spacy value\"");
         assertEquals(3, parts.length);
         assertEquals("-Dfoo=bar", parts[0]);
@@ -57,7 +57,7 @@ public class TestMojoTest {
 
     @Test
     public void testSplitArgLineUnbalancedQuotes() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         try {
             testMojo.splitArgLine("\"'missing closing double-quote'");
             fail("unreachable code");
@@ -69,7 +69,7 @@ public class TestMojoTest {
     @Test
     public void testAddProgramArgsWithSpaces() throws Exception {
         EquinoxLaunchConfiguration cli = createEquinoxConfiguration();
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         testMojo.addProgramArgs(cli, "-data", "/path with spaces ");
         assertEquals(2, cli.getProgramArguments().length);
         assertEquals("-data", cli.getProgramArguments()[0]);
@@ -79,7 +79,7 @@ public class TestMojoTest {
     @Test
     public void testAddProgramArgsNullArg() throws Exception {
         EquinoxLaunchConfiguration cli = createEquinoxConfiguration();
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         // null arg must be ignored
         testMojo.addProgramArgs(cli, "-data", null);
         assertEquals(1, cli.getProgramArguments().length);
@@ -87,27 +87,27 @@ public class TestMojoTest {
 
     @Test
     public void testShouldSkipWithNoValueSet() {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         assertFalse(testMojo.shouldSkip());
     }
 
     @Test
     public void testShouldSkipWithSkipTestsSetToTrue() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "skipTests", Boolean.TRUE);
         assertTrue(testMojo.shouldSkip());
     }
 
     @Test
     public void testShouldSkipWithMavenTestSkipSetToTrue() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "skip", Boolean.TRUE);
         assertTrue(testMojo.shouldSkip());
     }
 
     @Test
     public void testShouldSkipThatSkipTestsWillBePrefered() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "skip", Boolean.FALSE);
         setParameter(testMojo, "skipTests", Boolean.TRUE);
         assertTrue(testMojo.shouldSkip());
@@ -115,7 +115,7 @@ public class TestMojoTest {
 
     @Test
     public void testShouldSkipWithSkipExeSetToTrue() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "skipExec", Boolean.TRUE);
         assertTrue(testMojo.shouldSkip());
     }
@@ -143,7 +143,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeMissingThreadCountParameter() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         try {
             testMojo.getMergedProviderProperties();
@@ -155,7 +155,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeThreadCountSetTo1() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "threadCount", 1);
         try {
@@ -168,7 +168,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeWithThreadCountSet() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "threadCount", 2);
         Properties providerProperties = testMojo.getMergedProviderProperties();
@@ -178,7 +178,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeWithUseUnlimitedThreads() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "useUnlimitedThreads", Boolean.TRUE);
         Properties providerProperties = testMojo.getMergedProviderProperties();
@@ -188,7 +188,7 @@ public class TestMojoTest {
 
     @Test(expected = MojoExecutionException.class)
     public void testParallelModeWithPerCoreThreadCountMissingCount() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "perCoreThreadCount", true);
         testMojo.getMergedProviderProperties();
@@ -196,7 +196,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeWithPerCoreThreadCount() throws Exception {
-        AbstractTestMojo testMojo = new TestPluginMojo();
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "perCoreThreadCount", true);
         setParameter(testMojo, "threadCount", 1);
@@ -209,7 +209,7 @@ public class TestMojoTest {
     public ScanResult createDirectoryAndScanForTests(List<String> includes, List<String> excludes) throws Exception {
         File directory = null;
         try {
-            AbstractTestMojo testMojo = new TestPluginMojo();
+            AbstractEclipseTestMojo testMojo = new TestPluginMojo();
             directory = Files.createTempDirectory(this.getClass().getName()).toFile();
             File aTestFile = new File(directory, "ATest.class");
             aTestFile.createNewFile();

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoToolchainTests.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoToolchainTests.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class TestMojoToolchainTests {
 
     private ToolchainManager toolchainManager;
-    private AbstractTestMojo testMojo;
+    private AbstractEclipseTestMojo testMojo;
     private MavenSession session;
     private MavenProject project;
     private DefaultJavaToolChain breeToolchain;


### PR DESCRIPTION
This will allow to later have a real AbstractTestMojo that only has the basic properties to support other implementations.