### PR TITLE
Restore the sideeffect of download and the check that the local repos really contain the artifact.

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/repository/MirroringArtifactProvider.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/repository/MirroringArtifactProvider.java
@@ -174,8 +174,8 @@ public class MirroringArtifactProvider implements IRawArtifactFileProvider {
             return localArtifactRepository.getArtifactDescriptors(key);
         }
         if (remoteProviders.contains(key)) {
-        	//we can use it if the remote contains it, but want to shadow the repository returned by the descriptor
-        	//just in case someone uses this to download an artifact we are asked again...
+            //we can use it if the remote contains it, but want to shadow the repository returned by the descriptor
+            //just in case someone uses this to download an artifact we are asked again...
             return Arrays.stream(remoteProviders.getArtifactDescriptors(key))
                     .map(base -> new MirrorArtifactDescriptor(base, this)).toArray(IArtifactDescriptor[]::new);
         }
@@ -184,6 +184,13 @@ public class MirroringArtifactProvider implements IRawArtifactFileProvider {
 
     @Override
     public final boolean contains(IArtifactDescriptor descriptor) throws MirroringFailedException {
+        if (isContained(descriptor) && makeLocallyAvailable(descriptor.getArtifactKey())) {
+            return localArtifactRepository.contains(descriptor);
+        }
+        return false;
+    }
+
+    private boolean isContained(IArtifactDescriptor descriptor) {
         if (descriptor instanceof MirrorArtifactDescriptor mirrorDescriptor) {
             return mirrorDescriptor.provider == this;
         }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MirroringArtifactProviderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MirroringArtifactProviderTest.java
@@ -185,8 +185,8 @@ public class MirroringArtifactProviderTest extends TychoPlexusTestCase {
     @Test
     public void testContainsCanonicalArtifactDescriptor() {
         assertTrue(subject.contains(canonicalDescriptorFor(BUNDLE_A_KEY)));
-        //this should actually NOT mirror it!
-        assertEquals(0, localRepository.getArtifactDescriptors(BUNDLE_A_KEY).length);
+        //this should actually NOT mirror it! but currently Tycho seems to rely on this...
+        assertEquals(1, localRepository.getArtifactDescriptors(BUNDLE_A_KEY).length);
     }
 
     @Test


### PR DESCRIPTION
@mickaelistria this is just an idea that came into my mind, that probably some code in Tycho relies on the previous sideefect of "contains" downloading (and checking) the artifact, so probably this is a fix for the Platform issues?

FYI @iloveeclipse