### PR TITLE
Allow configuring ClassLoader order in OsgiSurefireBooter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ## 4.0.0 (under development)
 
+### Class loading changes for Eclipse based tests
+
+Due to reported class loading clashes, the ordering of class loading has been modified in Eclipse based tests.
+The previous loading can be restored by a new `classLoaderOrder` parameter.
+This applies to `tycho-surefire-plugin:test` and `tycho-surefire-plugin:plugin-test`.
+
 ### new bnd-test mojo
 
 Tycho now has a new mojo `tycho-surefire-plugin:bnd-test` to easily execute tests using the [bnd-testing](https://bnd.bndtools.org/chapters/310-testing.html) framework.

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -528,6 +528,27 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     @Parameter
     private int reactorConcurrencyLevel;
 
+    public enum ClassLoaderOrder {
+        booterFirst, testProbeFirst
+    }
+
+    /**
+     * The test runtime is configured with a composite class loader. This defines the order in which
+     * the loaders are searched, and it may need to be configured depending on the resolved
+     * classpath of the project.
+     * <p>
+     * Available values are:
+     * <ul>
+     * <li><code>booterFirst</code> - the loader of the surefire booter (including bundled test
+     * platform) is searched first</li>
+     * <li><code>testProbeFirst</code> - the loader of the test class's plugin is searched
+     * first</li>
+     * </ul>
+     * Defaults to <code>booterFirst</code>.
+     */
+    @Parameter(defaultValue = "booterFirst")
+    private ClassLoaderOrder classLoaderOrder;
+
     @Component
     private ProviderHelper providerHelper;
 
@@ -838,6 +859,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         wrapper.setProperty("rerunFailingTestsCount", String.valueOf(rerunFailingTestsCount));
         wrapper.setProperty("printBundles", String.valueOf(printBundles));
         wrapper.setProperty("printWires", String.valueOf(printWires));
+        wrapper.setProperty("classLoaderOrder", classLoaderOrder.toString());
         Properties mergedProviderProperties = getMergedProviderProperties();
         mergedProviderProperties.putAll(provider.getProviderSpecificProperties());
         Map<String, String> providerPropertiesAsMap = propertiesAsMap(mergedProviderProperties);


### PR DESCRIPTION
The composite loader searches the three loaders in order. If another "copy" of the JUnit Platform classes is available (and visible to the test class loader) it can take priority over the classes in the Surefire booter plugin causing a conflict.