### PR TITLE
Ignore some header in the baseline comparison

### DIFF
--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ManifestComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ManifestComparator.java
@@ -39,6 +39,7 @@ public class ManifestComparator implements ContentsComparator {
             new Name("Build-Jdk-Spec"),
             // lets be friendly to bnd/maven-bundle-plugin
             new Name("Bnd-LastModified"), //
+            new Name("Bundle-Developers"), //
             new Name("Tool"),
             // this is common attribute not supported by Tycho yet
             new Name("Eclipse-SourceReferences"));
@@ -88,11 +89,19 @@ public class ManifestComparator implements ContentsComparator {
         Set<Name> result = new LinkedHashSet<>();
         for (Object key : attributes.keySet()) {
             Name name = (Name) key;
-            if (!IGNORED_KEYS.contains(name)) {
+            if (!isIgnoredHeaderName(name)) {
                 result.add(name);
             }
         }
         return result;
+    }
+
+    public static boolean isIgnoredHeaderName(String name) {
+        return IGNORED_KEYS.contains(new Name(name));
+    }
+
+    public static boolean isIgnoredHeaderName(Name name) {
+        return IGNORED_KEYS.contains(name);
     }
 
     @Override

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BundleArtifactBaselineComparator.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BundleArtifactBaselineComparator.java
@@ -48,6 +48,7 @@ import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 import org.eclipse.tycho.artifactcomparator.ComparatorInputStream;
 import org.eclipse.tycho.p2maven.repository.P2RepositoryManager;
 import org.eclipse.tycho.zipcomparator.internal.ContentsComparator;
+import org.eclipse.tycho.zipcomparator.internal.ManifestComparator;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
@@ -318,12 +319,27 @@ public class BundleArtifactBaselineComparator implements ArtifactBaselineCompara
 		if (diff.getDelta() == Delta.UNCHANGED) {
 			return;
 		}
-		if (diff.getType() == Type.HEADER) {
+		if (isValidHeaderDif(diff)) {
 			manifestdiffs.add(diff);
 		}
 		for (Diff child : diff.getChildren()) {
 			collectManifest(child, manifestdiffs);
 		}
+	}
+
+	private boolean isValidHeaderDif(Diff diff) {
+		if (diff.getType() == Type.HEADER) {
+			String name = diff.getName();
+			if (name == null) {
+				return false;
+			}
+			String[] split = name.split(":", 2);
+			if (ManifestComparator.isIgnoredHeaderName(split[0])) {
+				return false;
+			}
+			return true;
+		}
+		return false;
 	}
 
 	private void collectResources(Diff diff, Map<Diff, ArtifactDelta> resourcediffs, Jar baselineJar, Jar projectJar,


### PR DESCRIPTION
Currently some headers (e.g. Build-Jdk-Spec) can cause baseline difference warnings even they do usually not account for a functional change.

This checks if the changed header is in the ignore list and then skip this header for the baseline check.