### PR TITLE
Add the AbstractApplication / MirrorApplication to Tycho code base

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2011 SAP SE and others.
+ * Copyright (c) 2010, 2023 SAP SE and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,13 +13,11 @@
 package org.eclipse.tycho.p2tools;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -31,12 +29,7 @@ import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.internal.repository.tools.RepositoryDescriptor;
 import org.eclipse.equinox.p2.internal.repository.tools.SlicingOptions;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-import org.eclipse.equinox.p2.metadata.IProvidedCapability;
 import org.eclipse.equinox.p2.metadata.IRequirement;
-import org.eclipse.equinox.p2.metadata.MetadataFactory;
-import org.eclipse.equinox.p2.metadata.MetadataFactory.InstallableUnitDescription;
-import org.eclipse.equinox.p2.metadata.Version;
-import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.equinox.p2.metadata.expression.IMatchExpression;
 import org.eclipse.equinox.p2.query.CollectionResult;
 import org.eclipse.equinox.p2.query.IQueryable;
@@ -50,7 +43,7 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.p2.tools.RepositoryReference;
 
-public class MirrorApplication extends org.eclipse.equinox.p2.internal.repository.tools.MirrorApplication {
+public class MirrorApplication extends org.eclipse.tycho.p2tools.copiedfromp2.MirrorApplication {
 
     private static final String SOURCE_SUFFIX = ".source";
     private final Map<String, String> extraArtifactRepositoryProperties;
@@ -62,8 +55,7 @@ public class MirrorApplication extends org.eclipse.equinox.p2.internal.repositor
 
     public MirrorApplication(IProvisioningAgent agent, Map<String, String> extraArtifactRepositoryProperties,
             List<RepositoryReference> repositoryReferences) {
-        super();
-        this.agent = agent;
+        super(agent);
         this.extraArtifactRepositoryProperties = extraArtifactRepositoryProperties;
         this.repositoryReferences = repositoryReferences;
         this.removeAddedRepositories = false;

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/AbstractApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/AbstractApplication.java
@@ -22,11 +22,9 @@ import java.util.List;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository;
-import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
 import org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository;
 import org.eclipse.equinox.internal.p2.repository.helpers.RepositoryHelper;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
-import org.eclipse.equinox.p2.core.IProvisioningAgentProvider;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.internal.repository.tools.Messages;
 import org.eclipse.equinox.p2.internal.repository.tools.RepositoryDescriptor;
@@ -39,8 +37,6 @@ import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.osgi.util.NLS;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceReference;
 
 public abstract class AbstractApplication {
     protected boolean removeAddedRepositories = true;
@@ -59,43 +55,8 @@ public abstract class AbstractApplication {
 
     protected IProvisioningAgent agent;
 
-    public AbstractApplication() {
-        super();
-        try {
-            setupAgent();
-        } catch (ProvisionException e) {
-            LogHelper.log(e);
-        }
-    }
-
     public AbstractApplication(IProvisioningAgent agent) {
         this.agent = agent;
-    }
-
-    private void setupAgent() throws ProvisionException {
-        // note if we ever wanted these applications to act on a different agent than
-        // the currently running system we would need to set it here
-        BundleContext bundleContext = Activator.getBundleContext();
-        if (bundleContext == null) {
-            return;
-        }
-        ServiceReference<IProvisioningAgent> agentRef = bundleContext.getServiceReference(IProvisioningAgent.class);
-        if (agentRef != null) {
-            agent = bundleContext.getService(agentRef);
-            if (agent != null)
-                return;
-        }
-        // there is no agent around so we need to create one
-        ServiceReference<IProvisioningAgentProvider> providerRef = bundleContext
-                .getServiceReference(IProvisioningAgentProvider.class);
-        if (providerRef == null)
-            throw new RuntimeException("No provisioning agent provider is available"); //$NON-NLS-1$
-        IProvisioningAgentProvider provider = bundleContext.getService(providerRef);
-        if (provider == null)
-            throw new RuntimeException("No provisioning agent provider is available"); //$NON-NLS-1$
-        // obtain agent for currently running system
-        agent = provider.createAgent(null);
-        bundleContext.ungetService(providerRef);
     }
 
     public void setSourceIUs(List<IInstallableUnit> ius) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/AbstractApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/AbstractApplication.java
@@ -1,0 +1,335 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2021 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2tools.copiedfromp2;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository;
+import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
+import org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository;
+import org.eclipse.equinox.internal.p2.repository.helpers.RepositoryHelper;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.IProvisioningAgentProvider;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.internal.repository.tools.Messages;
+import org.eclipse.equinox.p2.internal.repository.tools.RepositoryDescriptor;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.repository.ICompositeRepository;
+import org.eclipse.equinox.p2.repository.IRepository;
+import org.eclipse.equinox.p2.repository.IRepositoryManager;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
+import org.eclipse.osgi.util.NLS;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+public abstract class AbstractApplication {
+    protected boolean removeAddedRepositories = true;
+
+    protected List<RepositoryDescriptor> sourceRepositories = new ArrayList<>(); // List of repository descriptors
+    protected List<URI> artifactReposToRemove = new ArrayList<>();
+    protected List<URI> metadataReposToRemove = new ArrayList<>();
+    protected List<IInstallableUnit> sourceIUs = new ArrayList<>();
+    private List<RepositoryDescriptor> destinationRepos = new ArrayList<>();
+
+    protected IArtifactRepository destinationArtifactRepository = null;
+    protected IMetadataRepository destinationMetadataRepository = null;
+
+    private CompositeMetadataRepository compositeMetadataRepository = null;
+    private CompositeArtifactRepository compositeArtifactRepository = null;
+
+    protected IProvisioningAgent agent;
+
+    public AbstractApplication() {
+        super();
+        try {
+            setupAgent();
+        } catch (ProvisionException e) {
+            LogHelper.log(e);
+        }
+    }
+
+    public AbstractApplication(IProvisioningAgent agent) {
+        this.agent = agent;
+    }
+
+    private void setupAgent() throws ProvisionException {
+        // note if we ever wanted these applications to act on a different agent than
+        // the currently running system we would need to set it here
+        BundleContext bundleContext = Activator.getBundleContext();
+        if (bundleContext == null) {
+            return;
+        }
+        ServiceReference<IProvisioningAgent> agentRef = bundleContext.getServiceReference(IProvisioningAgent.class);
+        if (agentRef != null) {
+            agent = bundleContext.getService(agentRef);
+            if (agent != null)
+                return;
+        }
+        // there is no agent around so we need to create one
+        ServiceReference<IProvisioningAgentProvider> providerRef = bundleContext
+                .getServiceReference(IProvisioningAgentProvider.class);
+        if (providerRef == null)
+            throw new RuntimeException("No provisioning agent provider is available"); //$NON-NLS-1$
+        IProvisioningAgentProvider provider = bundleContext.getService(providerRef);
+        if (provider == null)
+            throw new RuntimeException("No provisioning agent provider is available"); //$NON-NLS-1$
+        // obtain agent for currently running system
+        agent = provider.createAgent(null);
+        bundleContext.ungetService(providerRef);
+    }
+
+    public void setSourceIUs(List<IInstallableUnit> ius) {
+        sourceIUs = ius;
+    }
+
+    protected void finalizeRepositories() {
+        if (removeAddedRepositories) {
+            IArtifactRepositoryManager artifactRepositoryManager = getArtifactRepositoryManager();
+            for (URI uri : artifactReposToRemove)
+                artifactRepositoryManager.removeRepository(uri);
+            IMetadataRepositoryManager metadataRepositoryManager = getMetadataRepositoryManager();
+            for (URI uri : metadataReposToRemove)
+                metadataRepositoryManager.removeRepository(uri);
+        }
+        metadataReposToRemove = null;
+        artifactReposToRemove = null;
+        compositeArtifactRepository = null;
+        compositeMetadataRepository = null;
+        destinationArtifactRepository = null;
+        destinationMetadataRepository = null;
+    }
+
+    protected IMetadataRepositoryManager getMetadataRepositoryManager() {
+        return agent.getService(IMetadataRepositoryManager.class);
+    }
+
+    protected IArtifactRepositoryManager getArtifactRepositoryManager() {
+        return agent.getService(IArtifactRepositoryManager.class);
+    }
+
+    public void initializeRepos(IProgressMonitor progress) throws ProvisionException {
+        IArtifactRepositoryManager artifactRepositoryManager = getArtifactRepositoryManager();
+        IMetadataRepositoryManager metadataRepositoryManager = getMetadataRepositoryManager();
+        URI curLocation = null;
+        for (RepositoryDescriptor repo : sourceRepositories) {
+            try {
+                curLocation = repo.getRepoLocation();
+                if (repo.isBoth()) {
+                    addRepository(artifactRepositoryManager, curLocation, 0, progress);
+                    addRepository(metadataRepositoryManager, curLocation, 0, progress);
+                } else if (repo.isArtifact())
+                    addRepository(artifactRepositoryManager, curLocation, 0, progress);
+                else if (repo.isMetadata())
+                    addRepository(metadataRepositoryManager, curLocation, 0, progress);
+                else
+                    throw new ProvisionException(NLS.bind(Messages.unknown_repository_type, repo.getRepoLocation()));
+            } catch (ProvisionException e) {
+                if (e.getCause() instanceof MalformedURLException) {
+                    throw new ProvisionException(NLS.bind(Messages.exception_invalidSource, curLocation), e);
+                } else if (e.getStatus().getCode() == ProvisionException.REPOSITORY_NOT_FOUND && repo.isOptional()) {
+                    continue;
+                }
+                throw e;
+            }
+        }
+        processDestinationRepos(artifactRepositoryManager, metadataRepositoryManager);
+    }
+
+    // Helper to add a repository. It takes care of adding the repos to the deletion
+    // list and loading it
+    protected IMetadataRepository addRepository(IMetadataRepositoryManager manager, URI location, int flags,
+            IProgressMonitor monitor) throws ProvisionException {
+        if (!manager.contains(location))
+            metadataReposToRemove.add(location);
+        return manager.loadRepository(location, flags, monitor);
+    }
+
+    // Helper to add a repository. It takes care of adding the repos to the deletion
+    // list and loading it
+    protected IArtifactRepository addRepository(IArtifactRepositoryManager manager, URI location, int flags,
+            IProgressMonitor monitor) throws ProvisionException {
+        if (!manager.contains(location))
+            artifactReposToRemove.add(location);
+        return manager.loadRepository(location, flags, monitor);
+    }
+
+    private void processDestinationRepos(IArtifactRepositoryManager artifactRepositoryManager,
+            IMetadataRepositoryManager metadataRepositoryManager) throws ProvisionException {
+        RepositoryDescriptor artifactRepoDescriptor = null;
+        RepositoryDescriptor metadataRepoDescriptor = null;
+
+        Iterator<RepositoryDescriptor> iter = destinationRepos.iterator();
+        while (iter.hasNext() && (artifactRepoDescriptor == null || metadataRepoDescriptor == null)) {
+            RepositoryDescriptor repo = iter.next();
+            if (repo.isArtifact() && artifactRepoDescriptor == null)
+                artifactRepoDescriptor = repo;
+            if (repo.isMetadata() && metadataRepoDescriptor == null)
+                metadataRepoDescriptor = repo;
+        }
+
+        if (artifactRepoDescriptor != null)
+            destinationArtifactRepository = initializeDestination(artifactRepoDescriptor, artifactRepositoryManager);
+        if (metadataRepoDescriptor != null)
+            destinationMetadataRepository = initializeDestination(metadataRepoDescriptor, metadataRepositoryManager);
+
+        if (destinationMetadataRepository == null && destinationArtifactRepository == null)
+            throw new ProvisionException(Messages.AbstractApplication_no_valid_destinations);
+    }
+
+    public IMetadataRepository getDestinationMetadataRepository() {
+        return destinationMetadataRepository;
+    }
+
+    public IArtifactRepository getDestinationArtifactRepository() {
+        return destinationArtifactRepository;
+    }
+
+    protected IMetadataRepository initializeDestination(RepositoryDescriptor toInit, IMetadataRepositoryManager mgr)
+            throws ProvisionException {
+        try {
+            IMetadataRepository repository = addRepository(mgr, toInit.getRepoLocation(),
+                    IRepositoryManager.REPOSITORY_HINT_MODIFIABLE, null);
+            if (initDestinationRepository(repository, toInit))
+                return repository;
+        } catch (ProvisionException e) {
+            // fall through and create a new repository below
+        }
+
+        IMetadataRepository source = null;
+        try {
+            if (toInit.getFormat() != null)
+                source = mgr.loadRepository(toInit.getFormat(), 0, null);
+        } catch (ProvisionException e) {
+            // Ignore.
+        }
+        // This code assumes source has been successfully loaded before this point
+        // No existing repository; create a new repository at destinationLocation but
+        // with source's attributes.
+        try {
+            IMetadataRepository result = mgr.createRepository(toInit.getRepoLocation(),
+                    toInit.getName() != null ? toInit.getName()
+                            : (source != null ? source.getName() : toInit.getRepoLocation().toString()),
+                    IMetadataRepositoryManager.TYPE_SIMPLE_REPOSITORY, source != null ? source.getProperties() : null);
+            if (toInit.isCompressed() && !result.getProperties().containsKey(IRepository.PROP_COMPRESSED))
+                result.setProperty(IRepository.PROP_COMPRESSED, "true"); //$NON-NLS-1$
+            return (IMetadataRepository) RepositoryHelper.validDestinationRepository(result);
+        } catch (UnsupportedOperationException e) {
+            throw new ProvisionException(NLS.bind(Messages.exception_invalidDestination, toInit.getRepoLocation()),
+                    e.getCause());
+        }
+    }
+
+    protected IArtifactRepository initializeDestination(RepositoryDescriptor toInit, IArtifactRepositoryManager mgr)
+            throws ProvisionException {
+        try {
+            IArtifactRepository repository = addRepository(mgr, toInit.getRepoLocation(),
+                    IRepositoryManager.REPOSITORY_HINT_MODIFIABLE, null);
+            if (initDestinationRepository(repository, toInit))
+                return repository;
+        } catch (ProvisionException e) {
+            // fall through and create a new repository below
+        }
+        IArtifactRepository source = null;
+        try {
+            if (toInit.getFormat() != null)
+                source = mgr.loadRepository(toInit.getFormat(), 0, null);
+        } catch (ProvisionException e) {
+            // Ignore.
+        }
+        // This code assumes source has been successfully loaded before this point
+        // No existing repository; create a new repository at destinationLocation but
+        // with source's attributes.
+        // TODO for now create a Simple repo by default.
+        try {
+            IArtifactRepository result = mgr.createRepository(toInit.getRepoLocation(),
+                    toInit.getName() != null ? toInit.getName()
+                            : (source != null ? source.getName() : toInit.getRepoLocation().toString()),
+                    IArtifactRepositoryManager.TYPE_SIMPLE_REPOSITORY, source != null ? source.getProperties() : null);
+            if (toInit.isCompressed() && !result.getProperties().containsKey(IRepository.PROP_COMPRESSED))
+                result.setProperty(IRepository.PROP_COMPRESSED, "true"); //$NON-NLS-1$
+            return (IArtifactRepository) RepositoryHelper.validDestinationRepository(result);
+        } catch (UnsupportedOperationException e) {
+            throw new ProvisionException(NLS.bind(Messages.exception_invalidDestination, toInit.getRepoLocation()),
+                    e.getCause());
+        }
+    }
+
+    protected boolean initDestinationRepository(IRepository<?> repository, RepositoryDescriptor descriptor) {
+        if (repository != null && repository.isModifiable()) {
+            if (descriptor.getName() != null)
+                repository.setProperty(IRepository.PROP_NAME, descriptor.getName());
+            if (repository instanceof ICompositeRepository<?> && !descriptor.isAppend())
+                ((ICompositeRepository<?>) repository).removeAllChildren();
+            else if (repository instanceof IMetadataRepository && !descriptor.isAppend())
+                ((IMetadataRepository) repository).removeAll();
+            else if (repository instanceof IArtifactRepository && !descriptor.isAppend())
+                ((IArtifactRepository) repository).removeAll();
+            return true;
+        }
+        return false;
+    }
+
+    public IMetadataRepository getCompositeMetadataRepository() {
+        if (compositeMetadataRepository == null) {
+            compositeMetadataRepository = CompositeMetadataRepository.createMemoryComposite(agent);
+            if (compositeMetadataRepository != null) {
+                for (RepositoryDescriptor repo : sourceRepositories) {
+                    if (repo.isMetadata())
+                        compositeMetadataRepository.addChild(repo.getRepoLocation());
+                }
+            }
+        }
+        return compositeMetadataRepository;
+    }
+
+    public IArtifactRepository getCompositeArtifactRepository() {
+        if (compositeArtifactRepository == null) {
+            compositeArtifactRepository = CompositeArtifactRepository.createMemoryComposite(agent);
+            if (compositeArtifactRepository != null) {
+                for (RepositoryDescriptor repo : sourceRepositories) {
+                    if (repo.isArtifact())
+                        compositeArtifactRepository.addChild(repo.getRepoLocation());
+                }
+            }
+        }
+        return compositeArtifactRepository;
+    }
+
+    public boolean hasArtifactSources() {
+        return ((ICompositeRepository<?>) getCompositeArtifactRepository()).getChildren().size() > 0;
+    }
+
+    public boolean hasMetadataSources() {
+        return ((ICompositeRepository<?>) getCompositeMetadataRepository()).getChildren().size() > 0;
+    }
+
+    public abstract IStatus run(IProgressMonitor monitor) throws ProvisionException;
+
+    public void addDestination(RepositoryDescriptor descriptor) {
+        destinationRepos.add(descriptor);
+    }
+
+    public void addSource(RepositoryDescriptor repo) {
+        sourceRepositories.add(repo);
+    }
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
@@ -77,10 +77,6 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
     private IArtifactMirrorLog mirrorLog;
     private IArtifactMirrorLog comparatorLog;
 
-    public MirrorApplication() {
-        super();
-    }
-
     public MirrorApplication(IProvisioningAgent agent) {
         super(agent);
     }
@@ -369,10 +365,10 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
     }
 
     private IQueryable<IInstallableUnit> performResolution(IProgressMonitor monitor) throws ProvisionException {
-        IProfileRegistry registry = Activator.getProfileRegistry();
+        IProfileRegistry registry = getProfileRegistry();
         String profileId = "MirrorApplication-" + System.currentTimeMillis(); //$NON-NLS-1$
         IProfile profile = registry.addProfile(profileId, slicingOptions.getFilter());
-        IPlanner planner = Activator.getAgent().getService(IPlanner.class);
+        IPlanner planner = agent.getService(IPlanner.class);
         if (planner == null)
             throw new IllegalStateException();
         IProfileChangeRequest pcr = planner.createChangeRequest(profile);
@@ -385,6 +381,13 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
         if (plan.getInstallerPlan() != null)
             arr[1] = plan.getInstallerPlan().getAdditions();
         return new CompoundQueryable<>(arr);
+    }
+
+    private IProfileRegistry getProfileRegistry() throws ProvisionException {
+        IProfileRegistry registry = agent.getService(IProfileRegistry.class);
+        if (registry == null)
+            throw new ProvisionException(Messages.no_profile_registry);
+        return registry;
     }
 
     private IQueryable<IInstallableUnit> slice(IProgressMonitor monitor) throws ProvisionException {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
@@ -1,0 +1,514 @@
+package org.eclipse.tycho.p2tools.copiedfromp2;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExecutableExtension;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.equinox.app.IApplication;
+import org.eclipse.equinox.app.IApplicationContext;
+import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
+import org.eclipse.equinox.internal.p2.director.PermissiveSlicer;
+import org.eclipse.equinox.internal.p2.director.Slicer;
+import org.eclipse.equinox.internal.p2.repository.Transport;
+import org.eclipse.equinox.internal.p2.repository.helpers.RepositoryHelper;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.engine.IProfile;
+import org.eclipse.equinox.p2.engine.IProfileRegistry;
+import org.eclipse.equinox.p2.engine.IProvisioningPlan;
+import org.eclipse.equinox.p2.internal.repository.comparator.ArtifactChecksumComparator;
+import org.eclipse.equinox.p2.internal.repository.mirroring.FileMirrorLog;
+import org.eclipse.equinox.p2.internal.repository.mirroring.IArtifactMirrorLog;
+import org.eclipse.equinox.p2.internal.repository.mirroring.Mirroring;
+import org.eclipse.equinox.p2.internal.repository.mirroring.XMLMirrorLog;
+import org.eclipse.equinox.p2.internal.repository.tools.Messages;
+import org.eclipse.equinox.p2.internal.repository.tools.RepositoryDescriptor;
+import org.eclipse.equinox.p2.internal.repository.tools.SlicingOptions;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.VersionRange;
+import org.eclipse.equinox.p2.planner.IPlanner;
+import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
+import org.eclipse.equinox.p2.query.CompoundQueryable;
+import org.eclipse.equinox.p2.query.IQuery;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.IQueryable;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+import org.eclipse.osgi.util.NLS;
+
+public class MirrorApplication extends AbstractApplication implements IApplication, IExecutableExtension {
+    private static final String DEFAULT_COMPARATOR = ArtifactChecksumComparator.COMPARATOR_ID + ".sha-256"; //$NON-NLS-1$
+    private static final String LOG_ROOT = "p2.mirror"; //$NON-NLS-1$
+    private static final String MIRROR_MODE = "metadataOrArtifacts"; //$NON-NLS-1$
+
+    protected SlicingOptions slicingOptions = new SlicingOptions();
+
+    private URI baseline;
+    private String comparatorID;
+    private IQuery<IArtifactDescriptor> compareExclusions = null;
+    private boolean compare = false;
+    private boolean failOnError = true;
+    private boolean raw = true;
+    private boolean verbose = false;
+    private boolean validate = false;
+    private boolean mirrorReferences = true;
+    private String metadataOrArtifacts = null;
+    private String[] rootIUs = null;
+    private boolean includePacked = true;
+    private boolean mirrorProperties = false;
+
+    private File mirrorLogFile; // file to log mirror output to (optional)
+    private File comparatorLogFile; // file to comparator output to (optional)
+    private IArtifactMirrorLog mirrorLog;
+    private IArtifactMirrorLog comparatorLog;
+
+    public MirrorApplication() {
+        super();
+    }
+
+    public MirrorApplication(IProvisioningAgent agent) {
+        super(agent);
+    }
+
+    /**
+     * Convert a list of tokens into an array. The list separator has to be specified.
+     */
+    public static String[] getArrayArgsFromString(String list, String separator) {
+        if (list == null || list.trim().equals("")) //$NON-NLS-1$
+            return new String[0];
+        List<String> result = new ArrayList<>();
+        for (StringTokenizer tokens = new StringTokenizer(list, separator); tokens.hasMoreTokens();) {
+            String token = tokens.nextToken().trim();
+            if (!token.equals("")) { //$NON-NLS-1$
+                if ((token.indexOf('[') >= 0 || token.indexOf('(') >= 0) && tokens.hasMoreTokens())
+                    result.add(token + separator + tokens.nextToken());
+                else
+                    result.add(token);
+            }
+        }
+        return result.toArray(new String[result.size()]);
+    }
+
+    @Override
+    public Object start(IApplicationContext context) throws Exception {
+        Map<?, ?> args = context.getArguments();
+        initializeFromArguments((String[]) args.get(IApplicationContext.APPLICATION_ARGS));
+        run(null);
+        return IApplication.EXIT_OK;
+    }
+
+    @Override
+    public void stop() {
+        // TODO Auto-generated method stub
+
+    }
+
+    /*
+     * The old "org.eclipse.equinox.p2.artifact.repository.mirrorApplication" application only does
+     * artifacts Similary, "org.eclipse.equinox.p2.metadata.repository.mirrorApplication" only does
+     * metadata
+     */
+    @Override
+    public void setInitializationData(IConfigurationElement config, String propertyName, Object data) {
+        if (data instanceof Map<?, ?> && ((Map<?, ?>) data).containsKey(MIRROR_MODE)) {
+            metadataOrArtifacts = (String) ((Map<?, ?>) data).get(MIRROR_MODE);
+        }
+    }
+
+    public void initializeFromArguments(String[] args) throws Exception {
+        if (args == null)
+            return;
+
+        File comparatorLogLocation = null;
+        File mirrorLogLocation = null;
+
+        RepositoryDescriptor destination = new RepositoryDescriptor();
+        RepositoryDescriptor sourceRepo = new RepositoryDescriptor();
+        if (metadataOrArtifacts != null) {
+            destination.setKind(metadataOrArtifacts);
+            sourceRepo.setKind(metadataOrArtifacts);
+        }
+
+        addDestination(destination);
+        addSource(sourceRepo);
+
+        for (int i = 0; i < args.length; i++) {
+            // check for args without parameters (i.e., a flag arg)
+            if (args[i].equalsIgnoreCase("-raw")) //$NON-NLS-1$
+                raw = true;
+            else if (args[i].equalsIgnoreCase("-ignoreErrors")) //$NON-NLS-1$
+                failOnError = false;
+            else if (args[i].equalsIgnoreCase("-verbose")) //$NON-NLS-1$
+                verbose = true;
+            else if (args[i].equalsIgnoreCase("-compare")) //$NON-NLS-1$
+                compare = true;
+            else if (args[i].equalsIgnoreCase("-validate")) //$NON-NLS-1$
+                validate = true;
+            else if (args[i].equalsIgnoreCase("-references")) //$NON-NLS-1$
+                mirrorReferences = true;
+            else if (args[i].equalsIgnoreCase("-properties")) //$NON-NLS-1$
+                mirrorProperties = true;
+
+            // check for args with parameters. If we are at the last argument or
+            // if the next one has a '-' as the first character, then we can't have
+            // an arg with a param so continue.
+            if (i == args.length - 1 || args[i + 1].startsWith("-")) //$NON-NLS-1$
+                continue;
+
+            String arg = args[++i];
+
+            if (args[i - 1].equalsIgnoreCase("-comparator")) //$NON-NLS-1$
+                comparatorID = arg;
+            else if (args[i - 1].equalsIgnoreCase("-comparatorLog")) //$NON-NLS-1$
+                comparatorLogLocation = new File(arg);
+            else if (args[i - 1].equalsIgnoreCase("-destinationName")) //$NON-NLS-1$
+                destination.setName(arg);
+            else if (args[i - 1].equalsIgnoreCase("-writeMode")) { //$NON-NLS-1$
+                if (args[i].equalsIgnoreCase("clean")) //$NON-NLS-1$
+                    destination.setAppend(false);
+            } else if (args[i - 1].equalsIgnoreCase("-log")) { //$NON-NLS-1$
+                mirrorLogLocation = new File(arg);
+            } else if (args[i - 1].equalsIgnoreCase("-roots")) { //$NON-NLS-1$
+                rootIUs = getArrayArgsFromString(arg, ","); //$NON-NLS-1$
+            } else if (args[i - 1].equalsIgnoreCase("-references")) {//$NON-NLS-1$
+                mirrorReferences = Boolean.parseBoolean(args[i]);
+            } else {
+                try {
+                    if (args[i - 1].equalsIgnoreCase("-source")) { //$NON-NLS-1$
+                        URI uri = RepositoryHelper.localRepoURIHelper(URIUtil.fromString(arg));
+                        sourceRepo.setLocation(uri);
+                        destination.setFormat(uri);
+                    } else if (args[i - 1].equalsIgnoreCase("-destination")) //$NON-NLS-1$
+                        destination.setLocation(RepositoryHelper.localRepoURIHelper(URIUtil.fromString(arg)));
+                    else if (args[i - 1].equalsIgnoreCase("-compareAgainst")) { //$NON-NLS-1$
+                        baseline = RepositoryHelper.localRepoURIHelper(URIUtil.fromString(arg));
+                        compare = true;
+                    }
+                } catch (URISyntaxException e) {
+                    throw new IllegalArgumentException(NLS.bind(Messages.ProcessRepo_location_not_url, arg));
+                }
+            }
+        }
+
+        // Create logs
+        if (mirrorLogLocation != null)
+            mirrorLog = getLog(mirrorLogLocation, "p2.artifact.mirror"); //$NON-NLS-1$
+        if (comparatorLogLocation != null && comparatorID != null)
+            comparatorLog = getLog(comparatorLogLocation, comparatorID);
+    }
+
+    @Override
+    public IStatus run(IProgressMonitor monitor) throws ProvisionException {
+        IStatus mirrorStatus = Status.OK_STATUS;
+        try {
+            initializeRepos(new NullProgressMonitor());
+            initializeLogs();
+            validate();
+            initializeIUs();
+            IQueryable<IInstallableUnit> slice = slice(new NullProgressMonitor());
+            if (destinationArtifactRepository != null) {
+                mirrorStatus = mirrorArtifacts(slice, new NullProgressMonitor());
+                if (failOnError && mirrorStatus.getSeverity() == IStatus.ERROR)
+                    return mirrorStatus;
+            }
+            if (destinationMetadataRepository != null)
+                mirrorMetadata(slice, new NullProgressMonitor());
+        } finally {
+            finalizeRepositories();
+            finalizeLogs();
+        }
+        if (mirrorStatus.isOK())
+            return Status.OK_STATUS;
+        return mirrorStatus;
+    }
+
+    private IStatus mirrorArtifacts(IQueryable<IInstallableUnit> slice, IProgressMonitor monitor) {
+        Mirroring mirror = getMirroring(slice, monitor);
+
+        IStatus result = mirror.run(failOnError, verbose);
+
+        if (mirrorLog != null)
+            mirrorLog.log(result);
+        else
+            LogHelper.log(result);
+        return result;
+    }
+
+    protected Mirroring getMirroring(IQueryable<IInstallableUnit> slice, IProgressMonitor monitor) {
+        // Obtain ArtifactKeys from IUs
+        IQueryResult<IInstallableUnit> ius = slice.query(QueryUtil.createIUAnyQuery(), monitor);
+        boolean iusSpecified = !ius.isEmpty(); // call before ius.iterator() to avoid bug 420318
+        ArrayList<IArtifactKey> keys = new ArrayList<>();
+        for (IInstallableUnit iu : ius) {
+            keys.addAll(iu.getArtifacts());
+        }
+
+        Mirroring mirror = new Mirroring(getCompositeArtifactRepository(), destinationArtifactRepository, raw);
+        mirror.setCompare(compare);
+        mirror.setComparatorId(comparatorID == null ? DEFAULT_COMPARATOR : comparatorID);
+        mirror.setBaseline(initializeBaseline());
+        mirror.setValidate(validate);
+        mirror.setCompareExclusions(compareExclusions);
+        mirror.setTransport((Transport) agent.getService(Transport.SERVICE_NAME));
+        mirror.setIncludePacked(includePacked);
+        mirror.setMirrorProperties(mirrorProperties);
+
+        // If IUs have been specified then only they should be mirrored, otherwise
+        // mirror everything.
+        if (iusSpecified)
+            mirror.setArtifactKeys(keys.toArray(new IArtifactKey[keys.size()]));
+
+        if (comparatorLog != null)
+            mirror.setComparatorLog(comparatorLog);
+        return mirror;
+    }
+
+    private IArtifactRepository initializeBaseline() {
+        if (baseline == null)
+            return null;
+        try {
+            return addRepository(getArtifactRepositoryManager(), baseline, 0, null);
+        } catch (ProvisionException e) {
+            if (mirrorLog != null && e.getStatus() != null)
+                mirrorLog.log(e.getStatus());
+            return null;
+        }
+    }
+
+    private void mirrorMetadata(IQueryable<IInstallableUnit> slice, IProgressMonitor monitor) {
+        IQueryResult<IInstallableUnit> allIUs = slice.query(QueryUtil.createIUAnyQuery(), monitor);
+        destinationMetadataRepository.addInstallableUnits(allIUs.toUnmodifiableSet());
+        if (mirrorReferences)
+            destinationMetadataRepository.addReferences(getCompositeMetadataRepository().getReferences());
+    }
+
+    /*
+     * Ensure all mandatory parameters have been set. Throw an exception if there are any missing.
+     * We don't require the user to specify the artifact repository here, we will default to the
+     * ones already registered in the manager. (callers are free to add more if they wish)
+     */
+    private void validate() throws ProvisionException {
+        if (sourceRepositories.isEmpty())
+            throw new ProvisionException(Messages.MirrorApplication_set_source_repositories);
+        if (!hasArtifactSources() && destinationArtifactRepository != null)
+            throw new ProvisionException(Messages.MirrorApplication_artifactDestinationNoSource);
+        if (!hasMetadataSources() && destinationMetadataRepository != null)
+            throw new ProvisionException(Messages.MirrorApplication_metadataDestinationNoSource);
+    }
+
+    /*
+     * If no IUs have been specified we want to mirror them all
+     */
+    private void initializeIUs() throws ProvisionException {
+        IMetadataRepository metadataRepo = getCompositeMetadataRepository();
+
+        if (rootIUs != null) {
+            sourceIUs = new ArrayList<>();
+            for (String rootIU : rootIUs) {
+                String[] segments = getArrayArgsFromString(rootIU, "/"); //$NON-NLS-1$
+                VersionRange range = segments.length > 1 ? VersionRange.create(segments[1]) : null;
+                Iterator<IInstallableUnit> queryResult = metadataRepo
+                        .query(QueryUtil.createIUQuery(segments[0], range), null).iterator();
+                while (queryResult.hasNext())
+                    sourceIUs.add(queryResult.next());
+            }
+        } else if (sourceIUs == null || sourceIUs.isEmpty()) {
+            sourceIUs = new ArrayList<>();
+            Iterator<IInstallableUnit> queryResult = metadataRepo.query(QueryUtil.createIUAnyQuery(), null).iterator();
+            while (queryResult.hasNext())
+                sourceIUs.add(queryResult.next());
+            /* old metadata mirroring app did not throw an exception here */
+            if (sourceIUs.size() == 0 && destinationMetadataRepository != null && metadataOrArtifacts == null)
+                throw new ProvisionException(Messages.MirrorApplication_no_IUs);
+        }
+    }
+
+    /*
+     * Initialize logs, if applicable
+     */
+    private void initializeLogs() {
+        if (compare && comparatorLogFile != null)
+            comparatorLog = getLog(comparatorLogFile, comparatorID);
+        if (mirrorLog == null && mirrorLogFile != null)
+            mirrorLog = getLog(mirrorLogFile, LOG_ROOT);
+    }
+
+    /*
+     * Finalize logs, if applicable
+     */
+    private void finalizeLogs() {
+        if (comparatorLog != null)
+            comparatorLog.close();
+        if (mirrorLog != null)
+            mirrorLog.close();
+    }
+
+    /*
+     * Get the log for a location
+     */
+    private IArtifactMirrorLog getLog(File location, String root) {
+        String absolutePath = location.getAbsolutePath();
+        if (absolutePath.toLowerCase().endsWith(".xml")) //$NON-NLS-1$
+            return new XMLMirrorLog(absolutePath, 0, root);
+        return new FileMirrorLog(absolutePath, 0, root);
+    }
+
+    private IQueryable<IInstallableUnit> performResolution(IProgressMonitor monitor) throws ProvisionException {
+        IProfileRegistry registry = Activator.getProfileRegistry();
+        String profileId = "MirrorApplication-" + System.currentTimeMillis(); //$NON-NLS-1$
+        IProfile profile = registry.addProfile(profileId, slicingOptions.getFilter());
+        IPlanner planner = Activator.getAgent().getService(IPlanner.class);
+        if (planner == null)
+            throw new IllegalStateException();
+        IProfileChangeRequest pcr = planner.createChangeRequest(profile);
+        pcr.addAll(sourceIUs);
+        IProvisioningPlan plan = planner.getProvisioningPlan(pcr, null, monitor);
+        registry.removeProfile(profileId);
+        @SuppressWarnings("unchecked")
+        IQueryable<IInstallableUnit>[] arr = new IQueryable[plan.getInstallerPlan() == null ? 1 : 2];
+        arr[0] = plan.getAdditions();
+        if (plan.getInstallerPlan() != null)
+            arr[1] = plan.getInstallerPlan().getAdditions();
+        return new CompoundQueryable<>(arr);
+    }
+
+    private IQueryable<IInstallableUnit> slice(IProgressMonitor monitor) throws ProvisionException {
+        if (slicingOptions == null)
+            slicingOptions = new SlicingOptions();
+        if (slicingOptions.getInstallTimeLikeResolution())
+            return performResolution(monitor);
+
+        Slicer slicer = createSlicer(slicingOptions);
+        IQueryable<IInstallableUnit> slice = slicer.slice(sourceIUs.toArray(new IInstallableUnit[sourceIUs.size()]),
+                monitor);
+
+        if (slice != null && slicingOptions.latestVersionOnly()) {
+            IQueryResult<IInstallableUnit> queryResult = slice.query(QueryUtil.createLatestIUQuery(), monitor);
+            slice = queryResult;
+        }
+        if (slicer.getStatus().getSeverity() != IStatus.OK && mirrorLog != null) {
+            mirrorLog.log(slicer.getStatus());
+        }
+        if (slice == null) {
+            throw new ProvisionException(slicer.getStatus());
+        }
+        return slice;
+    }
+
+    protected Slicer createSlicer(SlicingOptions options) {
+        PermissiveSlicer slicer = new PermissiveSlicer(getCompositeMetadataRepository(), options.getFilter(),
+                options.includeOptionalDependencies(), options.isEverythingGreedy(), options.forceFilterTo(),
+                options.considerStrictDependencyOnly(), options.followOnlyFilteredRequirements());
+        return slicer;
+    }
+
+    public void setSlicingOptions(SlicingOptions options) {
+        slicingOptions = options;
+    }
+
+    /*
+     * Set the location of the baseline repository. (used in comparison)
+     */
+    public void setBaseline(URI baseline) {
+        this.baseline = baseline;
+        compare = true;
+    }
+
+    /*
+     * Set the identifier of the comparator to use.
+     */
+    public void setComparatorID(String value) {
+        comparatorID = value;
+        compare = true;
+    }
+
+    /*
+     * Set whether or not the application should be calling a comparator when mirroring.
+     */
+    public void setCompare(boolean value) {
+        compare = value;
+    }
+
+    /*
+     * Set whether or not we should ignore errors when running the mirror application.
+     */
+    public void setIgnoreErrors(boolean value) {
+        failOnError = !value;
+    }
+
+    /*
+     * Set whether or not the the artifacts are raw.
+     */
+    public void setRaw(boolean value) {
+        raw = value;
+    }
+
+    /*
+     * Set whether or not the mirror application should be run in verbose mode.
+     */
+    public void setVerbose(boolean value) {
+        verbose = value;
+    }
+
+    /*
+     * Set the location of the log for comparator output
+     */
+    public void setComparatorLog(File comparatorLog) {
+        this.comparatorLogFile = comparatorLog;
+    }
+
+    /*
+     * Set the location of the log for mirroring.
+     */
+    public void setLog(File mirrorLog) {
+        this.mirrorLogFile = mirrorLog;
+    }
+
+    /*
+     * Set the ArtifactMirror log
+     */
+    public void setLog(IArtifactMirrorLog log) {
+        mirrorLog = log;
+    }
+
+    /*
+     * Set if the artifact mirror should be validated
+     */
+    public void setValidate(boolean value) {
+        validate = value;
+    }
+
+    /*
+     * Set if references should be mirrored
+     */
+    public void setReferences(boolean flag) {
+        mirrorReferences = flag;
+    }
+
+    public void setComparatorExclusions(IQuery<IArtifactDescriptor> exclusions) {
+        compareExclusions = exclusions;
+    }
+
+    public void setIncludePacked(boolean includePacked) {
+        this.includePacked = includePacked;
+    }
+
+    public void setMirrorProperties(boolean mirrorProperties) {
+        this.mirrorProperties = mirrorProperties;
+    }
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/README.MD
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/README.MD
@@ -1,0 +1,17 @@
+# This package contains copied content from P2
+
+To decouple Tycho from P2 and apply some changes to behavior of internal classes we have copies of these here, the mostly differ in some details, e.g. making methods or fields protected.
+In the (unlikely) case something changes in P2 one should be able to easily sync the changes by copy over the new version and perform a git compare to apply the patch from P2 to Tycho as well.
+
+These are the original location in P2:
+
+- AbstractApplication -> org.eclipse.equinox.p2.internal.repository.tools.AbstractApplication
+- MirrorApplication -> org.eclipse.equinox.p2.internal.repository.tools.MirrorApplication
+
+## History
+
+Tycho already customizes the P2 applications but they are not really used as a real application and instead called directly. In the past especially the MirrorApplication required some adjustments to fit Tycho needs, but it was not written with extensibility in mind.
+
+Even though sometimes we we able to work around that limitations or apply patches to P2 this really has slowed down the development and ability of Tycho to deliver new value to their users. On the other hand none of these changes has had added any value to pure P2 users and there are no real innovation in these areas over the years.
+
+Because of this, Tycho now includes a copy of these classes (but remains the extension pattern to allow apply of P2 patches to Tycho) to fasten development and decouple Tycho form P2 in the area of tools.


### PR DESCRIPTION
I don't know if it is strictly required but would be good to get a +1 as PL from @mickaelistria or @akurtakov here.

I hope the commit message and readme is sufficent, but I copy the relevant parts to this PR as well just in case:

> Tycho already customizes the P2 applications but they are not really used as a real application and instead called directly. In the past especially the MirrorApplication required some adjustments to fit Tycho needs, but it was not written with extensibility in mind.
> 
> Even though sometimes we we able to work around that limitations or apply patches to P2 this really has slowed down the development and ability of Tycho to deliver new value to their users. On the other hand none of these changes has had added any value to pure P2 users and there are no real innovation in these areas over the years.
> 
> Because of this, Tycho now includes a copy of these classes (but remains the extension pattern to allow apply of P2 patches to Tycho) to fasten development and decouple Tycho form P2 in the area of tools.

I have split the PR in two commits, one that adds the readme + original code (with just imports adjusted) as a base, and a second one that links Tycho with the copied code and apply some fixes due to changed API in P2 and unnecessary static Activator references.