### PR TITLE
Respect the -N,--non-recursivein version-plugin

### DIFF
--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/AbstractChangeMojo.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/AbstractChangeMojo.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2015 Sonatype Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Sonatype Inc. - initial API and implementation
+ *    Sebastien Arod - update version ranges
+ *******************************************************************************/
+package org.eclipse.tycho.versions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.tycho.versions.engine.ProjectMetadataReader;
+import org.eclipse.tycho.versions.engine.VersionsEngine;
+
+public abstract class AbstractChangeMojo extends AbstractMojo {
+
+    /**
+     * <p>
+     * Initial list of of projects to be changed. From these projects, the full list of projects to
+     * be changed is derived according to the rules described above. If set, this parameter needs to
+     * be specified as a comma separated list of artifactIds.
+     * </p>
+     */
+    @Parameter(property = "artifacts", defaultValue = "${project.artifactId}")
+    private String artifacts;
+
+    @Component
+    private VersionsEngine engine;
+
+    @Parameter(property = "session", readonly = true)
+    protected MavenSession session;
+
+    @Component
+    private ProjectMetadataReader metadataReader;
+
+    @Override
+    public final void execute() throws MojoExecutionException, MojoFailureException {
+        synchronized (engine) {
+            synchronized (metadataReader) {
+                try {
+                    metadataReader.addBasedir(session.getCurrentProject().getBasedir(),
+                            session.getRequest().isRecursive());
+                    engine.setProjects(metadataReader.getProjects());
+                    addChanges(split(artifacts), engine);
+                    engine.apply();
+                    engine.reset();
+                    metadataReader.reset();
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Could not set version", e);
+                }
+            }
+        }
+    }
+
+    protected static List<String> split(String str) {
+        ArrayList<String> result = new ArrayList<>();
+        if (str != null) {
+            StringTokenizer st = new StringTokenizer(str, ",");
+            while (st.hasMoreTokens()) {
+                result.add(st.nextToken().trim());
+            }
+        }
+        return result;
+    }
+
+    protected abstract void addChanges(List<String> artifacts, VersionsEngine engine)
+            throws MojoExecutionException, IOException;
+}

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/UpdateEclipseMetadataMojo.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/UpdateEclipseMetadataMojo.java
@@ -45,7 +45,7 @@ public class UpdateEclipseMetadataMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         synchronized (LOCK) {
             try {
-                pomReader.addBasedir(session.getCurrentProject().getBasedir());
+                pomReader.addBasedir(session.getCurrentProject().getBasedir(), true);
                 metadataUpdater.setProjects(pomReader.getProjects());
                 metadataUpdater.apply();
             } catch (IOException e) {

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/UpdatePomMojo.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/UpdatePomMojo.java
@@ -46,7 +46,7 @@ public class UpdatePomMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         synchronized (LOCK) {
             try {
-                pomReader.addBasedir(session.getCurrentProject().getBasedir());
+                pomReader.addBasedir(session.getCurrentProject().getBasedir(), true);
                 pomUpdater.setProjects(pomReader.getProjects());
                 pomUpdater.apply();
             } catch (IOException e) {

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/VersionBumpBuildListener.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/VersionBumpBuildListener.java
@@ -69,7 +69,7 @@ public class VersionBumpBuildListener implements BuildListener {
                         int increment = VersionBumpMojo.getIncrement(session, project, projectHelper);
                         metadataReader.reset();
                         engine.reset();
-                        PomFile pomFile = metadataReader.addBasedir(project.getBasedir());
+                        PomFile pomFile = metadataReader.addBasedir(project.getBasedir(), false);
                         if (pomFile != null) {
                             String currentVersion = pomFile.getVersion();
                             String newVersion = Versions.incrementVersion(currentVersion, increment);

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/ProjectMetadataReader.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/ProjectMetadataReader.java
@@ -47,7 +47,7 @@ public class ProjectMetadataReader {
         projects.clear();
     }
 
-    public PomFile addBasedir(File basedir) throws IOException {
+    public PomFile addBasedir(File basedir, boolean recursive) throws IOException {
         // Unfold configuration inheritance
 
         if (!basedir.exists()) {
@@ -90,9 +90,9 @@ public class ProjectMetadataReader {
         project.putMetadata(pom);
 
         String packaging = pom.getPackaging();
-        if (PACKAGING_POM.equals(packaging)) {
+        if (recursive && PACKAGING_POM.equals(packaging)) {
             for (File child : getChildren(basedir, pom)) {
-                addBasedir(child);
+                addBasedir(child, recursive);
             }
         }
         return pom;

--- a/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/EclipseVersionUpdaterTest.java
+++ b/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/EclipseVersionUpdaterTest.java
@@ -32,7 +32,7 @@ public class EclipseVersionUpdaterTest extends AbstractVersionChangeTest {
     public void test() throws Exception {
         File basedir = TestUtil.getBasedir("projects/updateeclipse");
 
-        reader.addBasedir(basedir);
+        reader.addBasedir(basedir, true);
 
         EclipseVersionUpdater updater = lookup(EclipseVersionUpdater.class);
         updater.setProjects(reader.getProjects());

--- a/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/PomUpdaterTest.java
+++ b/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/PomUpdaterTest.java
@@ -32,7 +32,7 @@ public class PomUpdaterTest extends AbstractVersionChangeTest {
     public void test() throws Exception {
         File basedir = TestUtil.getBasedir("projects/updatepom");
 
-        reader.addBasedir(basedir);
+        reader.addBasedir(basedir, true);
 
         PomVersionUpdater updater = lookup(PomVersionUpdater.class);
         updater.setProjects(reader.getProjects());

--- a/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/ProjectMetadataReaderTest.java
+++ b/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/ProjectMetadataReaderTest.java
@@ -33,7 +33,7 @@ public class ProjectMetadataReaderTest extends TychoPlexusTestCase {
     public void test_moduleElementWithExplicitPomXml() throws Exception {
         File basedir = new File("src/test/resources/projects/simple/pom.xml");
         Assert.assertTrue(basedir.exists()); // sanity check
-        reader.addBasedir(basedir);
+        reader.addBasedir(basedir, true);
         Assert.assertEquals(1, reader.getProjects().size());
     }
 
@@ -41,7 +41,7 @@ public class ProjectMetadataReaderTest extends TychoPlexusTestCase {
     public void test_customPomXmlFileName() throws Exception {
         File basedir = new File("src/test/resources/projects/simple/pom.xml_expected");
         Assert.assertTrue(basedir.exists()); // sanity check
-        reader.addBasedir(basedir);
+        reader.addBasedir(basedir, true);
         Assert.assertEquals(1, reader.getProjects().size());
     }
 
@@ -49,7 +49,7 @@ public class ProjectMetadataReaderTest extends TychoPlexusTestCase {
     public void test_missingBasedir() throws Exception {
         File basedir = new File("src/test/resources/projects/simple/missing");
         Assert.assertFalse(basedir.exists()); // sanity check
-        reader.addBasedir(basedir);
+        reader.addBasedir(basedir, true);
         Assert.assertEquals(0, reader.getProjects().size());
     }
 }

--- a/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/VersionsEngineTest.java
+++ b/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/VersionsEngineTest.java
@@ -369,7 +369,7 @@ public class VersionsEngineTest extends AbstractVersionChangeTest {
         VersionsEngine engine = lookup(VersionsEngine.class);
         ProjectMetadataReader reader = lookup(ProjectMetadataReader.class);
 
-        reader.addBasedir(basedir);
+        reader.addBasedir(basedir, true);
 
         engine.setProjects(reader.getProjects());
 


### PR DESCRIPTION
Maven has a -N,--non-recursive(Do not recurse into sub-projects) option but currently the version-plugin always recurse into subdirectories.

This reads the MavenExecutionRequest#isRecursive() form the MavenSession to not recurse into modules and extract the logic into an abstract mojo other mojos can derive from.