### PR TITLE
Improve Oomph setup

### DIFF
--- a/setup/Tycho.setup
+++ b/setup/Tycho.setup
@@ -168,8 +168,8 @@
     <workingSet
         name="Tycho">
       <predicate
-          xsi:type="predicates:LocationPredicate"
-          pattern=".*tycho.*"/>
+          xsi:type="predicates:RepositoryPredicate"
+          project="tycho-core"/>
     </workingSet>
   </setupTask>
   <setupTask


### PR DESCRIPTION
The working set wrongly matched everything that would be in "dev\tycho\git\foo.git", as I noticed when I created an additional clone of the Maven sources.