### PR TITLE
If pom file is empty, treat it as no pom file and dont ad it to the set

### DIFF
--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/ProjectMetadataReader.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/ProjectMetadataReader.java
@@ -72,8 +72,6 @@ public class ProjectMetadataReader {
         }
 
         ProjectMetadata project = new ProjectMetadata(basedir);
-        projects.put(basedir, project);
-
         File pomFile = null;
         for (ModelProcessor modelProcessor : modelprocessors) {
             File locatePom = modelProcessor.locatePom(basedir);
@@ -82,10 +80,11 @@ public class ProjectMetadataReader {
                 break;
             }
         }
-        if (pomFile == null || !pomFile.exists()) {
+        if (pomFile == null || !pomFile.exists() || pomFile.length() == 0) {
             log.warn("No pom file found at " + basedir);
             return null;
         }
+        projects.put(basedir, project);
         PomFile pom = PomFile.read(pomFile, PomFile.POM_XML.equals(pomFile.getName()));
         project.putMetadata(pom);
 


### PR DESCRIPTION
Currently a non existing (or null) file is treated as "no pom" but also an empty file is actually a "no pom".

Beside that, even if no pom was found the basedir was added to the projects what then fails the update later on with a different message.