### PR TITLE
Add a bridge that can transform P2 API into OSGi Resource API

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/resource/ArtifactDescriptorRepositoryContentCapability.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/resource/ArtifactDescriptorRepositoryContentCapability.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.osgi.resource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Resource;
+import org.osgi.service.repository.RepositoryContent;
+
+/**
+ * Implements a {@link Capability} that supply {@link RepositoryContent}
+ */
+public class ArtifactDescriptorRepositoryContentCapability implements Capability, RepositoryContent {
+
+    private IArtifactDescriptor descriptor;
+    private IArtifactRepository artifactRepository;
+    private Map<String, Object> attributes;
+    private Resource resource;
+
+    public ArtifactDescriptorRepositoryContentCapability(Resource resource, IArtifactDescriptor descriptor,
+            IArtifactRepository artifactRepository) {
+        this.resource = resource;
+        this.descriptor = descriptor;
+        this.artifactRepository = artifactRepository;
+//      <capability namespace='osgi.content'>
+//      <attribute name='osgi.content' value='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+//      <attribute name='url' value='http://www.acme.com/repository/org/acme/pool/org.acme.pool-1.5.6.jar'/>
+//      <attribute name='size' type='Long' value='4405'/>
+//      <attribute name='mime' value='application/vnd.osgi.bundle'/>
+//    </capability>
+        HashMap<String, Object> map = new HashMap<>(descriptor.getProperties());
+        String content = descriptor.getProperty(IArtifactDescriptor.DOWNLOAD_CHECKSUM + ".sha-256");
+        if (content != null) {
+            map.put("osgi.content", content);
+        }
+        //TODO can we get the URL from P2?
+        String size = descriptor.getProperty(IArtifactDescriptor.DOWNLOAD_SIZE);
+        if (size != null) {
+            map.put("size", Long.parseLong(size));
+        }
+        String contentType = descriptor.getProperty(IArtifactDescriptor.DOWNLOAD_CONTENTTYPE);
+        if (contentType != null) {
+            map.put("mime", contentType);
+        }
+        this.attributes = Map.copyOf(map);
+    }
+
+    @Override
+    public InputStream getContent() {
+        // TODO can we get this a bit more efficient without copy around?
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        IStatus status = artifactRepository.getArtifact(descriptor, outputStream, null);
+        if (!status.isOK()) {
+            return new InputStream() {
+
+                @Override
+                public int read() throws IOException {
+                    throw new IOException(status.toString(), status.getException());
+                }
+            };
+        }
+        return new ByteArrayInputStream(outputStream.toByteArray());
+    }
+
+    @Override
+    public String getNamespace() {
+        return "osgi.content";
+    }
+
+    @Override
+    public Map<String, String> getDirectives() {
+        return Map.of();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Resource getResource() {
+        return resource;
+    }
+
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/resource/InstallableUnitCapability.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/resource/InstallableUnitCapability.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.osgi.resource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IProvidedCapability;
+import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
+import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
+import org.osgi.framework.Version;
+import org.osgi.framework.namespace.BundleNamespace;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Resource;
+
+/**
+ * Maps an {@link IProvidedCapability} of an {@link IInstallableUnit} to a
+ * <a href="https://docs.osgi.org/specification/osgi.core/8.0.0/framework.resource.html">Resource
+ * API Specification</a> {@link Capability}
+ */
+public class InstallableUnitCapability implements Capability {
+
+    private static final String P2_NS_IDENTITY = "osgi.identity";
+    private IProvidedCapability capability;
+    private InstallableUnitResource resource;
+    private Map<String, Object> attributes;
+    private final String namespace;
+
+    public InstallableUnitCapability(InstallableUnitResource resource, IProvidedCapability capability) {
+        this.resource = resource;
+        this.capability = capability;
+        Map<String, Object> properties = capability.getProperties();
+        Map<String, Object> map = new HashMap<>(properties);
+        String ns = capability.getNamespace();
+        if (PublisherHelper.CAPABILITY_NS_JAVA_PACKAGE.equals(ns)) {
+//      <capability namespace='osgi.wiring.package'>
+//        <attribute name='osgi.wiring.package' value='org.acme.pool'/>
+//        <attribute name='version' type='Version' value='1.1.2'/>
+//        <attribute name='bundle-version' type='Version' value='1.5.6'/>
+//        <attribute name='bundle-symbolic-name' value='org.acme.pool'/>
+//        <directive name='uses' value='org.acme.pool,org.acme.util'/>
+//      </capability>
+            namespace = PackageNamespace.PACKAGE_NAMESPACE;
+            Object packageName = properties.get(PublisherHelper.CAPABILITY_NS_JAVA_PACKAGE);
+            if (packageName instanceof String) {
+                map.put(PackageNamespace.PACKAGE_NAMESPACE, packageName);
+            }
+            map.put(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, new Version(capability.getVersion().toString()));
+            findBundle(resource.installableUnit).ifPresent(bundle -> {
+                Object bundleName = bundle.getProperties().get(BundlesAction.CAPABILITY_NS_OSGI_BUNDLE);
+                if (bundleName instanceof String) {
+                    map.put(PackageNamespace.CAPABILITY_BUNDLE_SYMBOLICNAME_ATTRIBUTE, bundleName);
+                }
+                map.put(BundleNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE,
+                        new Version(bundle.getVersion().toString()));
+            });
+        } else if (BundlesAction.CAPABILITY_NS_OSGI_BUNDLE.equals(ns)) {
+//          <capability namespace='osgi.wiring.bundle'>
+//            <attribute name='osgi.wiring.bundle' value='org.acme.pool'/>
+//            <attribute name='bundle-version' type='Version' value='1.5.6'/>
+//          </capability>
+            namespace = BundleNamespace.BUNDLE_NAMESPACE;
+            Object bundleName = properties.get(BundlesAction.CAPABILITY_NS_OSGI_BUNDLE);
+            if (bundleName instanceof String) {
+                map.put(BundleNamespace.BUNDLE_NAMESPACE, bundleName);
+            }
+            map.put(BundleNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE,
+                    new Version(capability.getVersion().toString()));
+        } else {
+            //generic namespace definition e.g.
+//          <capability namespace='osgi.identity'>
+//            <attribute name='osgi.identity' value='org.acme.pool'/>
+//            <attribute name='version'type='Version' value='1.5.6'/>
+//            <attribute name='type' value='osgi.bundle'/>
+//          </capability>
+            map.put("version", new Version(capability.getVersion().toString()));
+            namespace = IInstallableUnit.NAMESPACE_IU_ID;
+        }
+        this.attributes = Map.copyOf(map);
+    }
+
+    private Optional<IProvidedCapability> findBundle(IInstallableUnit installableUnit) {
+        return installableUnit.getProvidedCapabilities().stream().filter(IProvidedCapability.class::isInstance)
+                .map(IProvidedCapability.class::cast)
+                .filter(cap -> BundlesAction.CAPABILITY_NS_OSGI_BUNDLE.equals(cap.getNamespace())).findFirst();
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public Map<String, String> getDirectives() {
+        return Map.of();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Resource getResource() {
+        return resource;
+    }
+
+    @Override
+    public String toString() {
+        return capability.toString();
+    }
+
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/resource/InstallableUnitRequirement.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/resource/InstallableUnitRequirement.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.osgi.resource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.equinox.internal.p2.metadata.RequiredCapability;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IRequirement;
+import org.eclipse.equinox.p2.metadata.VersionRange;
+import org.eclipse.equinox.p2.metadata.expression.IMatchExpression;
+import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
+import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
+import org.osgi.framework.namespace.BundleNamespace;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.resource.Namespace;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+
+/**
+ * Maps a {@link IRequirement} of an {@link IInstallableUnit} into a
+ * <a href="https://docs.osgi.org/specification/osgi.core/8.0.0/framework.resource.html">Resource
+ * API Specification</a> {@link Requirement}
+ * 
+ */
+public class InstallableUnitRequirement implements Requirement {
+
+    private static final String VERSION_REQUIREMENT_FILTER = "(&(%s=%s)(version%s%s)(!(version%s4.0)))";
+
+    private final InstallableUnitResource resource;
+    private final String namespace;
+    private final Map<String, String> directives;
+
+    private final IRequirement requirement;
+
+    public InstallableUnitRequirement(InstallableUnitResource p2Resource, IRequirement requirement) {
+        this.requirement = requirement;
+        Map<String, String> map = new HashMap<>(2);
+        IMatchExpression<IInstallableUnit> expression = requirement.getMatches();
+        String name = RequiredCapability.extractName(expression);
+        String ns = RequiredCapability.extractNamespace(expression);
+        VersionRange range = RequiredCapability.extractRange(expression);
+        if (PublisherHelper.CAPABILITY_NS_JAVA_PACKAGE.equals(ns)) {
+            this.namespace = PackageNamespace.PACKAGE_NAMESPACE;
+        } else if (BundlesAction.CAPABILITY_NS_OSGI_BUNDLE.equals(ns)) {
+            this.namespace = BundleNamespace.BUNDLE_NAMESPACE;
+        } else {
+            this.namespace = ns;
+        }
+        String filter = String.format(VERSION_REQUIREMENT_FILTER, namespace, name,
+                range.getIncludeMinimum() ? ">=" : ">", range.getMinimum().toString(),
+                range.getIncludeMaximum() ? ">" : ">=", range.getMaximum().toString());
+        map.put(Namespace.REQUIREMENT_FILTER_DIRECTIVE, filter);
+        if (requirement.getMin() == 0) {
+            map.put(Namespace.REQUIREMENT_RESOLUTION_DIRECTIVE, Namespace.RESOLUTION_OPTIONAL);
+        }
+        this.directives = Map.copyOf(map);
+        this.resource = p2Resource;
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public Map<String, String> getDirectives() {
+        return directives;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of();
+    }
+
+    @Override
+    public Resource getResource() {
+        return resource;
+    }
+
+    @Override
+    public String toString() {
+        return requirement.toString();
+    }
+
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/resource/InstallableUnitResource.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/resource/InstallableUnitResource.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.osgi.resource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.equinox.internal.p2.metadata.RequiredCapability;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IProvidedCapability;
+import org.eclipse.equinox.p2.metadata.IRequirement;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+
+/**
+ * Maps an {@link IInstallableUnit} into
+ * <a href="https://docs.osgi.org/specification/osgi.core/8.0.0/framework.resource.html">Resource
+ * API Specification</a> {@link Resource}
+ */
+public class InstallableUnitResource implements Resource {
+
+    IInstallableUnit installableUnit;
+    private final Map<String, List<Requirement>> requirementsMap;
+    private final Map<String, List<Capability>> capabilitiesMap;
+
+    public InstallableUnitResource(IInstallableUnit installableUnit, IArtifactRepository artifactRepository) {
+        this.installableUnit = installableUnit;
+        Collection<IRequirement> requirements = installableUnit.getRequirements();
+        requirementsMap = new HashMap<>(requirements.size());
+        for (IRequirement requirement : requirements) {
+            if (RequiredCapability.isVersionRangeRequirement(requirement.getMatches())) {
+                InstallableUnitRequirement req = new InstallableUnitRequirement(
+                        this, requirement);
+                requirementsMap.computeIfAbsent(req.getNamespace(), nil -> new ArrayList<>()).add(req);
+            }
+        }
+        //TODO <directive name='effective' value='meta'/> for meta requirements?!
+        List<IArtifactDescriptor> artifacts = installableUnit.getArtifacts().stream().flatMap(key -> {
+            IArtifactDescriptor[] descriptors = artifactRepository.getArtifactDescriptors(key);
+            return Arrays.stream(descriptors);
+        }).toList();
+        Collection<IProvidedCapability> capabilities = installableUnit.getProvidedCapabilities();
+        capabilitiesMap = new HashMap<>(capabilities.size() + artifacts.size() + 1);
+        for (IProvidedCapability capability : capabilities) {
+            InstallableUnitCapability cap = new InstallableUnitCapability(InstallableUnitResource.this,
+                    capability);
+            capabilitiesMap.computeIfAbsent(cap.getNamespace(), nil -> new ArrayList<>()).add(cap);
+        }
+        for (IArtifactDescriptor descriptor : artifacts) {
+            ArtifactDescriptorRepositoryContentCapability cap = new ArtifactDescriptorRepositoryContentCapability(this, descriptor, artifactRepository);
+            capabilitiesMap.computeIfAbsent(cap.getNamespace(), nil -> new ArrayList<>()).add(cap);
+        }
+    }
+
+    @Override
+    public List<Capability> getCapabilities(String namespace) {
+        if (namespace != null) {
+            return Collections.unmodifiableList(capabilitiesMap.getOrDefault(namespace, List.of()));
+        }
+        return capabilitiesMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Requirement> getRequirements(String namespace) {
+        if (namespace != null) {
+            return Collections.unmodifiableList(requirementsMap.getOrDefault(namespace, List.of()));
+        }
+        return requirementsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+    }
+
+    @Override
+    public String toString() {
+        return installableUnit.toString();
+    }
+
+}


### PR DESCRIPTION
OSGi defines two specifications:
- Resource API Specification
- Repository Service Specification

that we can map P2 IUs into resources and artifacts into RepsoitoryContent to interact with other services eg the Resolver Service Specification.