### PR TITLE
Cleanup Tycho Resolver SPI

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -61,11 +61,9 @@ import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.sisu.equinox.EquinoxServiceFactory;
 import org.eclipse.tycho.BuildFailureException;
 import org.eclipse.tycho.DependencyResolutionException;
-import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.DefaultBundleReader;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.utils.TychoVersion;
 import org.eclipse.tycho.p2maven.MavenProjectDependencyProcessor;
 import org.eclipse.tycho.p2maven.MavenProjectDependencyProcessor.ProjectDependencyClosure;
@@ -130,8 +128,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
             configureComponents(session);
 
             for (MavenProject project : projects) {
-                ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-                resolver.setupProject(session, project, reactorProject);
+                resolver.setupProject(session, project);
             }
             if (TychoConstants.USE_OLD_RESOLVER) {
                 resolveProjects(session, projects);
@@ -234,7 +231,6 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
     }
 
     private void resolveProjects(MavenSession session, List<MavenProject> projects) {
-        List<ReactorProject> reactorProjects = DefaultReactorProject.adapt(session);
 
         MavenExecutionRequest request = session.getRequest();
         boolean failFast = MavenExecutionRequest.REACTOR_FAIL_FAST.equals(request.getReactorFailureBehavior());
@@ -247,7 +243,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
             try {
                 MavenSession clone = session.clone();
                 clone.setCurrentProject(project);
-                resolver.resolveProject(clone, project, reactorProjects);
+                resolver.resolveProject(clone, project);
                 if (DUMP_DATA) {
                     try {
                         modelWriter.write(new File(project.getBasedir(), "pom-model-classic.xml"), Map.of(),

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoProjectExecutionListener.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoProjectExecutionListener.java
@@ -99,12 +99,11 @@ public class TychoProjectExecutionListener implements ProjectExecutionListener {
         }
         MavenProject mavenProject = event.getProject();
         MavenSession mavenSession = event.getSession();
-        List<ReactorProject> reactorProjects = DefaultReactorProject.adapt(mavenSession);
         MavenSession oldSession = legacySupport.getSession();
         try {
             legacySupport.setSession(mavenSession);
             //FIXME should return tycho project!
-            resolver.resolveProject(mavenSession, mavenProject, reactorProjects);
+            resolver.resolveProject(mavenSession, mavenProject);
             TychoProject tychoProject = projectManager.getTychoProject(mavenProject).orElse(null);
             if (tychoProject != null) {
                 try {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTychoResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTychoResolver.java
@@ -73,7 +73,8 @@ public class DefaultTychoResolver implements TychoResolver {
     public static final String TYCHO_ENV_OSGI_ARCH = "tycho.env.osgi.arch";
 
     @Override
-    public void setupProject(MavenSession session, MavenProject project, ReactorProject reactorProject) {
+    public void setupProject(MavenSession session, MavenProject project) {
+        ReactorProject reactorProject = DefaultReactorProject.adapt(project);
         AbstractTychoProject dr = (AbstractTychoProject) projectTypes.get(project.getPackaging());
         if (dr == null) {
             return;
@@ -112,13 +113,9 @@ public class DefaultTychoResolver implements TychoResolver {
     }
 
     @Override
-    public void resolveMavenProject(MavenSession session, MavenProject project, List<MavenProject> mavenProjects) {
+    public void resolveProject(MavenSession session, MavenProject project) {
+        List<MavenProject> mavenProjects = session.getProjects();
         List<ReactorProject> reactorProjects = mavenProjects.stream().map(DefaultReactorProject::adapt).toList();
-        resolveProject(session, project, reactorProjects);
-    }
-
-    @Override
-    public void resolveProject(MavenSession session, MavenProject project, List<ReactorProject> reactorProjects) {
         AbstractTychoProject dr = (AbstractTychoProject) projectTypes.get(project.getPackaging());
         if (dr == null) {
             return;

--- a/tycho-spi/src/main/java/org/eclipse/tycho/resolver/TychoResolver.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/resolver/TychoResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2011 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2023 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,18 +12,25 @@
  *******************************************************************************/
 package org.eclipse.tycho.resolver;
 
-import java.util.List;
-
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
-import org.eclipse.tycho.ReactorProject;
 
 public interface TychoResolver {
-    // TODO project and reactorProject represent the same thing!? -> should be one paramenter
-    public void setupProject(MavenSession session, MavenProject project, ReactorProject reactorProject);
+    /**
+     * Performs basic project setup of a maven project for a given session
+     * 
+     * @param session
+     * @param project
+     */
+    void setupProject(MavenSession session, MavenProject project);
 
-    public void resolveMavenProject(MavenSession session, MavenProject project, List<MavenProject> mavenProjects);
-
-    public void resolveProject(MavenSession session, MavenProject project, List<ReactorProject> reactorProjects);
+    /**
+     * Performs resolve operation of Tycho dependencies and inject the result into the maven model
+     * of the given project
+     * 
+     * @param session
+     * @param project
+     */
+    void resolveProject(MavenSession session, MavenProject project);
 
 }

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/testing/AbstractTychoMojoTestCase.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/testing/AbstractTychoMojoTestCase.java
@@ -178,7 +178,7 @@ public class AbstractTychoMojoTestCase extends AbstractMojoTestCase {
             MavenSession oldSession = lookup.getSession();
             try {
                 lookup.setSession(session);
-                tychoResolver.resolveMavenProject(session, mavenProject, projects);
+                tychoResolver.resolveProject(session, mavenProject);
             } catch (RuntimeException e) {
                 result.addException(e);
             } finally {


### PR DESCRIPTION
historically it has references to the ReactorProject but actually can work without as there is always a mapping from
MavenProject->ReactorProject, also the list of projects can be determined directly from the session so there is no need to keep this in the API as implementation might choose to query other sources as well.