### PR TITLE
Compute ExecutionEnvironmentConfiguration in the TychoProjectManager

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TargetPlatformService.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TargetPlatformService.java
@@ -23,6 +23,15 @@ public interface TargetPlatformService {
 
     /**
      * 
+     * @return the target platform for current calling context or an empty optional if the calling
+     *         context do not has one.
+     * @throws DependencyResolutionException
+     *             when the target platform for the project can not be resolved
+     */
+    Optional<TargetPlatform> getTargetPlatform() throws DependencyResolutionException;
+
+    /**
+     * 
      * @param project
      *            the project for what the {@link TargetPlatform} should be queried
      * @return the target platform for the given {@link ReactorProject} or an empty optional if the

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -45,7 +45,6 @@ public interface TychoConstants {
     static final String CTX_ECLIPSE_PLUGIN_TEST_CLASSPATH = CTX_BASENAME + "/eclipsePluginTestClasspath";
     static final String CTX_ECLIPSE_PLUGIN_TEST_EXTRA_CLASSPATH = CTX_BASENAME + "/eclipsePluginTestClasspathExtra";
 
-    static final String CTX_TARGET_PLATFORM_CONFIGURATION = CTX_BASENAME + "/targetPlatformConfiguration";
     static final String CTX_EXECUTION_ENVIRONMENT_CONFIGURATION = CTX_BASENAME + "/executionEnvironmentConfiguration";
 
     static final String CTX_DEPENDENCY_WALKER = CTX_BASENAME + "/dependencyWalker";

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -74,6 +74,7 @@ import org.eclipse.tycho.SourcepathEntry;
 import org.eclipse.tycho.classpath.ClasspathContributor;
 import org.eclipse.tycho.core.BundleProject;
 import org.eclipse.tycho.core.TychoProject;
+import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.dotClasspath.JREClasspathEntry;
 import org.eclipse.tycho.core.dotClasspath.M2ClasspathVariable;
 import org.eclipse.tycho.core.dotClasspath.ProjectClasspathEntry;
@@ -91,7 +92,6 @@ import org.eclipse.tycho.core.osgitools.OsgiBundleProject;
 import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.core.osgitools.project.EclipsePluginProject;
 import org.eclipse.tycho.core.resolver.shared.PomDependencies;
-import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.helper.PluginRealmHelper;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
@@ -361,6 +361,9 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
     private List<String> currentSourceRoots;
 
     private List<String> currentExcludes;
+
+    @Component
+    private TychoProjectManager tychoProjectManager;
 
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
@@ -817,9 +820,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
     }
 
     private ExecutionEnvironment getTargetExecutionEnvironment() {
-        // never null
-        return TychoProjectUtils.getExecutionEnvironmentConfiguration(DefaultReactorProject.adapt(project))
-                .getFullSpecification();
+        return tychoProjectManager.getExecutionEnvironmentConfiguration(project).getFullSpecification();
     }
 
     @Override

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractTychoProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractTychoProject.java
@@ -127,24 +127,28 @@ public abstract class AbstractTychoProject extends AbstractLogEnabled implements
 
     public void readExecutionEnvironmentConfiguration(ReactorProject project, MavenSession mavenSession,
             ExecutionEnvironmentConfiguration sink) {
-        TargetPlatformConfiguration tpConfiguration = projectManager.getTargetPlatformConfiguration(project);
+        readExecutionEnvironmentConfiguration(projectManager.getTargetPlatformConfiguration(project), sink);
+    }
 
-        String configuredForcedProfile = tpConfiguration.getExecutionEnvironment();
+    public static void readExecutionEnvironmentConfiguration(TargetPlatformConfiguration targetPlatformConfiguration,
+            ExecutionEnvironmentConfiguration executionEnvironmentConfiguration) {
+
+        String configuredForcedProfile = targetPlatformConfiguration.getExecutionEnvironment();
         if (configuredForcedProfile != null) {
-            sink.overrideProfileConfiguration(configuredForcedProfile,
+            executionEnvironmentConfiguration.overrideProfileConfiguration(configuredForcedProfile,
                     "target-platform-configuration <executionEnvironment>");
         } else {
-            tpConfiguration.getTargets().stream() //
+            targetPlatformConfiguration.getTargets().stream() //
                     .map(TargetDefinition::getTargetEE) //
                     .filter(Objects::nonNull) //
                     .findFirst() //
-                    .ifPresent(profile -> sink.overrideProfileConfiguration(profile,
+                    .ifPresent(profile -> executionEnvironmentConfiguration.overrideProfileConfiguration(profile,
                             "first targetJRE from referenced target-definition files"));
         }
 
-        String configuredDefaultProfile = tpConfiguration.getExecutionEnvironmentDefault();
+        String configuredDefaultProfile = targetPlatformConfiguration.getExecutionEnvironmentDefault();
         if (configuredDefaultProfile != null) {
-            sink.setProfileConfiguration(configuredDefaultProfile,
+            executionEnvironmentConfiguration.setProfileConfiguration(configuredDefaultProfile,
                     "target-platform-configuration <executionEnvironmentDefault>");
         }
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultReactorProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultReactorProject.java
@@ -44,6 +44,12 @@ public class DefaultReactorProject implements ReactorProject {
             + System.identityHashCode(ReactorProject.class);
 
     /**
+     * Conventional key used to store ReactorProject in MavenProject.context
+     */
+    private static final String CTX_MAVEN_SESSION = "tycho.reactor-project."
+            + System.identityHashCode(MavenSession.class);
+
+    /**
      * Conventional key used to store dependency metadata in MavenProject.context
      */
     private static final String CTX_DEPENDENCY_METADATA_PREFIX = "tycho.dependency-metadata-";
@@ -92,7 +98,9 @@ public class DefaultReactorProject implements ReactorProject {
     public static List<ReactorProject> adapt(MavenSession session) {
         ArrayList<ReactorProject> result = new ArrayList<>();
         for (MavenProject project : session.getProjects()) {
-            result.add(adapt(project));
+            ReactorProject reactorProject = adapt(project);
+            reactorProject.computeContextValue(CTX_MAVEN_SESSION, () -> session);
+            result.add(reactorProject);
         }
         return result;
     }
@@ -260,7 +268,7 @@ public class DefaultReactorProject implements ReactorProject {
     @Override
     public <T> T adapt(Class<T> target) {
         if (target == MavenSession.class) {
-            //TODO
+            return target.cast(getContextValue(CTX_MAVEN_SESSION));
         }
         if (target == MavenProject.class) {
             return target.cast(project);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -331,8 +331,8 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
     private ModuleContainer getResolverState(ReactorProject project, DependencyArtifacts artifacts,
             MavenSession session) {
         try {
-            ExecutionEnvironmentConfiguration eeConfiguration = TychoProjectUtils
-                    .getExecutionEnvironmentConfiguration(project);
+            ExecutionEnvironmentConfiguration eeConfiguration = projectManager
+                    .getExecutionEnvironmentConfiguration(getMavenProject(project));
             ExecutionEnvironment executionEnvironment = eeConfiguration.getFullSpecification();
             return resolver.newResolvedState(project, session,
                     eeConfiguration.isIgnoredByResolver() ? null : executionEnvironment, artifacts);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformService.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformService.java
@@ -55,6 +55,19 @@ public class DefaultTargetPlatformService implements TargetPlatformService {
     ReactorRepositoryManager repositoryManager;
 
     @Override
+    public Optional<TargetPlatform> getTargetPlatform() throws DependencyResolutionException {
+        MavenSession session = legacySupport.getSession();
+        if (session == null) {
+            return Optional.empty();
+        }
+        MavenProject mavenProject = session.getCurrentProject();
+        if (mavenProject == null) {
+            return Optional.empty();
+        }
+        return getTargetPlatform(DefaultReactorProject.adapt(mavenProject));
+    }
+
+    @Override
     public Optional<TargetPlatform> getTargetPlatform(ReactorProject project) throws DependencyResolutionException {
         synchronized (project) {
             Object contextValue = project.getContextValue(TargetPlatform.FINAL_TARGET_PLATFORM_KEY);
@@ -62,7 +75,7 @@ public class DefaultTargetPlatformService implements TargetPlatformService {
                 return Optional.of((TargetPlatform) contextValue);
             }
             MavenSession session = legacySupport.getSession();
-            if (repositoryManager == null) {
+            if (repositoryManager == null || session == null) {
                 return Optional.empty();
             }
             List<ReactorProjectIdentities> upstreamProjects = getReferencedTychoProjects(project);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTychoResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTychoResolver.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -34,15 +33,12 @@ import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.PlatformPropertiesUtils;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetPlatform;
-import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.BundleProject;
 import org.eclipse.tycho.core.DependencyResolver;
 import org.eclipse.tycho.core.DependencyResolverConfiguration;
 import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.TychoProjectManager;
-import org.eclipse.tycho.core.ee.ExecutionEnvironmentConfigurationImpl;
-import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.osgitools.AbstractTychoProject;
 import org.eclipse.tycho.core.osgitools.DebugUtils;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
@@ -61,9 +57,6 @@ public class DefaultTychoResolver implements TychoResolver {
     @Requirement()
     TychoProjectManager projectManager;
 
-    @Requirement
-    private ToolchainManager toolchainManager;
-
     public static final String TYCHO_ENV_OSGI_WS = "tycho.env.osgi.ws";
     public static final String TYCHO_ENV_OSGI_OS = "tycho.env.osgi.os";
     public static final String TYCHO_ENV_OSGI_ARCH = "tycho.env.osgi.arch";
@@ -78,13 +71,7 @@ public class DefaultTychoResolver implements TychoResolver {
             if (reactorProject.getContextValue(ReactorProject.CTX_MERGED_PROPERTIES) != null) {
                 return;
             }
-
-            // generic Eclipse/OSGi metadata
-
             dr.setupProject(session, project);
-
-            // p2 metadata
-
             Properties properties = new Properties();
             properties.putAll(project.getProperties());
             properties.putAll(session.getSystemProperties()); // session wins
@@ -92,13 +79,6 @@ public class DefaultTychoResolver implements TychoResolver {
             reactorProject.setContextValue(ReactorProject.CTX_MERGED_PROPERTIES, properties);
 
             setTychoEnvironmentProperties(properties, project);
-
-            TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
-            ExecutionEnvironmentConfiguration eeConfiguration = new ExecutionEnvironmentConfigurationImpl(logger,
-                    !configuration.isResolveWithEEConstraints(), toolchainManager, session);
-            dr.readExecutionEnvironmentConfiguration(reactorProject, session, eeConfiguration);
-            reactorProject.setContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION, eeConfiguration);
-
             dependencyResolver.setupProjects(session, project, reactorProject);
         }
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/utils/TychoProjectUtils.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/utils/TychoProjectUtils.java
@@ -20,7 +20,6 @@ import org.eclipse.tycho.DependencyArtifacts;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.TychoConstants;
-import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.resolver.shared.DependencySeed;
 
 public class TychoProjectUtils {
@@ -70,15 +69,6 @@ public class TychoProjectUtils {
      */
     public static TargetPlatform getTargetPlatformIfAvailable(ReactorProject project) {
         return (TargetPlatform) project.getContextValue(TargetPlatform.FINAL_TARGET_PLATFORM_KEY);
-    }
-
-    public static ExecutionEnvironmentConfiguration getExecutionEnvironmentConfiguration(ReactorProject project) {
-        ExecutionEnvironmentConfiguration storedConfig = (ExecutionEnvironmentConfiguration) project
-                .getContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION);
-        if (storedConfig == null) {
-            throw new IllegalStateException(TYCHO_NOT_CONFIGURED + project.toString());
-        }
-        return storedConfig;
     }
 
     /**

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -132,8 +132,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
     @Override
     public void setupProjects(final MavenSession session, final MavenProject project,
             final ReactorProject reactorProject) {
-        TargetPlatformConfiguration configuration = (TargetPlatformConfiguration) reactorProject
-                .getContextValue(TychoConstants.CTX_TARGET_PLATFORM_CONFIGURATION);
+        TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
         List<TargetEnvironment> environments = configuration.getEnvironments();
         Map<String, IDependencyMetadata> metadataMap = getDependencyMetadata(session, project, environments,
                 OptionalResolutionAction.OPTIONAL);
@@ -184,7 +183,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
             List<ReactorProject> reactorProjects) {
         ReactorProject reactorProject = DefaultReactorProject.adapt(project);
         TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
-        ExecutionEnvironmentConfiguration ee = TychoProjectUtils.getExecutionEnvironmentConfiguration(reactorProject);
+        ExecutionEnvironmentConfiguration ee = projectManager.getExecutionEnvironmentConfiguration(project);
 
         TargetPlatformConfigurationStub tpConfiguration = new TargetPlatformConfigurationStub();
         for (ArtifactRepository repository : project.getRemoteArtifactRepositories()) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomUnits.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomUnits.java
@@ -18,6 +18,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -30,7 +31,6 @@ import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.DependencyArtifacts;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.ReactorProject;
-import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.TychoProjectManager;
@@ -67,8 +67,8 @@ public class PomUnits {
         if (tychoProject.isEmpty()) {
             return new CollectionResult<>(Collections.emptyList());
         }
-        TargetPlatformConfiguration configuration = (TargetPlatformConfiguration) reactorProject
-                .getContextValue(TychoConstants.CTX_TARGET_PLATFORM_CONFIGURATION);
+        TargetPlatformConfiguration configuration = tychoProjectManager
+                .getTargetPlatformConfiguration(reactorProject.adapt(MavenProject.class));
         return reactorProject.computeContextValue(KEY, () -> {
             return new PomInstallableUnitStore(tychoProject.get(), reactorProject, generator, artifactHandlerManager,
                     logger, configuration);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ReactorRepositoryManagerImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ReactorRepositoryManagerImpl.java
@@ -16,6 +16,9 @@ package org.eclipse.tycho.p2resolver;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
@@ -24,7 +27,9 @@ import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.ReactorProjectIdentities;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.DependencyResolver;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
+import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.P2ResolverFactory;
 import org.eclipse.tycho.p2.repository.module.PublishingRepositoryImpl;
 import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
@@ -45,6 +50,11 @@ public class ReactorRepositoryManagerImpl implements ReactorRepositoryManager {
     @Requirement
     P2ResolverFactory p2ResolverFactory;
 
+    @Requirement(hint = P2DependencyResolver.ROLE_HINT)
+    DependencyResolver p2Resolver;
+
+    @Requirement
+    LegacySupport legacySupport;
     private TargetPlatformFactory tpFactory;
 
     @Override
@@ -74,8 +84,20 @@ public class ReactorRepositoryManagerImpl implements ReactorRepositoryManager {
             List<? extends ReactorProjectIdentities> upstreamProjects, PomDependencyCollector pomDependencyCollector) {
         PreliminaryTargetPlatformImpl preliminaryTargetPlatform = getRegisteredPreliminaryTargetPlatform(project);
         if (preliminaryTargetPlatform == null) {
-            // project doesn't seem to use resolver=p2
-            return null;
+            MavenSession session = project.adapt(MavenSession.class);
+            if (session == null) {
+                session = legacySupport.getSession();
+                if (session == null) {
+                    return null;
+                }
+            }
+            MavenProject mavenProject = project.adapt(MavenProject.class);
+            if (mavenProject == null) {
+                return null;
+            }
+            return p2Resolver.computePreliminaryTargetPlatform(session, mavenProject,
+                    DefaultReactorProject.adapt(session));
+
         }
         List<PublishingRepository> upstreamProjectResults = getBuildResults(upstreamProjects);
         TargetPlatform result = getTpFactory().createTargetPlatformWithUpdatedReactorContent(preliminaryTargetPlatform,

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentTest.java
@@ -13,8 +13,10 @@ import java.io.File;
 import java.util.Optional;
 
 import org.apache.maven.project.MavenProject;
+import org.eclipse.tycho.ReactorProject;
+import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
-import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.testing.AbstractTychoMojoTestCase;
 
 public class ExecutionEnvironmentTest extends AbstractTychoMojoTestCase {
@@ -23,7 +25,16 @@ public class ExecutionEnvironmentTest extends AbstractTychoMojoTestCase {
         File basedir = getBasedir("projects/targetJRE");
         Optional<MavenProject> project = getSortedProjects(basedir).stream().filter(p -> p.getName().equals("bundle"))
                 .findAny();
-        assertEquals("JavaSE-1.7", TychoProjectUtils
-                .getExecutionEnvironmentConfiguration(DefaultReactorProject.adapt(project.get())).getProfileName());
+        assertEquals("JavaSE-1.7",
+                getExecutionEnvironmentConfiguration(DefaultReactorProject.adapt(project.get())).getProfileName());
+    }
+
+    public static ExecutionEnvironmentConfiguration getExecutionEnvironmentConfiguration(ReactorProject project) {
+        ExecutionEnvironmentConfiguration storedConfig = (ExecutionEnvironmentConfiguration) project
+                .getContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION);
+        if (storedConfig == null) {
+            throw new IllegalStateException(project.toString());
+        }
+        return storedConfig;
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/EquinoxResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/EquinoxResolverTest.java
@@ -23,10 +23,11 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.osgi.container.Module;
 import org.eclipse.osgi.container.ModuleContainer;
 import org.eclipse.tycho.ReactorProject;
+import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.ee.ExecutionEnvironmentUtils;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironment;
+import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.osgitools.targetplatform.DefaultDependencyArtifacts;
-import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.testing.AbstractTychoMojoTestCase;
 import org.eclipse.tycho.version.TychoVersion;
 import org.osgi.framework.BundleException;
@@ -65,8 +66,7 @@ public class EquinoxResolverTest extends AbstractTychoMojoTestCase {
         MavenProject javaSE10Project = getProject("projects/javase-11");
         assertEquals("executionenvironment.javase11", javaSE10Project.getArtifactId());
         ReactorProject reactorProject = DefaultReactorProject.adapt(javaSE10Project);
-        ExecutionEnvironment ee = TychoProjectUtils.getExecutionEnvironmentConfiguration(reactorProject)
-                .getFullSpecification();
+        ExecutionEnvironment ee = getExecutionEnvironmentConfiguration(reactorProject).getFullSpecification();
         assertEquals("JavaSE-" + Runtime.version().feature(), ee.getProfileName());
         Properties platformProperties = subject.getPlatformProperties(reactorProject, null,
                 new DefaultDependencyArtifacts(), ee);
@@ -91,6 +91,15 @@ public class EquinoxResolverTest extends AbstractTychoMojoTestCase {
 //        String capabilities = platformProperties.getProperty("org.osgi.framework.system.capabilities");
 //        assertTrue(capabilities.contains(
 //                "osgi.ee=\"JavaSE\"; version:List<Version>=\"1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 9.0, 10.0, 11.0\""));
+    }
+
+    public static ExecutionEnvironmentConfiguration getExecutionEnvironmentConfiguration(ReactorProject project) {
+        ExecutionEnvironmentConfiguration storedConfig = (ExecutionEnvironmentConfiguration) project
+                .getContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION);
+        if (storedConfig == null) {
+            throw new IllegalStateException(project.toString());
+        }
+        return storedConfig;
     }
 
     public void testBundleNativeCode() throws IOException, Exception {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/test/DependencyComputerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/test/DependencyComputerTest.java
@@ -40,6 +40,7 @@ import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.ee.CustomExecutionEnvironment;
 import org.eclipse.tycho.core.ee.ExecutionEnvironmentUtils;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironment;
+import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.ee.shared.SystemCapability;
 import org.eclipse.tycho.core.ee.shared.SystemCapability.Type;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
@@ -47,7 +48,6 @@ import org.eclipse.tycho.core.osgitools.DependencyComputer;
 import org.eclipse.tycho.core.osgitools.DependencyComputer.DependencyEntry;
 import org.eclipse.tycho.core.osgitools.EquinoxResolver;
 import org.eclipse.tycho.core.utils.MavenSessionUtils;
-import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.testing.AbstractTychoMojoTestCase;
 import org.eclipse.tycho.version.TychoVersion;
 import org.junit.Assert;
@@ -83,8 +83,8 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
         DependencyArtifacts platform = (DependencyArtifacts) reactorProject
                 .getContextValue(TychoConstants.CTX_DEPENDENCY_ARTIFACTS);
 
-        ExecutionEnvironment executionEnvironment = TychoProjectUtils
-                .getExecutionEnvironmentConfiguration(reactorProject).getFullSpecification();
+        ExecutionEnvironment executionEnvironment = getExecutionEnvironmentConfiguration(reactorProject)
+                .getFullSpecification();
         ModuleContainer state = resolver.newResolvedState(reactorProject, null, executionEnvironment, platform);
         ModuleRevision bundle = state.getModule(project.getBasedir().getAbsolutePath()).getCurrentRevision();
 
@@ -94,6 +94,15 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
         Assert.assertEquals("dep2", dependencies.get(1).module.getSymbolicName());
         Assert.assertEquals("dep3", dependencies.get(2).module.getSymbolicName());
         Assert.assertTrue(dependencies.get(2).rules.isEmpty());
+    }
+
+    public static ExecutionEnvironmentConfiguration getExecutionEnvironmentConfiguration(ReactorProject project) {
+        ExecutionEnvironmentConfiguration storedConfig = (ExecutionEnvironmentConfiguration) project
+                .getContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION);
+        if (storedConfig == null) {
+            throw new IllegalStateException(project.toString());
+        }
+        return storedConfig;
     }
 
     @Test

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -37,13 +37,14 @@ import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.artifactcomparator.ArtifactComparator;
 import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
+import org.eclipse.tycho.core.TychoProjectManager;
+import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.exceptions.VersionBumpRequiredException;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult.Entry;
 import org.eclipse.tycho.core.resolver.P2Resolver;
 import org.eclipse.tycho.core.resolver.P2ResolverFactory;
-import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
 import org.osgi.framework.Version;
 
@@ -110,6 +111,9 @@ public class CompareWithBaselineMojo extends AbstractMojo {
     @Component
     private Logger plexusLogger;
 
+    @Component
+    private TychoProjectManager projectManager;
+
     /**
      * The hint of an available {@link ArtifactComparator} component to use for comparison of
      * artifacts with same version.
@@ -146,8 +150,10 @@ public class CompareWithBaselineMojo extends AbstractMojo {
         for (String baselineRepo : this.baselines) {
             baselineTPStub.addP2Repository(toRepoURI(baselineRepo));
         }
+        ExecutionEnvironmentConfiguration eeConfiguration = projectManager
+                .getExecutionEnvironmentConfiguration(project);
         TargetPlatform baselineTP = resolverFactory.getTargetPlatformFactory().createTargetPlatform(baselineTPStub,
-                TychoProjectUtils.getExecutionEnvironmentConfiguration(reactorProject), null);
+                eeConfiguration, null);
 
         for (IInstallableUnit item : dependencyMetadata) {
             try {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -84,7 +84,6 @@ import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.osgitools.project.BuildOutputJar;
-import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.dev.DevBundleInfo;
 import org.eclipse.tycho.dev.DevWorkspaceResolver;
 import org.eclipse.tycho.p2.tools.RepositoryReferences;
@@ -1077,8 +1076,8 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     }
 
     private void addCustomProfileArg(EquinoxLaunchConfiguration cli) throws MojoExecutionException {
-        ExecutionEnvironmentConfiguration eeConfig = TychoProjectUtils
-                .getExecutionEnvironmentConfiguration(DefaultReactorProject.adapt(project));
+
+        ExecutionEnvironmentConfiguration eeConfig = projectManager.getExecutionEnvironmentConfiguration(project);
         if (eeConfig.isCustomProfile()) {
             Properties customProfileProps = eeConfig.getFullSpecification().getProfileProperties();
             File profileFile = new File(new File(project.getBuild().getDirectory()), "custom.profile");

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -62,7 +62,6 @@ import org.eclipse.tycho.core.maven.ToolchainProvider;
 import org.eclipse.tycho.core.maven.ToolchainProvider.JDKUsage;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.osgitools.OsgiBundleProject;
-import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.osgi.framework.Constants;
 
 import aQute.bnd.osgi.Analyzer;
@@ -439,8 +438,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
     }
 
     protected String getTestProfileName() {
-        String profileName = TychoProjectUtils
-                .getExecutionEnvironmentConfiguration(DefaultReactorProject.adapt(project)).getProfileName();
+        String profileName = projectManager.getExecutionEnvironmentConfiguration(project).getProfileName();
         return profileName;
     }
 

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoToolchainTests.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoToolchainTests.java
@@ -26,11 +26,10 @@ import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.apache.maven.toolchain.java.DefaultJavaToolChain;
 import org.codehaus.plexus.util.ReflectionUtils;
-import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.maven.ToolchainProvider;
 import org.eclipse.tycho.core.maven.ToolchainProvider.JDKUsage;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +43,7 @@ public class TestMojoToolchainTests {
     private DefaultJavaToolChain breeToolchain;
     private Toolchain systemToolchain;
     private ToolchainProvider toolchainProvider;
+    private TychoProjectManager tychoProjectManager;
 
     @Before
     public void setUp() throws Exception {
@@ -52,6 +52,7 @@ public class TestMojoToolchainTests {
         breeToolchain = mock(DefaultJavaToolChain.class);
         systemToolchain = mock(Toolchain.class);
         toolchainProvider = mock(ToolchainProvider.class);
+        tychoProjectManager = mock(TychoProjectManager.class);
         project = new MavenProject();
         testMojo = new TestPluginMojo();
         setParameter(testMojo, "useJDK", JDKUsage.SYSTEM);
@@ -59,6 +60,7 @@ public class TestMojoToolchainTests {
         setParameter(testMojo, "toolchainProvider", toolchainProvider);
         setParameter(testMojo, "project", project);
         setParameter(testMojo, "session", session);
+        setParameter(testMojo, "projectManager", tychoProjectManager);
     }
 
     @Test
@@ -99,8 +101,7 @@ public class TestMojoToolchainTests {
         setParameter(testMojo, "useJDK", JDKUsage.BREE);
         ExecutionEnvironmentConfiguration envConf = mock(ExecutionEnvironmentConfiguration.class);
         when(envConf.getProfileName()).thenReturn("myId");
-        DefaultReactorProject.adapt(project).setContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION,
-                envConf);
+        when(tychoProjectManager.getExecutionEnvironmentConfiguration(project)).thenReturn(envConf);
     }
 
     private void setParameter(Object object, String variable, Object value)


### PR DESCRIPTION
Currently the ExecutionEnvironmentConfiguration is always computed in the setup phase of a project even if it is not used anywhere and afterwards accessed with a static helper util.

This has several drawbacks:
- components wanting to access this information require always the Tycho resolver setup even if this is not required at all
- bound to static util method
- no way for "non tycho" projects to read that information
- hard to integrate with m2e and similar
- eager computation even if never used at all

This moves the code into the TychoProjectManager where it is computed at first access independent from the setup phase.