### PR TITLE
Discover indirect parent references in version-update

### DIFF
--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/pom/GAV.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/pom/GAV.java
@@ -37,6 +37,10 @@ public class GAV {
         dom.getChild("version").setText(version);
     }
 
+    public String getRelativePath() {
+        return getChildText("relativePath");
+    }
+
     private String getChildText(String name) {
         Element child = dom.getChild(name);
         return child != null ? child.getTrimmedText() : null;


### PR DESCRIPTION
Currently the tycho-version plugin can miss to update a indirect parent reference, e.g. if a child module includes another parent (not listed as a module) and that parent actually references the parent of the root.