### PR TITLE
Add option to configure eager resolve in the TargetPlatformConfiguration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -226,15 +226,27 @@ This can be disabled with the following configuration in the pom:
 
 ### Migration guide 3.x > 4.x
 
-### New Tycho Resolver
+### New delayed target platform resolving
 
-Tycho has already introduced a new resolver in Tycho 3.0.0 that was finalized in Tycho 4.x, the new resolver has several advantages:
-- resolve dependencies is delayed until the project is build, this allows more parallelization and even make tycho start the build faster
+Tycho has already introduced a new mode in Tycho 3.0.0 that was activated with `-Dtycho.resolver.classic=false` that was finalized in Tycho 4.x this new mode has several advantages:
+- resolve dependencies is delayed until the project is build, this allows more parallelization and even make Tycho start the build faster
 - pom dependencies are considered by default, this behaves more like one would expect from a maven perspective
 - mixed reactor builds are now fully supported without any special configuration
 - Tycho detects if the current project requires dependency resolution and skip resolving the target platform if not needed
 
-If you see any issues please let us know so we can fix any problem with it, to enable it you can use `-Dtycho.resolver.classic=false` the plan is to switch to the new old resolver mode some time in the future completely.
+If you see any issues please let us know so we can fix any problem with it, this new mode is now configured through the target platform configuration
+and if you like the old behavior it can be configured in the following way:
+
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>target-platform-configuration</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		<requireEagerResolve>true</requireEagerResolve>
+	</configuration>
+</plugin>
+```
 
 ### Tycho-Build Extension uses smart builder
 
@@ -298,6 +310,7 @@ for example with annotations that are only retained at source or class level.
 One example that uses [API-Guardian](https://github.com/apiguardian-team/apiguardian) annotations can be found here: https://github.com/eclipse/tycho/tree/master/tycho-its/projects/compiler-pomdependencies
 
 You can disable this feature through the `tycho-compiler-plugin` configuration:
+
 ```
 <plugin>
 	<groupId>org.eclipse.tycho</groupId>

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
@@ -76,8 +76,12 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
      * POM dependencies (and the pomDependencies=consider configuration) typically need to be added in
      * the parent POM.
      * </p>
