### PR TITLE
Use bundled version of JUnit4

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/MavenArtifactKey.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/MavenArtifactKey.java
@@ -28,6 +28,10 @@ public interface MavenArtifactKey extends ArtifactKey {
      */
     String getArtifactId();
 
+    static MavenArtifactKey bundle(String id, String version, String groupId, String artifactId) {
+        return of(PackagingType.TYPE_ECLIPSE_PLUGIN, id, version, groupId, artifactId);
+    }
+
     static MavenArtifactKey of(String type, String id, String version, String groupId, String artifactId) {
         return new MavenArtifactKey() {
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/dotClasspath/ClasspathParser.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/dotClasspath/ClasspathParser.java
@@ -188,15 +188,11 @@ public class ClasspathParser implements Disposable {
         @Override
         public Collection<MavenArtifactKey> getArtifacts() {
             if (JUNIT3.equals(junit)) {
-                return Arrays.asList(JUNIT3_PLUGIN);
+                return JUNIT3_PLUGINS;
             } else if (JUNIT4.equals(junit)) {
-                return Arrays.asList(JUNIT4_PLUGIN, HAMCREST_CORE_PLUGIN);
+                return JUNIT4_PLUGINS;
             } else if (JUNIT5.equals(junit)) {
-                return Arrays.asList(JUNIT_JUPITER_API_PLUGIN, JUNIT_JUPITER_ENGINE_PLUGIN,
-                        JUNIT_JUPITER_MIGRATIONSUPPORT_PLUGIN, JUNIT_JUPITER_PARAMS_PLUGIN,
-                        JUNIT_PLATFORM_COMMONS_PLUGIN, JUNIT_PLATFORM_ENGINE_PLUGIN, JUNIT_PLATFORM_LAUNCHER_PLUGIN,
-                        JUNIT_PLATFORM_RUNNER_PLUGIN, JUNIT_PLATFORM_SUITE_API_PLUGIN, JUNIT_VINTAGE_ENGINE_PLUGIN,
-                        JUNIT_OPENTEST4J_PLUGIN, JUNIT_APIGUARDIAN_PLUGIN, JUNIT4_PLUGIN, HAMCREST_CORE_PLUGIN);
+                return JUNIT5_PLUGINS;
             }
             return Collections.emptyList();
         }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/dotClasspath/JUnitClasspathContainerEntry.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/dotClasspath/JUnitClasspathContainerEntry.java
@@ -13,6 +13,7 @@
 package org.eclipse.tycho.core.dotClasspath;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.MavenArtifactKey;
@@ -26,10 +27,10 @@ public interface JUnitClasspathContainerEntry extends ClasspathContainerEntry {
     static final String JUNIT5 = "5";
 
     static final MavenArtifactKey JUNIT3_PLUGIN = MavenArtifactKey.of(ArtifactType.TYPE_INSTALLABLE_UNIT, "org.junit",
-            "[3.8.2,3.9)", "junit", "junit");
+            "[3.8.2,3.9)", "org.apache.servicemix.bundles", "org.apache.servicemix.bundles.junit");
 
     static final MavenArtifactKey JUNIT4_PLUGIN = MavenArtifactKey.of(ArtifactType.TYPE_INSTALLABLE_UNIT, "org.junit",
-            "[4.13.0,5.0.0)", "junit", "junit");
+            "[4.13.0,5.0.0)", "org.apache.servicemix.bundles", "org.apache.servicemix.bundles.junit");
 
     static final MavenArtifactKey HAMCREST_CORE_PLUGIN = MavenArtifactKey.of(ArtifactType.TYPE_INSTALLABLE_UNIT,
             "org.hamcrest.core", "[1.1.0,2.0.0)", "org.hamcrest", "hamcrest-core");
@@ -73,6 +74,14 @@ public interface JUnitClasspathContainerEntry extends ClasspathContainerEntry {
 
     static final MavenArtifactKey JUNIT_APIGUARDIAN_PLUGIN = MavenArtifactKey.of(ArtifactType.TYPE_INSTALLABLE_UNIT,
             "org.apiguardian.api", "[1.0.0,2.0.0)", "org.apiguardian", "apiguardian-api");
+
+    static final List<MavenArtifactKey> JUNIT3_PLUGINS = List.of(JUNIT3_PLUGIN);
+    static final List<MavenArtifactKey> JUNIT4_PLUGINS = List.of(JUNIT4_PLUGIN, HAMCREST_CORE_PLUGIN);
+    static final List<MavenArtifactKey> JUNIT5_PLUGINS = List.of(JUNIT_JUPITER_API_PLUGIN, JUNIT_JUPITER_ENGINE_PLUGIN,
+            JUNIT_JUPITER_MIGRATIONSUPPORT_PLUGIN, JUNIT_JUPITER_PARAMS_PLUGIN, JUNIT_PLATFORM_COMMONS_PLUGIN,
+            JUNIT_PLATFORM_ENGINE_PLUGIN, JUNIT_PLATFORM_LAUNCHER_PLUGIN, JUNIT_PLATFORM_RUNNER_PLUGIN,
+            JUNIT_PLATFORM_SUITE_API_PLUGIN, JUNIT_VINTAGE_ENGINE_PLUGIN, JUNIT_OPENTEST4J_PLUGIN,
+            JUNIT_APIGUARDIAN_PLUGIN, JUNIT4_PLUGIN, HAMCREST_CORE_PLUGIN);
 
     /**
      * 


### PR DESCRIPTION
Currently the official juni:junit is used, but this is not a bundle, this changes the reference to the servicemix variant of junit that has proper bundle headers.