### PR TITLE
Fix the annotation contributor to place the correct version on the CP

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ResolvedArtifactKey.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ResolvedArtifactKey.java
@@ -23,6 +23,10 @@ public interface ResolvedArtifactKey extends ArtifactKey {
         return of(key.getType(), key.getId(), key.getVersion(), location);
     }
 
+    static ResolvedArtifactKey bundle(String id, String version, File location) {
+        return of(ArtifactType.TYPE_ECLIPSE_PLUGIN, id, version, location);
+    }
+
     static ResolvedArtifactKey of(String type, String id, String version, File location) {
         Objects.requireNonNull(location);
         if (!location.exists()) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/BundleAnnotationsClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/BundleAnnotationsClasspathContributor.java
@@ -19,7 +19,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.classpath.ClasspathContributor;
-import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 @Component(role = ClasspathContributor.class, hint = "bundle-annotations")
 @SessionScoped
@@ -28,7 +28,7 @@ public class BundleAnnotationsClasspathContributor extends AbstractSpecification
     private static final String PACKAGE_NAME = "org.osgi.annotation.bundle";
     private static final String GROUP_ID = "org.osgi";
     private static final String ARTIFACT_ID = "org.osgi.annotation.bundle";
-    private static final Version VERSION = new Version(1, 0, 0);
+    private static final VersionRange VERSION = new VersionRange("[1,2)");
 
     @Inject
     protected BundleAnnotationsClasspathContributor(MavenSession session) {
@@ -36,7 +36,7 @@ public class BundleAnnotationsClasspathContributor extends AbstractSpecification
     }
 
     @Override
-    protected Version getSpecificationVersion(MavenProject project) {
+    protected VersionRange getSpecificationVersion(MavenProject project) {
         return VERSION;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/ConfigurationAdminAnnotationsClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/ConfigurationAdminAnnotationsClasspathContributor.java
@@ -19,7 +19,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.classpath.ClasspathContributor;
-import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 @Component(role = ClasspathContributor.class, hint = "cm-annotations")
 @SessionScoped
@@ -29,7 +29,7 @@ public class ConfigurationAdminAnnotationsClasspathContributor extends AbstractS
     private static final String GROUP_ID = "org.osgi";
     //TODO there is no extra artifact see https://github.com/osgi/osgi/issues/567
     private static final String ARTIFACT_ID = "org.osgi.service.cm";
-    private static final Version VERSION = new Version(1, 0, 0);
+    private static final VersionRange VERSION = new VersionRange("[1.5,2)");
 
     @Inject
     protected ConfigurationAdminAnnotationsClasspathContributor(MavenSession session) {
@@ -37,7 +37,7 @@ public class ConfigurationAdminAnnotationsClasspathContributor extends AbstractS
     }
 
     @Override
-    protected Version getSpecificationVersion(MavenProject project) {
+    protected VersionRange getSpecificationVersion(MavenProject project) {
         return VERSION;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EventAdminAnnotationsClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EventAdminAnnotationsClasspathContributor.java
@@ -19,7 +19,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.classpath.ClasspathContributor;
-import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 @Component(role = ClasspathContributor.class, hint = "eventadmin-annotations")
 @SessionScoped
@@ -29,7 +29,7 @@ public class EventAdminAnnotationsClasspathContributor extends AbstractSpecifica
     private static final String GROUP_ID = "org.osgi";
     //TODO there is no extra artifact see https://github.com/osgi/osgi/issues/567
     private static final String ARTIFACT_ID = "org.osgi.service.event";
-    private static final Version VERSION = new Version(1, 0, 0);
+    private static final VersionRange VERSION = new VersionRange("[1.3,2)");
 
     @Inject
     protected EventAdminAnnotationsClasspathContributor(MavenSession session) {
@@ -37,7 +37,7 @@ public class EventAdminAnnotationsClasspathContributor extends AbstractSpecifica
     }
 
     @Override
-    protected Version getSpecificationVersion(MavenProject project) {
+    protected VersionRange getSpecificationVersion(MavenProject project) {
         return VERSION;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/MavenBundleResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/MavenBundleResolver.java
@@ -83,7 +83,6 @@ public class MavenBundleResolver {
                     return Optional.of(ResolvedArtifactKey.of(resolvedType, resolvedArtifact.getId(),
                             resolvedArtifact.getVersion(), location));
                 }
-
             } catch (DependencyResolutionException | IllegalArtifactReferenceException e) {
                 logger.debug("Cannot find key " + mavenArtifactKey + " in target platform " + e + ", try maven now...");
             }
@@ -97,6 +96,9 @@ public class MavenBundleResolver {
             dependency.setArtifactId(artifactId);
             dependency.setVersion(mavenArtifactKey.getVersion());
             Artifact artifact = dependenciesResolver.resolveHighestVersion(project, mavenSession, dependency);
+            if (artifact == null) {
+                return Optional.empty();
+            }
             ArtifactKey artifactKey = projectManager.getArtifactKey(artifact);
             return Optional.of(ResolvedArtifactKey.of(resolvedType, artifactKey.getId(), artifactKey.getVersion(),
                     artifact.getFile()));

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/MetatypeAnnotationsClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/MetatypeAnnotationsClasspathContributor.java
@@ -19,7 +19,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.classpath.ClasspathContributor;
-import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 @Component(role = ClasspathContributor.class, hint = "metatype-annotations")
 @SessionScoped
@@ -28,7 +28,7 @@ public class MetatypeAnnotationsClasspathContributor extends AbstractSpecificati
     private static final String PACKAGE_NAME = "org.osgi.service.metatype.annotations";
     private static final String GROUP_ID = "org.osgi";
     private static final String ARTIFACT_ID = "org.osgi.service.metatype.annotations";
-    private static final Version VERSION = new Version(1, 0, 0);
+    private static final VersionRange VERSION = new VersionRange("[1,2)");
 
     @Inject
     protected MetatypeAnnotationsClasspathContributor(MavenSession session) {
@@ -36,7 +36,7 @@ public class MetatypeAnnotationsClasspathContributor extends AbstractSpecificati
     }
 
     @Override
-    protected Version getSpecificationVersion(MavenProject project) {
+    protected VersionRange getSpecificationVersion(MavenProject project) {
         return VERSION;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/VersioningAnnotationsClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/VersioningAnnotationsClasspathContributor.java
@@ -19,7 +19,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.classpath.ClasspathContributor;
-import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 @Component(role = ClasspathContributor.class, hint = "versioning-annotations")
 @SessionScoped
@@ -28,7 +28,7 @@ public class VersioningAnnotationsClasspathContributor extends AbstractSpecifica
     private static final String PACKAGE_NAME = "org.osgi.annotation.versioning";
     private static final String GROUP_ID = "org.osgi";
     private static final String ARTIFACT_ID = "org.osgi.annotation.versioning";
-    private static final Version VERSION = new Version(1, 0, 0);
+    private static final VersionRange VERSION = new VersionRange("[1,2)");
 
     @Inject
     protected VersioningAnnotationsClasspathContributor(MavenSession session) {
@@ -36,7 +36,7 @@ public class VersioningAnnotationsClasspathContributor extends AbstractSpecifica
     }
 
     @Override
-    protected Version getSpecificationVersion(MavenProject project) {
+    protected VersionRange getSpecificationVersion(MavenProject project) {
         return VERSION;
     }
 


### PR DESCRIPTION
Currently DS Classpath contributor uses an open range, what will cause using a more recent annotation jar