### PR TITLE
OsgiManifest parse should catch all Exception. then rethrow detail Os…

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiManifest.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiManifest.java
@@ -43,7 +43,8 @@ public class OsgiManifest {
             ManifestElement.parseBundleManifest(stream, headers);
             // this will do more strict validation of headers on OSGi semantical level
             this.bundleSymbolicName = OSGiManifestBuilderFactory.createBuilder(headers).getSymbolicName();
-        } catch (IOException | BundleException e) {
+        } catch (Exception e) {
+            // it should catch all Exception. then rethrow detail OsgiManifestParserException.
             throw new OsgiManifestParserException(location, e);
         }
         if (this.bundleSymbolicName == null) {


### PR DESCRIPTION
 All exceptions should be caught during OsgiManifest parsing and then re-thrown with a detailed exception with location. It is easy for users to troubleshoot which package has the problem. For example, parsing internal throw java.lang.IllegalArgumentException. it not included `location`

```log
Caused by: java.lang.IllegalArgumentException: invalid version "V008R003B1009": non-numeric "V008R003B1009"
    at org.osgi.framework.Version.parseInt (Version.java:169)
    at org.osgi.framework.Version.<init> (Version.java:126)
    at org.osgi.framework.Version.valueOf (Version.java:255)
    at org.osgi.framework.Version.parseVersion (Version.java:226)
    at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.getPackageExports (OSGiManifestBuilderFactory.java:334)
    at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.createBuilder (OSGiManifestBuilderFactory.java:106)
    at org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory.createBuilder (OSGiManifestBuilderFactory.java:78)
    at org.eclipse.tycho.core.osgitools.OsgiManifest.<init> (OsgiManifest.java:45)
```