### PR TITLE
Improve finding the right comparator for baseline comparison

### DIFF
--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/NestedZipComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/NestedZipComparator.java
@@ -48,7 +48,7 @@ public class NestedZipComparator implements ContentsComparator {
 
     @Override
     public boolean matches(String extension) {
-        return TYPE.equalsIgnoreCase(extension);
+        return TYPE.equalsIgnoreCase(extension) || "jar".equalsIgnoreCase(extension) || "war".equalsIgnoreCase(extension);
     }
 
 }

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/PropertiesComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/PropertiesComparator.java
@@ -75,6 +75,8 @@ public class PropertiesComparator implements ContentsComparator {
 
     @Override
     public boolean matches(String extension) {
-        return TYPE.equalsIgnoreCase(extension) || "bnd".equalsIgnoreCase(extension);
+        return TYPE.equalsIgnoreCase(extension) || "bnd".equalsIgnoreCase(extension)
+        // .mapping comes from org.eclipse.equinox.p2.internal.repository.comparator.JarComparator
+                || "mappings".equalsIgnoreCase(extension);
     }
 }


### PR DESCRIPTION
Currently a fixed list of names is checked that needs manual maintenance.

This changes the lookup to a more generic for, where first the extension is looked up directly and if nothing is found all comparators are asked if they match.