### PR TITLE
Ignore testfailures in the platform build...

### DIFF
--- a/.github/workflows/verify-platform2.yml
+++ b/.github/workflows/verify-platform2.yml
@@ -69,6 +69,7 @@ jobs:
         --global-toolchains ${{ github.workspace }}/platform/.github/toolchains.xml
         -Pbuild-individual-bundles
         -Pbree-libs
+        -Dmaven.test.failure.ignore=true
         -Dtycho.version=4.0.0-SNAPSHOT
         -T1C
         clean verify


### PR DESCRIPTION
... we are actually only interested that the build itself resolve, compile and run the tests, but not so much about there results.