### PR TITLE
Compute Merged Properties in the TychoProjectUtils

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ReactorProject.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ReactorProject.java
@@ -14,7 +14,6 @@
 package org.eclipse.tycho;
 
 import java.io.File;
-import java.util.Properties;
 import java.util.function.Supplier;
 
 /**
@@ -70,10 +69,6 @@ public interface ReactorProject extends IDependencyMetadata {
     public String getBuildQualifier();
 
     public String getExpandedVersion();
-
-    default Properties getProperties() {
-        return (Properties) getContextValue(CTX_MERGED_PROPERTIES);
-    }
 
     /**
      * human-readable id used in error messages

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TargetEnvironment.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TargetEnvironment.java
@@ -28,6 +28,7 @@ public final class TargetEnvironment {
     private static final String OSGI_OS = "osgi.os";
     private static final String OSGI_WS = "osgi.ws";
     private static final String OSGI_ARCH = "osgi.arch";
+    private static TargetEnvironment runningEnvironment;
 
     private String os;
     private String ws;
@@ -157,20 +158,13 @@ public final class TargetEnvironment {
     }
 
     public static TargetEnvironment getRunningEnvironment() {
-        return getRunningEnvironment(null);
-    }
-
-    public static TargetEnvironment getRunningEnvironment(ReactorProject project) {
-        Properties properties;
-        if (project == null) {
-            properties = EMPTY_PROPERTIES;
-        } else {
-            properties = Objects.requireNonNullElse(project.getProperties(), EMPTY_PROPERTIES);
+        if (runningEnvironment == null) {
+            String os = PlatformPropertiesUtils.getOS(EMPTY_PROPERTIES);
+            String ws = PlatformPropertiesUtils.getWS(EMPTY_PROPERTIES);
+            String arch = PlatformPropertiesUtils.getArch(EMPTY_PROPERTIES);
+            runningEnvironment = new TargetEnvironment(os, ws, arch);
         }
-        String os = PlatformPropertiesUtils.getOS(properties);
-        String ws = PlatformPropertiesUtils.getWS(properties);
-        String arch = PlatformPropertiesUtils.getArch(properties);
-        return new TargetEnvironment(os, ws, arch);
+        return runningEnvironment;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultReactorProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultReactorProject.java
@@ -76,7 +76,9 @@ public class DefaultReactorProject implements ReactorProject {
 
     public static ReactorProject adapt(MavenProject project, MavenSession mavenSession) {
         ReactorProject reactorProject = adapt(project);
-        reactorProject.setContextValue(CTX_MAVEN_SESSION, mavenSession);
+        if (mavenSession != null) {
+            reactorProject.setContextValue(CTX_MAVEN_SESSION, mavenSession);
+        }
         return reactorProject;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -32,6 +32,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
@@ -66,6 +67,7 @@ import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.ee.ExecutionEnvironmentUtils;
 import org.eclipse.tycho.core.ee.StandardExecutionEnvironment;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironment;
+import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
@@ -205,7 +207,7 @@ public class EquinoxResolver {
         TargetEnvironment environment = configuration.getEnvironments().get(0);
         logger.debug("Using TargetEnvironment " + environment.toFilterExpression() + " to create resolver properties");
         Properties properties = new Properties();
-        properties.putAll(project.getProperties());
+        properties.putAll(TychoProjectUtils.getMergedProperties(project.adapt(MavenProject.class), mavenSession));
         return getPlatformProperties(properties, mavenSession, environment, ee);
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -275,8 +275,8 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
         for (ProjectClasspathEntry cpe : entries) {
             if (cpe instanceof JUnitClasspathContainerEntry junit) {
                 logger.info("Resolving JUnit " + junit.getJUnitSegment() + " classpath container");
-                P2Resolver resolver = resolverFactory.createResolver(
-                        Collections.singletonList(TargetEnvironment.getRunningEnvironment(reactorProject)));
+                P2Resolver resolver = resolverFactory
+                        .createResolver(Collections.singletonList(TargetEnvironment.getRunningEnvironment()));
                 TargetPlatform tp = TychoProjectUtils.getTargetPlatform(reactorProject);
                 Collection<P2ResolutionResult> result = resolver.resolveArtifactDependencies(tp, junit.getArtifacts())
                         .values();

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -45,7 +45,6 @@ import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.TargetPlatformConfiguration.BREEHeaderSelectionPolicy;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.TychoProjectManager;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
 import org.eclipse.tycho.core.resolver.shared.PomDependencies;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolver;
@@ -152,7 +151,7 @@ public class DefaultTargetPlatformConfigurationReader {
         if (result.getEnvironments().isEmpty()) {
             // applying defaults
             logger.warn("No explicit target runtime environment configuration. Build is platform dependent.");
-            result.addEnvironment(TargetEnvironment.getRunningEnvironment(DefaultReactorProject.adapt(project)));
+            result.addEnvironment(TargetEnvironment.getRunningEnvironment());
             result.setImplicitTargetEnvironment(true);
         } else {
             result.setImplicitTargetEnvironment(false);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/utils/TychoProjectUtils.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/utils/TychoProjectUtils.java
@@ -15,15 +15,24 @@ package org.eclipse.tycho.core.utils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.DependencyArtifacts;
+import org.eclipse.tycho.PlatformPropertiesUtils;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.shared.DependencySeed;
 
 public class TychoProjectUtils {
     private static final String TYCHO_NOT_CONFIGURED = "Tycho build extension not configured for ";
+
+    public static final String TYCHO_ENV_OSGI_WS = "tycho.env.osgi.ws";
+    public static final String TYCHO_ENV_OSGI_OS = "tycho.env.osgi.os";
+    public static final String TYCHO_ENV_OSGI_ARCH = "tycho.env.osgi.arch";
 
     /**
      * Returns the {@link DependencyArtifacts} instance associated with the given project.
@@ -102,5 +111,41 @@ public class TychoProjectUtils {
             throw new IllegalStateException(TYCHO_NOT_CONFIGURED + project.toString());
         }
         return resolvedDependencies;
+    }
+
+    /**
+     * Computes the merged properties from maven session and the project
+     * 
+     * @param mavenProject
+     * @param mavenSession
+     * @return a (possibly cached) value, do not modify the object!
+     */
+    public static Properties getMergedProperties(MavenProject mavenProject, MavenSession mavenSession) {
+        if (mavenSession == null) {
+            //only temporary ...
+            return computeMergedProperties(mavenProject, null);
+        }
+        return DefaultReactorProject.adapt(mavenProject, mavenSession).computeContextValue(
+                ReactorProject.CTX_MERGED_PROPERTIES, () -> computeMergedProperties(mavenProject, mavenSession));
+    }
+
+    private static Properties computeMergedProperties(MavenProject mavenProject, MavenSession mavenSession) {
+        Properties properties = new Properties();
+        properties.putAll(mavenProject.getProperties());
+        if (mavenSession != null) {
+            properties.putAll(mavenSession.getSystemProperties()); // session wins
+            properties.putAll(mavenSession.getUserProperties());
+        }
+        setTychoEnvironmentProperties(properties, mavenProject);
+        return properties;
+    }
+
+    public static void setTychoEnvironmentProperties(Properties properties, MavenProject project) {
+        String arch = PlatformPropertiesUtils.getArch(properties);
+        String os = PlatformPropertiesUtils.getOS(properties);
+        String ws = PlatformPropertiesUtils.getWS(properties);
+        project.getProperties().put(TYCHO_ENV_OSGI_WS, ws);
+        project.getProperties().put(TYCHO_ENV_OSGI_OS, os);
+        project.getProperties().put(TYCHO_ENV_OSGI_ARCH, arch);
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/DefaultTychoResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/DefaultTychoResolverTest.java
@@ -19,6 +19,7 @@ import java.util.Properties;
 
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.PlatformPropertiesUtils;
+import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,11 +44,11 @@ public class DefaultTychoResolverTest {
         Properties projectProperties = new Properties();
         when(project.getProperties()).thenReturn(projectProperties);
 
-        defaultTychoResolver.setTychoEnvironmentProperties(mergedProperties, project);
+        TychoProjectUtils.setTychoEnvironmentProperties(mergedProperties, project);
 
-        Object ws = projectProperties.getProperty(DefaultTychoResolver.TYCHO_ENV_OSGI_WS);
-        Object os = projectProperties.getProperty(DefaultTychoResolver.TYCHO_ENV_OSGI_OS);
-        Object arch = projectProperties.getProperty(DefaultTychoResolver.TYCHO_ENV_OSGI_ARCH);
+        Object ws = projectProperties.getProperty(TychoProjectUtils.TYCHO_ENV_OSGI_WS);
+        Object os = projectProperties.getProperty(TychoProjectUtils.TYCHO_ENV_OSGI_OS);
+        Object arch = projectProperties.getProperty(TychoProjectUtils.TYCHO_ENV_OSGI_ARCH);
 
         Assert.assertEquals(3, projectProperties.size());
         Assert.assertEquals(PlatformPropertiesUtils.ARCH_X86_64, arch);

--- a/tycho-extras/target-platform-validation-plugin/src/main/java/org/eclipse/tycho/extras/tpvalidator/TPValidationMojo.java
+++ b/tycho-extras/target-platform-validation-plugin/src/main/java/org/eclipse/tycho/extras/tpvalidator/TPValidationMojo.java
@@ -39,7 +39,6 @@ import org.eclipse.tycho.core.ee.ExecutionEnvironmentUtils;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironment;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.ee.shared.SystemCapability;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
 import org.eclipse.tycho.core.resolver.P2Resolver;
 import org.eclipse.tycho.core.resolver.P2ResolverFactory;
@@ -188,8 +187,7 @@ public class TPValidationMojo extends AbstractMojo {
             TargetDefinitionFile targetDefinition = TargetDefinitionFile.read(targetFile);
             TargetPlatformConfigurationStub tpConfiguration = new TargetPlatformConfigurationStub();
             tpConfiguration.addTargetDefinition(targetDefinition);
-            tpConfiguration.setEnvironments(Collections
-                    .singletonList(TargetEnvironment.getRunningEnvironment(DefaultReactorProject.adapt(project))));
+            tpConfiguration.setEnvironments(Collections.singletonList(TargetEnvironment.getRunningEnvironment()));
 
             P2Resolver resolver = this.factory.createResolver(tpConfiguration.getEnvironments());
 

--- a/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
@@ -52,7 +52,6 @@ import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.core.ee.ExecutionEnvironmentConfigurationImpl;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.maven.ToolchainProvider;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult.Entry;
 import org.eclipse.tycho.core.resolver.P2Resolver;
@@ -344,8 +343,8 @@ public class EclipseRunMojo extends AbstractMojo {
 		eeConfiguration.setProfileConfiguration(executionEnvironment, "tycho-eclipserun-plugin <executionEnvironment>");
 		TargetPlatform targetPlatform = resolverFactory.getTargetPlatformFactory().createTargetPlatform(tpConfiguration,
 				eeConfiguration, null);
-		P2Resolver resolver = resolverFactory.createResolver(Collections
-				.singletonList(TargetEnvironment.getRunningEnvironment(DefaultReactorProject.adapt(project))));
+		P2Resolver resolver = resolverFactory
+				.createResolver(Collections.singletonList(TargetEnvironment.getRunningEnvironment()));
 		for (Dependency dependency : dependencies) {
 			try {
 				resolver.addDependency(dependency.getType(), dependency.getArtifactId(), dependency.getVersion());

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -140,13 +140,12 @@ public class CompareWithBaselineMojo extends AbstractMojo {
                     + this.artifactComparators.keySet());
         }
 
-        P2Resolver resolver = resolverFactory.createResolver(Collections
-                .singletonList(TargetEnvironment.getRunningEnvironment(DefaultReactorProject.adapt(project))));
+        TargetEnvironment runningEnvironment = TargetEnvironment.getRunningEnvironment();
+        P2Resolver resolver = resolverFactory.createResolver(Collections.singletonList(runningEnvironment));
 
         TargetPlatformConfigurationStub baselineTPStub = new TargetPlatformConfigurationStub();
         baselineTPStub.setForceIgnoreLocalArtifacts(true);
-        baselineTPStub.setEnvironments(Collections
-                .singletonList(TargetEnvironment.getRunningEnvironment(DefaultReactorProject.adapt(project))));
+        baselineTPStub.setEnvironments(Collections.singletonList(runningEnvironment));
         for (String baselineRepo : this.baselines) {
             baselineTPStub.addP2Repository(toRepoURI(baselineRepo));
         }

--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/AbstractUpdateMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/AbstractUpdateMojo.java
@@ -24,7 +24,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
 import org.eclipse.tycho.TargetEnvironment;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.P2Resolver;
 import org.eclipse.tycho.core.resolver.P2ResolverFactory;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
@@ -61,8 +60,7 @@ public abstract class AbstractUpdateMojo extends AbstractMojo {
     protected abstract void doUpdate() throws Exception;
 
     private void createResolver() {
-        p2 = factory.createResolver(Collections
-                .singletonList(TargetEnvironment.getRunningEnvironment(DefaultReactorProject.adapt(project))));
+        p2 = factory.createResolver(Collections.singletonList(TargetEnvironment.getRunningEnvironment()));
         resolutionContext = new TargetPlatformConfigurationStub();
     }
 

--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
@@ -28,7 +28,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.tycho.TargetEnvironment;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
 import org.eclipse.tycho.targetplatform.TargetDefinition.IncludeMode;
@@ -57,8 +56,7 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
         try (FileInputStream input = new FileInputStream(targetFile)) {
             target = TargetDefinitionFile.parseDocument(input);
             TargetDefinitionFile parsedTarget = TargetDefinitionFile.parse(target, targetFile.getAbsolutePath());
-            resolutionContext.setEnvironments(Collections
-                    .singletonList(TargetEnvironment.getRunningEnvironment(DefaultReactorProject.adapt(project))));
+            resolutionContext.setEnvironments(Collections.singletonList(TargetEnvironment.getRunningEnvironment()));
             resolutionContext.addTargetDefinition(new LatestVersionTarget(parsedTarget));
             P2ResolutionResult result = p2.getTargetPlatformAsResolutionResult(resolutionContext, executionEnvironment);
 

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
@@ -455,8 +455,7 @@ public class SourceFeatureMojo extends AbstractMojo {
      */
     private void fillReferences(Feature sourceFeature, Feature feature, TargetPlatform targetPlatform)
             throws MojoExecutionException {
-        P2Resolver p2 = factory.createResolver(Collections
-                .singletonList(TargetEnvironment.getRunningEnvironment(DefaultReactorProject.adapt(project))));
+        P2Resolver p2 = factory.createResolver(Collections.singletonList(TargetEnvironment.getRunningEnvironment()));
 
         List<PluginRef> missingSourcePlugins = new ArrayList<>();
         List<FeatureRef> missingSourceFeatures = new ArrayList<>();

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -84,6 +84,7 @@ import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.osgitools.project.BuildOutputJar;
+import org.eclipse.tycho.core.utils.TychoProjectUtils;
 import org.eclipse.tycho.dev.DevBundleInfo;
 import org.eclipse.tycho.dev.DevWorkspaceResolver;
 import org.eclipse.tycho.p2.tools.RepositoryReferences;
@@ -990,13 +991,12 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
 
     private String decodeReturnCode(int result) {
         try {
-            Properties properties = DefaultReactorProject.adapt(project).getProperties();
-            if (PlatformPropertiesUtils.OS_LINUX.equals(PlatformPropertiesUtils.getOS(properties))) {
+            if (PlatformPropertiesUtils.OS_LINUX.equals(PlatformPropertiesUtils.getOS(System.getProperties()))) {
                 int signal = result - 128;
                 if (signal > 0 && signal < UNIX_SIGNAL_NAMES.length) {
                     return result + "(" + UNIX_SIGNAL_NAMES[signal] + " received?)";
                 }
-            } else if (PlatformPropertiesUtils.OS_WIN32.equals(PlatformPropertiesUtils.getOS(properties))) {
+            } else if (PlatformPropertiesUtils.OS_WIN32.equals(PlatformPropertiesUtils.getOS(System.getProperties()))) {
                 return result + " (HRESULT Code 0x" + Integer.toHexString(result).toUpperCase()
                         + ", check for example https://www.hresult.info/ for further details)";
             }
@@ -1021,7 +1021,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
 
         cli.addVMArguments("-Dosgi.noShutdown=false");
 
-        Properties properties = DefaultReactorProject.adapt(project).getProperties();
+        Properties properties = TychoProjectUtils.getMergedProperties(project, session);
         cli.addVMArguments("-Dosgi.os=" + PlatformPropertiesUtils.getOS(properties), //
                 "-Dosgi.ws=" + PlatformPropertiesUtils.getWS(properties), //
                 "-Dosgi.arch=" + PlatformPropertiesUtils.getArch(properties));

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -407,7 +407,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
     protected List<TargetEnvironment> getTestTargetEnvironments() {
         TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
         List<TargetEnvironment> targetEnvironments = configuration.getEnvironments();
-        TargetEnvironment runningEnvironment = TargetEnvironment.getRunningEnvironment(getReactorProject());
+        TargetEnvironment runningEnvironment = TargetEnvironment.getRunningEnvironment();
         for (TargetEnvironment targetEnvironment : targetEnvironments) {
             if (targetEnvironment.equals(runningEnvironment)) {
                 getLog().debug("Using matching target environment " + targetEnvironment.toFilterProperties()


### PR DESCRIPTION
Currently the Merged Properties is always computed in the setup phase of a project even if it is not used anywhere.

This has several drawbacks:
- components wanting to access this information require always the Tycho resolver setup even if this is not required at all
- bound to implicit init also its not quite clear what these properties are different
- no way for "non tycho" projects to read that information
- hard to integrate with m2e and similar
- eager computation even if never used at all

This moves the code into the TychoProjectUtils where it is computed at first access independent from the setup phase.