### PR TITLE
Catch unexpected socket error when sending noop command

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/FtpTransportProtocolHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/FtpTransportProtocolHandler.java
@@ -9,6 +9,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
 import org.eclipse.tycho.MavenRepositorySettings.Credentials;
 
 import java.io.*;
+import java.net.SocketException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.time.Duration;
@@ -144,6 +145,8 @@ public class FtpTransportProtocolHandler implements TransportProtocolHandler, Di
             }
         } catch (final FTPConnectionClosedException e) {
             logger.debug(String.format("Connection to host %s was closed, reconnecting", key));
+        } catch (final SocketException e) {
+            logger.debug(String.format("Socket connection error for host %s, reconnecting", key), e);
         }
 
         client.disconnect();


### PR DESCRIPTION
The following stacktrace is from an error that I cannot reproduce anymore.  

I think catching the exception and trying to reconnect is ok.  
If there is a serious issue it will fail again when re-connecting.

```
[2023-02-17T21:41:33.890Z] [ERROR] Failed to execute goal org.eclipse.tycho:tycho-p2-repository-plugin:4.0.0-SNAPSHOT:assemble-repository (default-assemble-repository) on project com.ibm.etools.fm.p2updatesite: Execution default-assemble-repository of goal org.eclipse.tycho:tycho-p2-repository-plugin:4.0.0-SNAPSHOT:assemble-repository failed: Could not mirror artifact osgi.bundle,org.apache.ant,1.10.12.v20211102-1452 into the local Maven repository.See log output for details. An established connection was aborted by the software in your host machine -> [Help 1]
[2023-02-17T21:41:33.890Z] org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.eclipse.tycho:tycho-p2-repository-plugin:4.0.0-SNAPSHOT:assemble-repository (default-assemble-repository) on project com.ibm.etools.fm.p2updatesite: Execution default-assemble-repository of goal org.eclipse.tycho:tycho-p2-repository-plugin:4.0.0-SNAPSHOT:assemble-repository failed: Could not mirror artifact osgi.bundle,org.apache.ant,1.10.12.v20211102-1452 into the local Maven repository.See log output for details.
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:375)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
[2023-02-17T21:41:33.890Z]     at java.lang.reflect.Method.invoke (Method.java:568)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[2023-02-17T21:41:33.890Z] Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-assemble-repository of goal org.eclipse.tycho:tycho-p2-repository-plugin:4.0.0-SNAPSHOT:assemble-repository failed: Could not mirror artifact osgi.bundle,org.apache.ant,1.10.12.v20211102-1452 into the local Maven repository.See log output for details.
[2023-02-17T21:41:33.890Z]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:148)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
[2023-02-17T21:41:33.890Z]     at java.lang.reflect.Method.invoke (Method.java:568)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[2023-02-17T21:41:33.890Z] Caused by: org.eclipse.tycho.p2.repository.MirroringArtifactProvider$MirroringFailedException: Could not mirror artifact osgi.bundle,org.apache.ant,1.10.12.v20211102-1452 into the local Maven repository.See log output for details.
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.downloadArtifact (MirroringArtifactProvider.java:322)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.makeOneFormatLocallyAvailable (MirroringArtifactProvider.java:256)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.makeLocallyAvailable (MirroringArtifactProvider.java:206)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.getArtifactFile (MirroringArtifactProvider.java:137)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.CompositeArtifactProvider.getArtifactFile (CompositeArtifactProvider.java:89)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.CompositeArtifactProvider.getArtifactFile (CompositeArtifactProvider.java:89)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2resolver.TargetPlatformBaseImpl.getLocalArtifactFile (TargetPlatformBaseImpl.java:166)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.resolver.DefaultP2ResolutionResult.lambda$addArtifact$2 (DefaultP2ResolutionResult.java:90)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.resolver.DefaultP2ResolutionResultEntry.getLocation (DefaultP2ResolutionResultEntry.java:73)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2resolver.P2DependencyResolver.lambda$newDefaultTargetPlatform$4 (P2DependencyResolver.java:366)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.targetplatform.ArtifactCollection.lambda$addArtifactFile$2 (ArtifactCollection.java:69)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.DefaultArtifactDescriptor.getLocation (DefaultArtifactDescriptor.java:74)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.targetplatform.ArtifactCollection.lambda$addArtifact$3 (ArtifactCollection.java:148)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.DefaultArtifactDescriptor.getLocation (DefaultArtifactDescriptor.java:74)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.targetplatform.ArtifactCollection.lambda$addArtifact$3 (ArtifactCollection.java:148)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.DefaultArtifactDescriptor.getLocation (DefaultArtifactDescriptor.java:74)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2tools.RepositoryReferenceTool.lambda$addTargetPlatformRepository$0 (RepositoryReferenceTool.java:125)
[2023-02-17T21:41:33.890Z]     at java.util.ArrayList.forEach (ArrayList.java:1511)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2tools.RepositoryReferenceTool.addTargetPlatformRepository (RepositoryReferenceTool.java:125)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2tools.RepositoryReferenceTool.getVisibleRepositories (RepositoryReferenceTool.java:96)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.plugins.p2.repository.AssembleRepositoryMojo.execute (AssembleRepositoryMojo.java:221)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
[2023-02-17T21:41:33.890Z]     at java.lang.reflect.Method.invoke (Method.java:568)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[2023-02-17T21:41:33.890Z] Caused by: java.net.SocketException: An established connection was aborted by the software in your host machine
[2023-02-17T21:41:33.890Z]     at sun.nio.ch.NioSocketImpl.implRead (NioSocketImpl.java:325)
[2023-02-17T21:41:33.890Z]     at sun.nio.ch.NioSocketImpl.read (NioSocketImpl.java:350)
[2023-02-17T21:41:33.890Z]     at sun.nio.ch.NioSocketImpl$1.read (NioSocketImpl.java:803)
[2023-02-17T21:41:33.890Z]     at java.net.Socket$SocketInputStream.read (Socket.java:966)
[2023-02-17T21:41:33.890Z]     at sun.nio.cs.StreamDecoder.readBytes (StreamDecoder.java:270)
[2023-02-17T21:41:33.890Z]     at sun.nio.cs.StreamDecoder.implRead (StreamDecoder.java:313)
[2023-02-17T21:41:33.890Z]     at sun.nio.cs.StreamDecoder.read (StreamDecoder.java:188)
[2023-02-17T21:41:33.890Z]     at java.io.InputStreamReader.read (InputStreamReader.java:177)
[2023-02-17T21:41:33.890Z]     at java.io.BufferedReader.fill (BufferedReader.java:162)
[2023-02-17T21:41:33.890Z]     at java.io.BufferedReader.read (BufferedReader.java:183)
[2023-02-17T21:41:33.890Z]     at org.apache.commons.net.io.CRLFLineReader.readLine (CRLFLineReader.java:56)
[2023-02-17T21:41:33.890Z]     at org.apache.commons.net.ftp.FTP.getReply (FTP.java:565)
[2023-02-17T21:41:33.890Z]     at org.apache.commons.net.ftp.FTP.getReply (FTP.java:556)
[2023-02-17T21:41:33.890Z]     at org.apache.commons.net.ftp.FTP.sendCommand (FTP.java:1222)
[2023-02-17T21:41:33.890Z]     at org.apache.commons.net.ftp.FTP.sendCommand (FTP.java:1148)
[2023-02-17T21:41:33.890Z]     at org.apache.commons.net.ftp.FTP.sendCommand (FTP.java:1131)
[2023-02-17T21:41:33.890Z]     at org.apache.commons.net.ftp.FTP.noop (FTP.java:938)
[2023-02-17T21:41:33.890Z]     at org.apache.commons.net.ftp.FTPClient.sendNoOp (FTPClient.java:2854)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2maven.transport.FtpTransportProtocolHandler.getClient (FtpTransportProtocolHandler.java:142)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2maven.transport.FtpTransportProtocolHandler.getFile (FtpTransportProtocolHandler.java:72)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2maven.transport.TychoRepositoryTransport.stream (TychoRepositoryTransport.java:141)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2maven.transport.TychoRepositoryTransport.download (TychoRepositoryTransport.java:101)
[2023-02-17T21:41:33.890Z]     at org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository.downloadArtifact (SimpleArtifactRepository.java:748)
[2023-02-17T21:41:33.890Z]     at org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository.downloadArtifact (SimpleArtifactRepository.java:672)
[2023-02-17T21:41:33.890Z]     at org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository.getArtifact (SimpleArtifactRepository.java:804)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.RepositoryArtifactProvider.getArtifactFromOneMirror (RepositoryArtifactProvider.java:243)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.RepositoryArtifactProvider.getArtifactFromAnyMirror (RepositoryArtifactProvider.java:223)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.RepositoryArtifactProvider$1.perform (RepositoryArtifactProvider.java:198)
[2023-02-17T21:41:33.890Z]     at org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository.getArtifact (SimpleArtifactRepository.java:787)
[2023-02-17T21:41:33.890Z]     at org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository.getArtifacts (SimpleArtifactRepository.java:864)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.LazyArtifactRepository.getArtifacts (LazyArtifactRepository.java:102)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.RepositoryArtifactProvider.getArtifactFromAnyChildRepository (RepositoryArtifactProvider.java:210)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.RepositoryArtifactProvider.getArtifactFromAnyFormatAvailableInRepository (RepositoryArtifactProvider.java:177)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.RepositoryArtifactProvider.getArtifactFromAnySource (RepositoryArtifactProvider.java:163)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.CompositeArtifactProviderBaseImpl.getArtifact (CompositeArtifactProviderBaseImpl.java:55)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.downloadCanonicalArtifact (MirroringArtifactProvider.java:339)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.downloadMostSpecificNeededFormatOfArtifact (MirroringArtifactProvider.java:332)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.downloadArtifact (MirroringArtifactProvider.java:317)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.makeOneFormatLocallyAvailable (MirroringArtifactProvider.java:256)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.makeLocallyAvailable (MirroringArtifactProvider.java:206)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.MirroringArtifactProvider.getArtifactFile (MirroringArtifactProvider.java:137)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.CompositeArtifactProvider.getArtifactFile (CompositeArtifactProvider.java:89)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2.repository.CompositeArtifactProvider.getArtifactFile (CompositeArtifactProvider.java:89)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2resolver.TargetPlatformBaseImpl.getLocalArtifactFile (TargetPlatformBaseImpl.java:166)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.resolver.DefaultP2ResolutionResult.lambda$addArtifact$2 (DefaultP2ResolutionResult.java:90)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.resolver.DefaultP2ResolutionResultEntry.getLocation (DefaultP2ResolutionResultEntry.java:73)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2resolver.P2DependencyResolver.lambda$newDefaultTargetPlatform$4 (P2DependencyResolver.java:366)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.targetplatform.ArtifactCollection.lambda$addArtifactFile$2 (ArtifactCollection.java:69)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.DefaultArtifactDescriptor.getLocation (DefaultArtifactDescriptor.java:74)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.targetplatform.ArtifactCollection.lambda$addArtifact$3 (ArtifactCollection.java:148)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.DefaultArtifactDescriptor.getLocation (DefaultArtifactDescriptor.java:74)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.targetplatform.ArtifactCollection.lambda$addArtifact$3 (ArtifactCollection.java:148)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.core.osgitools.DefaultArtifactDescriptor.getLocation (DefaultArtifactDescriptor.java:74)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2tools.RepositoryReferenceTool.lambda$addTargetPlatformRepository$0 (RepositoryReferenceTool.java:125)
[2023-02-17T21:41:33.890Z]     at java.util.ArrayList.forEach (ArrayList.java:1511)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2tools.RepositoryReferenceTool.addTargetPlatformRepository (RepositoryReferenceTool.java:125)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.p2tools.RepositoryReferenceTool.getVisibleRepositories (RepositoryReferenceTool.java:96)
[2023-02-17T21:41:33.890Z]     at org.eclipse.tycho.plugins.p2.repository.AssembleRepositoryMojo.execute (AssembleRepositoryMojo.java:221)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
[2023-02-17T21:41:33.890Z]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
[2023-02-17T21:41:33.890Z]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
[2023-02-17T21:41:33.890Z]     at java.lang.reflect.Method.invoke (Method.java:568)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
[2023-02-17T21:41:33.890Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```