### PR TITLE
Respect -ntp argument of Maven

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/DefaultTransportCacheConfig.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/DefaultTransportCacheConfig.java
@@ -21,6 +21,7 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
+import org.eclipse.aether.transfer.TransferListener;
 
 @Component(role = TransportCacheConfig.class)
 public class DefaultTransportCacheConfig implements TransportCacheConfig, Initializable {
@@ -46,11 +47,19 @@ public class DefaultTransportCacheConfig implements TransportCacheConfig, Initia
 			offline = session.isOffline();
 			repoDir = new File(session.getLocalRepository().getBasedir());
 			update = session.getRequest().isUpdateSnapshots();
-			interactive = session.getRequest().isInteractiveMode();
+			interactive = session.getRequest().isInteractiveMode() && showTransferProgress(session);
 		}
 
 		cacheLocation = new File(repoDir, ".cache/tycho");
 		cacheLocation.mkdirs();
+	}
+
+	private boolean showTransferProgress(MavenSession session) {
+		// TODO request the -ntp flag to be made available explicitly in
+		// MavenExecutionRequest
+		TransferListener transferListener = session.getRequest().getTransferListener();
+		return transferListener == null
+				|| !"QuietMavenTransferListener".equals(transferListener.getClass().getSimpleName());
 	}
 
 	@Override


### PR DESCRIPTION
If the -ntp argument is present, MavenCli creates a new instance of QuietMavenTransferListener, which is just a concrete version of the abstract super class, with no code added.

Since there is no explicit flag in MavenExecutionRequest, we can only check for the class name as workaround.