### PR TITLE
Filter provided units and artifacts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -55,6 +55,11 @@ Also feature baselining is supported according to [Versioning features](https://
 
 The parameters of the `tycho-apitools-plugin:generate` goal have been completed and improved.
 
+### New parameter for tycho-p2-repository-plugin:assemble-repository
+
+The `tycho-p2-repository-plugin:assemble-repository` mojo has now a new configuration parameter `filterProvided` that (if enabled) filter units and artifacts that are already present in one of the referenced repositories.
+That way one can prevent including items that are already present in the same form in another repository.
+
 
 ### Migration guide 3.x > 4.x
 

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
@@ -54,6 +54,7 @@ public interface MirrorApplicationService {
      *            Whether to include bundles mentioned in the require section of a feature
      * @param includeRequiredFeatures
      *            Whether to include features mentioned in the require section of a feature
+     * @param filterProvided Whether to filter IU/artifacts that are already provided by a referenced repository
      * @param filterProperties
      *            additional filter properties to be set in the p2 slicing options. May be
      *            <code>null</code>
@@ -63,7 +64,7 @@ public interface MirrorApplicationService {
     public void mirrorReactor(RepositoryReferences sources, DestinationRepositoryDescriptor destination,
             Collection<DependencySeed> seeds, BuildContext context, boolean includeAllDependencies,
             boolean includeAllSource, boolean includeRequiredBundles, boolean includeRequiredFeatures,
-            Map<String, String> filterProperties) throws FacadeException;
+            boolean filterProvided, Map<String, String> filterProperties) throws FacadeException;
 
     /**
      * recreates the metadata of an existing repository e.g. to account for changes in the contained

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -80,7 +80,7 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
             Collection<IUDescription> seedIUs, MirrorOptions mirrorOptions, BuildDirectory tempDirectory)
             throws FacadeException {
         agent.getService(IArtifactRepositoryManager.class); //force init of framework if not already done!
-        final MirrorApplication mirrorApp = createMirrorApplication(sources, destination, agent);
+        final TychoMirrorApplication mirrorApp = createMirrorApplication(sources, destination, agent);
         mirrorApp.setSlicingOptions(createSlicingOptions(mirrorOptions));
         mirrorApp.setIgnoreErrors(mirrorOptions.isIgnoreErrors());
         try {
@@ -153,8 +153,8 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
     public void mirrorReactor(RepositoryReferences sources, DestinationRepositoryDescriptor destination,
             Collection<DependencySeed> projectSeeds, BuildContext context, boolean includeAllDependencies,
             boolean includeAllSource, boolean includeRequiredBundles, boolean includeRequiredFeatures,
-            Map<String, String> filterProperties) throws FacadeException {
-        final MirrorApplication mirrorApp = createMirrorApplication(sources, destination, agent);
+            boolean filterProvided, Map<String, String> filterProperties) throws FacadeException {
+        final TychoMirrorApplication mirrorApp = createMirrorApplication(sources, destination, agent);
 
         // mirror scope: seed units...
         mirrorApp
@@ -163,7 +163,7 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
         mirrorApp.setIncludeRequiredBundles(includeRequiredBundles);
         mirrorApp.setIncludeRequiredFeatures(includeRequiredFeatures);
         mirrorApp.setIncludePacked(false); // no way, Tycho do no longer support packed artifacts anyways
-
+        mirrorApp.setFilterProvided(filterProvided);
         // TODO the p2 mirror tool should support mirroring multiple environments at once
         for (TargetEnvironment environment : context.getEnvironments()) {
             SlicingOptions options = new SlicingOptions();
@@ -234,9 +234,9 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
         xzCompress(destination);
     }
 
-    private static MirrorApplication createMirrorApplication(RepositoryReferences sources,
+    private static TychoMirrorApplication createMirrorApplication(RepositoryReferences sources,
             DestinationRepositoryDescriptor destination, IProvisioningAgent agent) {
-        final MirrorApplication mirrorApp = new MirrorApplication(agent,
+        final TychoMirrorApplication mirrorApp = new TychoMirrorApplication(agent,
                 destination.getExtraArtifactRepositoryProperties(), destination.getRepositoryReferences());
         mirrorApp.setRaw(false);
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceTest.java
@@ -101,13 +101,13 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         Collection<DependencySeed> noSeeds = Collections.emptyList();
 
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, noSeeds, context, false, false, false,
-                false, null);
+                false, false, null);
     }
 
     @Test
     public void testMirrorFeatureWithContent() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false,
-                false, false, false, null);
+                false, false, false, false, null);
 
         logVerifier.expectNoWarnings();
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.4.0.v20080512.jar").exists());
@@ -123,7 +123,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest2"), DEFAULT_NAME, false, false,
                 false, false, true, extraArtifactRepositoryProperties, Collections.emptyList());
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false,
-                false, false, false, null);
+                false, false, false, false, null);
 
         logVerifier.expectNoWarnings();
         File artifactsXml = repoFile(destinationRepo, "artifacts.xml");
@@ -146,7 +146,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
     @Test
     public void testMirrorPatch() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e352"), destinationRepo, seedFor(FEATURE_PATCH_IU), context, false,
-                false, false, false, null);
+                false, false, false, false, null);
 
         //TODO why mirror tool emits a warning here?        logVerifier.expectNoWarnings();
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.5.0.v20090525.jar").exists());
@@ -156,7 +156,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
     @Test
     public void testMirrorFeatureAndPatch() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e352"), destinationRepo,
-                seedFor(SIMPLE_FEATURE_IU, FEATURE_PATCH_IU), context, false, false, false, false, null);
+                seedFor(SIMPLE_FEATURE_IU, FEATURE_PATCH_IU), context, false, false, false, false, false, null);
 
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.5.0.v20090525.jar").exists());
         assertTrue(repoFile(destinationRepo, "features/" + SIMPLE_FEATURE + "_1.0.0.jar").exists());
@@ -175,7 +175,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
          * warning is issued.
          */
         subject.mirrorReactor(sourceRepos("patch"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false, false,
-                false, false, null);
+                false, false, false, null);
 
         logVerifier.expectWarning(not(is("")));
     }
@@ -189,7 +189,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         List<DependencySeed> seeds = Collections
                 .singletonList(new DependencySeed(null, "org.eclipse.core.runtime", null));
 
-        subject.mirrorReactor(sourceRepos("e342"), destinationRepo, seeds, context, false, false, false, false, null);
+        subject.mirrorReactor(sourceRepos("e342"), destinationRepo, seeds, context, false, false, false, false, false, null);
 
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.4.0.v20080512.jar").exists());
     }

