### PR TITLE
Support discovery of shadowed units

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PreliminaryTargetPlatformImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PreliminaryTargetPlatformImpl.java
@@ -53,11 +53,13 @@ public class PreliminaryTargetPlatformImpl extends TargetPlatformBaseImpl {
 
     private final boolean includeLocalRepo;
 
+    private Set<IInstallableUnit> shadowed;
+
     public PreliminaryTargetPlatformImpl(Map<IInstallableUnit, ReactorProjectIdentities> reactorProjectIUs,
             Collection<IInstallableUnit> externalIUs, ExecutionEnvironmentResolutionHints executionEnvironment,
             TargetPlatformFilterEvaluator filter, LocalMetadataRepository localMetadataRepository,
             IRawArtifactFileProvider externalArtifacts, LocalArtifactRepository localArtifactRepository,
-            boolean includeLocalRepo, MavenLogger logger) {
+            boolean includeLocalRepo, MavenLogger logger, Set<IInstallableUnit> shadowed) {
         super(collectAllInstallableUnits(reactorProjectIUs, externalIUs, executionEnvironment), executionEnvironment,
                 externalArtifacts, localArtifactRepository, reactorProjectIUs, new HashMap<>());
         this.externalIUs = externalIUs;
@@ -65,6 +67,7 @@ public class PreliminaryTargetPlatformImpl extends TargetPlatformBaseImpl {
         this.localMetadataRepository = localMetadataRepository;
         this.includeLocalRepo = includeLocalRepo;
         this.logger = logger;
+        this.shadowed = shadowed;
     }
 
     public static LinkedHashSet<IInstallableUnit> collectAllInstallableUnits(
@@ -118,6 +121,13 @@ public class PreliminaryTargetPlatformImpl extends TargetPlatformBaseImpl {
 
     public IRawArtifactFileProvider getExternalArtifacts() {
         return artifacts;
+    }
+
+    /**
+     * @return all units that are shadowed by a reactor project IU
+     */
+    public Set<IInstallableUnit> getShadowed() {
+        return shadowed;
     }
 
     @Override

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ShadowedUnitsQueryable.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ShadowedUnitsQueryable.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2resolver;
+
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.query.IQuery;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.IQueryable;
+import org.eclipse.tycho.core.resolver.target.P2TargetPlatform;
+
+final class ShadowedUnitsQueryable implements IQueryable<IInstallableUnit> {
+    private final P2TargetPlatform targetPlatform;
+    private final IQueryable<IInstallableUnit> availableUnits;
+    private Set<IInstallableUnit> usedShadowedUnits;
+
+    ShadowedUnitsQueryable(P2TargetPlatform targetPlatform, IQueryable<IInstallableUnit> availableUnits,
+            Set<IInstallableUnit> usedShadowedUnits) {
+        this.targetPlatform = targetPlatform;
+        this.availableUnits = availableUnits;
+        this.usedShadowedUnits = usedShadowedUnits;
+    }
+
+    @Override
+    public IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
+        IQueryResult<IInstallableUnit> result = availableUnits.query(query, monitor);
+        if (result.isEmpty()) {
+            if (targetPlatform instanceof PreliminaryTargetPlatformImpl) {
+                PreliminaryTargetPlatformImpl preliminaryTargetPlatform = (PreliminaryTargetPlatformImpl) targetPlatform;
+                Set<IInstallableUnit> shadowed = preliminaryTargetPlatform.getShadowed();
+                IQueryResult<IInstallableUnit> shadowedResult = query.perform(shadowed.iterator());
+                if (!shadowedResult.isEmpty()) {
+                    for (IInstallableUnit unit : shadowedResult) {
+                        usedShadowedUnits.add(unit);
+                    }
+                    return shadowedResult;
+                }
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Currently Tycho removes each unit form the target platform state that is matching the ID of a reactor project. If there is a requirement that has a strict range (e.g. including a specific build qualifier) resolution can fail.

This adds support for first look in the project units, then if nothing is found the shadowed units are queried and if a result is found this is returned and a warning is printed to inform the user about this.