### PR TITLE
[3.0.x] Backport fixes/improvements for tycho-apitools-plugin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 This page describes the noteworthy improvements provided by each release of Eclipse Tycho.
 
+## 3.0.3
+
+### Parameter enhancements for tycho-apitools-plugin:generate goal
+
+The parameters of the `tycho-apitools-plugin:generate` goal have been completed and improved.
+
 ## 3.0.2
 
 ### Fixed support for the generation of a source feature from a maven target-location template

--- a/tycho-apitools-plugin/pom.xml
+++ b/tycho-apitools-plugin/pom.xml
@@ -8,6 +8,9 @@
 	<artifactId>tycho-apitools-plugin</artifactId>
 	<name>Plugin for performing API analysis tasks</name>
 	<packaging>maven-plugin</packaging>
+	<properties>
+		<asm.version>9.4</asm.version>
+	</properties>
 	<dependencies>
 		<!-- Maven -->
 		<dependency>
@@ -57,6 +60,22 @@
 		    <groupId>org.eclipse.jdt</groupId>
 		    <artifactId>org.eclipse.jdt.core</artifactId>
 		    <version>3.32.0</version>
+		</dependency>
+		<!-- libs -->
+		<dependency>
+		  <groupId>org.ow2.asm</groupId>
+		  <artifactId>asm</artifactId>
+		  <version>${asm.version}</version>
+		</dependency>
+		<dependency>
+		  <groupId>org.ow2.asm</groupId>
+		  <artifactId>asm-tree</artifactId>
+		  <version>${asm.version}</version>
+		</dependency>
+		<dependency>
+		  <groupId>org.ow2.asm</groupId>
+		  <artifactId>asm-util</artifactId>
+		  <version>${asm.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java
@@ -45,6 +45,36 @@ public class ApiFileGenerationMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.artifactId}_${project.version}")
 	protected String projectName;
 
+	/**
+	 * @Since 3.0.3
+	 */
+	@Parameter(defaultValue = "false")
+	private boolean allowNonApiProject;
+
+	/**
+	 * @Since 3.0.3
+	 */
+	@Parameter
+	protected String encoding;
+
+	/**
+	 * @Since 3.0.3
+	 */
+	@Parameter
+	protected boolean debug;
+
+	/**
+	 * @Since 3.0.3
+	 */
+	@Parameter
+	protected String extraManifests;
+
+	/**
+	 * @Since 3.0.3
+	 */
+	@Parameter
+	protected String extraSourceLocations;
+
 	@Parameter(defaultValue = "false", property = "tycho.apitools.generate.skip")
 	private boolean skip;
 
@@ -61,6 +91,11 @@ public class ApiFileGenerationMojo extends AbstractMojo {
 				generator.projectLocation = projectLocation.getAbsolutePath();
 				generator.binaryLocations = binaryLocations.getAbsolutePath();
 				generator.targetFolder = targetFolder.getAbsolutePath();
+				generator.allowNonApiProject = allowNonApiProject;
+				generator.encoding = encoding;
+				generator.debug = debug;
+				generator.manifests = extraManifests;
+				generator.sourceLocations = extraSourceLocations;
 				generator.generateAPIFile();
 			}
 		}

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java
@@ -53,6 +53,9 @@ public class ApiFileGenerationMojo extends AbstractMojo {
 		if (new File(project.getBasedir(), JarFile.MANIFEST_NAME).isFile()) {
 			synchronized (ApiFileGenerationMojo.class) {
 				// TODO check if the generator is thread safe, then we can remove this!
+				if (!binaryLocations.exists()) {
+					binaryLocations.mkdirs();
+				}
 				APIFileGenerator generator = new APIFileGenerator();
 				generator.projectName = projectName;
 				generator.projectLocation = projectLocation.getAbsolutePath();


### PR DESCRIPTION
`tycho-apitools-plugin` is currently unusable in 3.0.x, as it is missing d6c543d700be37d09a64e31654249424cd2b4f4e.

This PR backports this fix as well as other improvements to bring `tycho-apitools-plugin` on par with 4.x