### PR TITLE
Document (and fix) content compare detailed unified diff option

### DIFF
--- a/src/site/markdown/SystemProperties.md
+++ b/src/site/markdown/SystemProperties.md
@@ -19,3 +19,10 @@ Name | Value | Documentation
 --- | --- | ---
 tycho.debug.artifactcomparator | _any_ | In `tycho-p2-plugin`, output verbose artifact comparison information during baseline validation
 tycho.debug.resolver | `true` or _artifactId_ | Enable debug output for the artifact resolver for all projects or the project with the given _artifactId_
+
+### Baseline compare
+
+Name | Value | Default | Documentation
+--- | --- | ---
+tycho.comparator.showDiff | true / false | false | If set to true if text-like files show a unified diff of possible differences in files
+tycho.comparator.threshold | bytes | 5242880 (~5MB) | gives the number of bytes for content to be compared semantically, larger files will only be compared byte-by-byte

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ContentsComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ContentsComparator.java
@@ -22,9 +22,10 @@ import org.eclipse.tycho.artifactcomparator.ComparatorInputStream;
 public interface ContentsComparator {
 
     /**
-     * System property that control if a detailed diff is desired or not (default = off)
+     * System property that control if a detailed diff is desired or not, <code>false</code>
+     * (default) = no detailed diff is shown, <code>true</code> show detailed difference.
      */
-    static final boolean NO_DIFF_DETAILS = Boolean.getBoolean("tycho.comparator.noDiff");
+    static final boolean SHOW_DIFF_DETAILS = Boolean.getBoolean("tycho.comparator.showDiff");
 
     /**
      * System property that controls the threshold size where a direct byte compare is performed

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/TextComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/TextComparator.java
@@ -100,22 +100,22 @@ public class TextComparator implements ContentsComparator {
 
     public static ArtifactDelta createDelta(String message, ComparatorInputStream baseline,
             ComparatorInputStream reactor) {
-        if (NO_DIFF_DETAILS) {
-            return ArtifactDelta.DEFAULT;
+        if (SHOW_DIFF_DETAILS) {
+            String detailed;
+            try {
+                List<String> source = IOUtils.readLines(baseline.asNewStream(), StandardCharsets.UTF_8);
+                List<String> target = IOUtils.readLines(reactor.asNewStream(), StandardCharsets.UTF_8);
+                Patch<String> patch = DiffUtils.diff(source, target);
+                List<String> unifiedDiffList = UnifiedDiffUtils.generateUnifiedDiff("baseline", "reactor", source,
+                        patch, 0);
+                detailed = unifiedDiffList.stream().collect(Collectors.joining((System.lineSeparator())));
+            } catch (Exception e) {
+                detailed = message;
+            }
+            return new SimpleArtifactDelta(message, detailed, baseline.asString(StandardCharsets.UTF_8),
+                    reactor.asString(StandardCharsets.UTF_8));
         }
-        String detailed;
-        try {
-            List<String> source = IOUtils.readLines(baseline.asNewStream(), StandardCharsets.UTF_8);
-            List<String> target = IOUtils.readLines(reactor.asNewStream(), StandardCharsets.UTF_8);
-            Patch<String> patch = DiffUtils.diff(source, target);
-            List<String> unifiedDiffList = UnifiedDiffUtils.generateUnifiedDiff("baseline", "reactor", source, patch,
-                    0);
-            detailed = unifiedDiffList.stream().collect(Collectors.joining((System.lineSeparator())));
-        } catch (Exception e) {
-            detailed = message;
-        }
-        return new SimpleArtifactDelta(message, detailed, baseline.asString(StandardCharsets.UTF_8),
-                reactor.asString(StandardCharsets.UTF_8));
+        return ArtifactDelta.DEFAULT;
     }
 
 }


### PR DESCRIPTION
Currently (in contrast to the javadoc) detailed diffs are ON by default.

This changes the name to be less confusing (no NoDiff = false meaning effectively use a diff..) and add it to the documented system properties.

Fix https://github.com/eclipse-tycho/tycho/issues/2006