--- a/tycho-its/projects/p2Repository.filter/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2Repository.filter/bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: bundle
+Bundle-Version: 0.0.1.qualifier
+Require-Bundle: org.eclipse.core.resources;bundle-version="3.18.100"

--- a/tycho-its/projects/p2Repository.filter/bundle/build.properties
+++ b/tycho-its/projects/p2Repository.filter/bundle/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/p2Repository.filter/bundle/pom.xml
+++ b/tycho-its/projects/p2Repository.filter/bundle/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+   <groupId>org.eclipse.tycho.its</groupId>
+    <artifactId>parent-include</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>bundle</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/p2Repository.filter/pom.xml
+++ b/tycho-its/projects/p2Repository.filter/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.tycho.its</groupId>
+	<artifactId>parent-include</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<repositories>
+		<repository>
+			<id>eclipse</id>
+			<url>http://download.eclipse.org/releases/latest/</url>
+			<layout>p2</layout>
+		</repository>
+	</repositories>
+	
+	<properties>
+		<tycho-version>4.0.0-SNAPSHOT</tycho-version>
+	</properties>
+	
+	<modules>
+		<module>bundle</module>
+		<module>repository</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<compress>false</compress>
+					<includeAllDependencies>true</includeAllDependencies>
+					<filterProvided>true</filterProvided>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2Repository.filter/repository/category.xml
+++ b/tycho-its/projects/p2Repository.filter/repository/category.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <bundle id="bundle">
+      <category name="test.category"/>
+   </bundle>
+   <category-def name="test.category" label="Test"/>
+   <repository-reference location="http://download.eclipse.org/releases/latest/" enabled="true" />
+</site>