+     * <p>
+     * If no explicit value is configured Tycho uses {@link PomDependencies#ignore} if eager
+     * resolution is activated and {@link PomDependencies#consider} otherwhise.
+     * </p>
      */
-    @Parameter(name = DefaultTargetPlatformConfigurationReader.POM_DEPENDENCIES, defaultValue = "ignore")
+    @Parameter(name = DefaultTargetPlatformConfigurationReader.POM_DEPENDENCIES)
     private PomDependencies pomDependencies;
 
     /**
@@ -100,6 +104,20 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
 
     @Parameter(name = DefaultTargetPlatformConfigurationReader.RESOLVE_WITH_EXECUTION_ENVIRONMENT_CONSTRAINTS, defaultValue = "true")
     private boolean resolveWithExcutionEnvironmentConstraints;
+
+    /**
+     * Configures when resolve of the project specific target platform happens. If the value is
+     * <code>true</code> the project platform is computed as early as when starting the build before
+     * the first mojo executes, if the value is <code>false</code> the resolving is delayed until
+     * the project is actually executed, this can considerably improve your build speed in parallel
+     * builds. The drawback is that there might be some tools making assumptions about the build
+     * being static from the start or having "hidden" dependency chains that point back to your
+     * build reactor. For these reason this can be configured here even though it is recommend to
+     * always use lazy resolve for best performance and maximum of features, e.g. using mixed maven
+     * builds require lazy resolving of that projects depend on the plain maven projects.
+     */
+    @Parameter(name = DefaultTargetPlatformConfigurationReader.REQUIRE_EAGER_RESOLVE, defaultValue = "false", property = DefaultTargetPlatformConfigurationReader.PROPERTY_REQUIRE_EAGER_RESOLVE, alias = DefaultTargetPlatformConfigurationReader.PROPERTY_ALIAS_REQUIRE_EAGER_RESOLVE)
+    private boolean requireEagerResolve;
 
     /**
      * Selectively remove content from the target platform.

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/resolver/shared/PomDependencies.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/resolver/shared/PomDependencies.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.resolver.shared;
 
-import org.eclipse.tycho.TychoConstants;
-
 public enum PomDependencies {
 
     /**
@@ -31,6 +29,4 @@ public enum PomDependencies {
      */
     wrapAsBundle;
 
-    public static final PomDependencies DEFAULT = TychoConstants.USE_OLD_RESOLVER ? PomDependencies.ignore
-            : PomDependencies.consider;
 }

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -18,7 +18,6 @@ import java.util.regex.Pattern;
 public interface TychoConstants {
     static final String ANY_QUALIFIER = "qualifier";
 
-    static final boolean USE_OLD_RESOLVER = Boolean.parseBoolean(System.getProperty("tycho.resolver.classic", "true"));
     static final boolean USE_SMART_BUILDER = Boolean
             .parseBoolean(System.getProperty("tycho.build.smartbuilder", "true"));
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -78,7 +78,7 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     private final List<URI> targets = new ArrayList<>();
     private IncludeSourceMode targetDefinitionIncludeSourceMode = IncludeSourceMode.honor;
 
-    private PomDependencies pomDependencies = PomDependencies.DEFAULT;
+    private PomDependencies pomDependencies;
 
     private String executionEnvironment;
     private String executionEnvironmentDefault;
@@ -98,6 +98,7 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     private LocalArtifactHandling localArtifactHandling;
 
+    private boolean requireEagerResolve;
     /**
      * Returns the list of configured target environments, or the running environment if no
      * environments have been specified explicitly.
@@ -154,6 +155,13 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     }
 
     public PomDependencies getPomDependencies() {
+        if (pomDependencies == null) {
+            if (isRequireEagerResolve()) {
+                return PomDependencies.ignore;
+            } else {
+                return PomDependencies.consider;
+            }
+        }
         return pomDependencies;
     }
 
@@ -195,6 +203,14 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     public void setResolveWithEEContraints(boolean value) {
         this.resolveWithEEConstraints = value;
+    }
+
+    public boolean isRequireEagerResolve() {
+        return requireEagerResolve;
+    }
+
+    public void setRequireEagerResolve(boolean value) {
+        this.requireEagerResolve = value;
     }
 
     public void setFilters(List<TargetPlatformFilter> filters) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -66,6 +66,9 @@ public class DefaultTargetPlatformConfigurationReader {
 
     public static final String FILTERS = "filters";
     public static final String RESOLVE_WITH_EXECUTION_ENVIRONMENT_CONSTRAINTS = "resolveWithExecutionEnvironmentConstraints";
+    public static final String REQUIRE_EAGER_RESOLVE = "requireEagerResolve";
+    public static final String PROPERTY_REQUIRE_EAGER_RESOLVE = "tycho.target.eager";
+    public static final String PROPERTY_ALIAS_REQUIRE_EAGER_RESOLVE = "tycho.resolver.classic";
     public static final String BREE_HEADER_SELECTION_POLICY = "breeHeaderSelectionPolicy";
     public static final String EXECUTION_ENVIRONMENT_DEFAULT = "executionEnvironmentDefault";
     public static final String EXECUTION_ENVIRONMENT = "executionEnvironment";
@@ -118,6 +121,7 @@ public class DefaultTargetPlatformConfigurationReader {
                 setExecutionEnvironmentDefault(result, configuration);
                 setBREEHeaderSelectionPolicy(result, configuration);
                 setResolveWithEEContraints(result, configuration);
+                setRequireEagerResolve(result, configuration, session);
 
                 readFilters(result, configuration);
                 try {
@@ -315,6 +319,16 @@ public class DefaultTargetPlatformConfigurationReader {
             return;
         }
         result.setResolveWithEEContraints(Boolean.valueOf(value));
+    }
+
+    private void setRequireEagerResolve(TargetPlatformConfiguration result, Xpp3Dom resolverDom, MavenSession session) {
+        Xpp3Dom child = resolverDom.getChild(REQUIRE_EAGER_RESOLVE);
+        String value = getStringValue(child, session, PROPERTY_REQUIRE_EAGER_RESOLVE,
+                PROPERTY_ALIAS_REQUIRE_EAGER_RESOLVE);
+        if (value == null) {
+            return;
+        }
+        result.setRequireEagerResolve(Boolean.valueOf(value));
     }
 
     private void setDisableP2Mirrors(Xpp3Dom configuration) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
@@ -60,6 +60,7 @@ import org.eclipse.tycho.ReactorProjectIdentities;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfigurationStub;
 import org.eclipse.tycho.core.resolver.DefaultP2ResolutionResult;
@@ -223,8 +224,10 @@ public class P2ResolverImpl implements P2Resolver {
         strategy.setData(data);
         Collection<IInstallableUnit> newState;
         try {
-            if ((pomDependencies != PomDependencies.ignore || !TychoConstants.USE_OLD_RESOLVER) && project != null) {
-                if (p2ResolverFactoryImpl != null) {
+            if (project != null && p2ResolverFactoryImpl != null && pomDependencies != PomDependencies.ignore) {
+                TargetPlatformConfiguration configuration = p2ResolverFactoryImpl.getProjectManager()
+                        .getTargetPlatformConfiguration(project);
+                if (!configuration.isRequireEagerResolve()) {
                     data.setAdditionalUnitStore(p2ResolverFactoryImpl.getPomUnits().createPomQueryable(project));
                 }
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomInstallableUnitStore.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomInstallableUnitStore.java
@@ -76,7 +76,7 @@ class PomInstallableUnitStore implements IQueryable<IInstallableUnit> {
         this.configuration = configuration;
         this.considerPomDependencies = ofNullable(configuration)//
                 .map(TargetPlatformConfiguration::getPomDependencies)//
-                .orElse(PomDependencies.DEFAULT);
+                .orElse(PomDependencies.ignore);
     }
 
     @Override


### PR DESCRIPTION
Once there was the idea to switch between a "new" and "old" resolver style but this did not worked well as one only can switch this globally with a system property and it is actually confusing as not the resolver itself is different by the time when resolving happens.

This is now an attempt to unify this under a new (configurable) way that works by specify in the target platform what mode is actually desired for a given configuration.