### PR TITLE
Make maven-compat test dependency in tycho-core

### DIFF
--- a/tycho-core/pom.xml
+++ b/tycho-core/pom.xml
@@ -269,6 +269,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-compat</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/tycho-its/projects/resolver.usesConstraintViolations/pom.xml
+++ b/tycho-its/projects/resolver.usesConstraintViolations/pom.xml
@@ -8,10 +8,6 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<properties>
-		<tycho-version>2.6.0-SNAPSHOT</tycho-version>
-	</properties>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -32,7 +28,12 @@
 						<environment>
 							<os>linux</os>
 							<ws>gtk</ws>
-							<arch>x86</arch>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86_64</arch>
 						</environment>
 					</environments>
 				</configuration>


### PR DESCRIPTION
It's used only in tests so this is first step for removing it from dependency tree.