--- a/tycho-its/projects/p2Repository.filter/repository/pom.xml
+++ b/tycho-its/projects/p2Repository.filter/repository/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tycho.its</groupId>
+		<artifactId>parent-include</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>repository</artifactId>
+	<packaging>eclipse-repository</packaging>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepositoryIncludeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepositoryIncludeTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - inital API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.p2Repository;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.eclipse.tycho.test.util.P2RepositoryTool;
+import org.junit.Test;
+
+public class RepositoryIncludeTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testFilterProvided() throws Exception {
+		Verifier verifier = getVerifier("p2Repository.filter", false, true);
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+		P2RepositoryTool p2Repo = P2RepositoryTool
+				.forEclipseRepositoryModule(new File(verifier.getBasedir(), "repository"));
+		p2Repo.getUniqueIU("bundle");
+		p2Repo.assertNumberOfUnits(1, u -> u.id.equals("a.jre.javase") || u.id.endsWith(".test.category"));
+		assertTrue("Bundle artifact not found!", p2Repo.findBundleArtifact("bundle").isPresent());
+		p2Repo.assertNumberOfBundles(1);
+		p2Repo.assertNumberOfFeatures(0);
+	}
+
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho188P2EnabledRcpTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho188P2EnabledRcpTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -122,8 +123,8 @@ public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 				.forEclipseRepositoryModule(new File(verifier.getBasedir(), MODULE));
 
 		// test that root level feature is assembled into the p2 repository...
-		File rootFeatureInRepo = p2Repository.findFeatureArtifact("pi.root-level-installed-feature");
-		assertTrue(rootFeatureInRepo.isFile());
+		Optional<File> rootFeatureInRepo = p2Repository.findFeatureArtifact("pi.root-level-installed-feature");
+		assertTrue(rootFeatureInRepo.isPresent());
 
 		// ... although there is no dependency from the product IU.
 		assertThat(p2Repository.getUniqueIU("main.product.id").getRequiredIds(),

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetRestrictionThroughTargetFilesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetRestrictionThroughTargetFilesTest.java
@@ -62,7 +62,7 @@ public class TargetRestrictionThroughTargetFilesTest extends AbstractTychoIntegr
 		assertFalse(p2Repo.getBundleArtifact("trt.bundle.referenced", "2.0.0.201108051319").isFile());
 		assertTrue(p2Repo.getBundleArtifact("trt.bundle.referenced", "1.0.0.201108051343").isFile());
 
-		assertTrue(p2Repo.findFeatureArtifact("trt.feature").isFile());
+		assertTrue(p2Repo.findFeatureArtifact("trt.feature").isPresent());
 	}
 
 	@Test
@@ -86,7 +86,7 @@ public class TargetRestrictionThroughTargetFilesTest extends AbstractTychoIntegr
 		assertFalse(p2Repo.getBundleArtifact("trt.bundle.referenced", "2.0.0.201108051319").isFile());
 		assertTrue(p2Repo.getBundleArtifact("trt.bundle.referenced", "1.0.0.201108051343").isFile());
 
-		assertTrue(p2Repo.findFeatureArtifact("trt.feature").isFile());
+		assertTrue(p2Repo.findFeatureArtifact("trt.feature").isPresent());
 	}
 
 	private File getTargetsProject() {

--- a/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
@@ -92,6 +92,15 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
     private boolean includeAllSources;
 
     /**
+     * If enabled, units and artifacts that are part of a referenced repository are excluded from
+     * the mirror operation. This can be used (together with {@link #includeAllDependencies}) to
+     * build a repository that is both self contained and minimal in regard to the referenced
+     * repositories)
+     */
+    @Parameter(defaultValue = "false")
+    private boolean filterProvided;
+
+    /**
      * <p>
      * By default, only included plugins of a feature are included in the repository, setting this
      * to true will also include plugins mentioned in the dependencies section of a feature
@@ -224,7 +233,7 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
                         !createArtifactRepository, true, extraArtifactRepositoryProperties, repositoryReferences);
                 mirrorApp.mirrorReactor(sources, destinationRepoDescriptor, projectSeeds, getBuildContext(),
                         includeAllDependencies, includeAllSources, includeRequiredPlugins, includeRequiredFeatures,
-                        profileProperties);
+                        filterProvided, profileProperties);
             } catch (FacadeException e) {
                 throw new MojoExecutionException("Could not assemble p2 repository", e);
             }


### PR DESCRIPTION
A work in progress (test is required and depend on #2027) but something that came into my mind when reading 
https://github.com/eclipse-m2e/m2e-core/issues/1214#issuecomment-1404244327

FYI @HannesWell  As m2e references some 3rd party sites, we might can use this option to include everything but those already available from the referenced repos without mention all of them in features.