### PR TITLE
Make local artifact handling configurable by the target platform

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,30 @@ a demo can be found here https://github.com/eclipse-tycho/tycho/tree/master/demo
 The tycho-build extension can now also build projects with a [BND Workspaces](https://bndtools.org/concepts.html) layout in a complete pomless way,
 details can be found here: https://tycho.eclipseprojects.io/doc/master/BndBuild.html
 
+### Handling of local artifacts can now be configured through the target platform
+
+Previously it was only possible to influence the handling of local artifacts with the `-Dtycho.localArtifacts=<ignore/default>` option, from now on this can be configured through the target platform as well like this:
+
+
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>target-platform-configuration</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		<dependency-resolution>
+			<localArtifacts>ignore</localArtifacts>
+		</dependency-resolution>
+	</configuration>
+</plugin>
+```
+
+the supported values are:
+
+- `include` - (default) local artifacts are included and may override items from the target, 
+- `default` - for backward-compatibility with older documentation, equivalent to `include`
+- `ignore` - local artifacts are ignored
+
 ### new tycho-versions-plugin mojos
 
 #### bump-versions mojo

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/DependencyResolutionConfiguration.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/DependencyResolutionConfiguration.java
@@ -12,19 +12,23 @@ package org.eclipse.tycho.target;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.tycho.OptionalResolutionAction;
+import org.eclipse.tycho.core.TargetPlatformConfiguration.LocalArtifactHandling;
+import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
+
 public class DependencyResolutionConfiguration {
 
-	public class ExtraRequirementConfiguration {
-		// Adapted from DefaultArtifactKey
-		public String type;
-		public String id;
-		public String versionRange;
-	}
+    public class ExtraRequirementConfiguration {
+        // Adapted from DefaultArtifactKey
+        public String type;
+        public String id;
+        public String versionRange;
+    }
 
-	/**
-	 * One of <code>ignore</code>, <code>optional</code>, <code>require</code>
-	 */
-	public String optionalDependencies;
+    public OptionalResolutionAction optionalDependencies;
     public List<ExtraRequirementConfiguration> extraRequirements;
     public Properties profileProperties;
+    @Parameter(property = DefaultTargetPlatformConfigurationReader.LOCAL_ARTIFACTS_PROPERTY, name = DefaultTargetPlatformConfigurationReader.LOCAL_ARTIFACTS)
+    public LocalArtifactHandling localArtifacts;
 }

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/target/facade/TargetPlatformConfigurationStub.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/p2/target/facade/TargetPlatformConfigurationStub.java
@@ -36,6 +36,10 @@ public class TargetPlatformConfigurationStub {
     private boolean forceIgnoreLocalArtifacts = false;
     private IncludeSourceMode includeSourceMode = IncludeSourceMode.honor;
 
+    public TargetPlatformConfigurationStub() {
+        // TODO Auto-generated constructor stub
+    }
+
     public void setEnvironments(List<TargetEnvironment> environments) {
         this.environments = environments;
     }
@@ -73,11 +77,11 @@ public class TargetPlatformConfigurationStub {
         return targetDefinitions;
     }
 
-    public void setForceIgnoreLocalArtifacts(boolean forceIgnoreLocalArtifacts) {
+    public void setIgnoreLocalArtifacts(boolean forceIgnoreLocalArtifacts) {
         this.forceIgnoreLocalArtifacts = forceIgnoreLocalArtifacts;
     }
 
-    public boolean getForceIgnoreLocalArtifacts() {
+    public boolean getIgnoreLocalArtifacts() {
         return forceIgnoreLocalArtifacts;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -43,6 +43,32 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
         first, minimal
     }
 
+    public enum LocalArtifactHandling {
+        /**
+         * local artifacts are included and override items from the target
+         */
+        include,
+        /**
+         * NOT SUPPORTED YET! local artifacts override items from the target that are
+         * <i>equivalent</i> (major and minor version must equal the version from the target).
+         */
+        equivalent,
+        /**
+         * NOT SUPPORTED YET! local artifacts override items from the target that are
+         * <i>compatible</i> (major version must equal the version from the target).
+         */
+        compatible,
+        /**
+         * NOT SUPPORTED YET! local artifacts override items from the target that match
+         * <i>exactly</i> the version from the target.
+         */
+        perfect,
+        /**
+         * local artifacts are ignored
+         */
+        ignore;
+    }
+
     private String resolver;
 
     private List<TargetEnvironment> environments = new ArrayList<>();
@@ -69,6 +95,8 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     private Map<String, String> resolverProfileProperties = new HashMap<>();
 
     List<Supplier<File>> lazyTargetFiles = new ArrayList<>();
+
+    private LocalArtifactHandling localArtifactHandling;
 
     /**
      * Returns the list of configured target environments, or the running environment if no
@@ -224,6 +252,17 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     @Override
     public Collection<IRequirement> getAdditionalRequirements() {
         return List.of();
+    }
+
+    public LocalArtifactHandling getIgnoreLocalArtifacts() {
+        if (localArtifactHandling == null) {
+            return LocalArtifactHandling.include;
+        }
+        return localArtifactHandling;
+    }
+
+    public void setLocalArtifactHandling(LocalArtifactHandling localArtifactHandling) {
+        this.localArtifactHandling = localArtifactHandling;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -64,6 +64,7 @@ import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.DependencyResolver;
 import org.eclipse.tycho.core.DependencyResolverConfiguration;
 import org.eclipse.tycho.core.TargetPlatformConfiguration;
+import org.eclipse.tycho.core.TargetPlatformConfiguration.LocalArtifactHandling;
 import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.maven.MavenDependencyInjector;
@@ -197,6 +198,8 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
 
         tpConfiguration.addFilters(configuration.getFilters());
         tpConfiguration.setIncludeSourceMode(configuration.getTargetDefinitionIncludeSourceMode());
+        tpConfiguration
+                .setIgnoreLocalArtifacts(configuration.getIgnoreLocalArtifacts() == LocalArtifactHandling.ignore);
 
         return reactorRepositoryManager.computePreliminaryTargetPlatform(reactorProject, tpConfiguration, ee,
                 reactorProjects);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryImpl.java
@@ -168,7 +168,7 @@ public class TargetPlatformFactoryImpl implements TargetPlatformFactory {
         registerRepositoryIDs(completeRepositories);
 
         // collect & process metadata
-        boolean includeLocalMavenRepo = shouldIncludeLocallyInstalledUnits(tpConfiguration);
+        boolean includeLocalMavenRepo = !tpConfiguration.getIgnoreLocalArtifacts();
         LinkedHashSet<IInstallableUnit> externalUIs = gatherExternalInstallableUnits(completeRepositories,
                 targetFileContent, includeLocalMavenRepo);
 
@@ -232,25 +232,6 @@ public class TargetPlatformFactoryImpl implements TargetPlatformFactory {
         for (MavenRepositoryLocation location : repositoriesWithIDs) {
             remoteRepositoryIdManager.addMapping(location.getId(), location.getURL());
         }
-    }
-
-    private boolean shouldIncludeLocallyInstalledUnits(TargetPlatformConfigurationStub tpConfiguration) {
-        if (tpConfiguration.getForceIgnoreLocalArtifacts()) {
-            return false;
-
-        } else {
-            // check if disabled on command line or via Maven settings
-            boolean ignoreLocal = "ignore"
-                    .equalsIgnoreCase(mavenContext.getSessionProperties().getProperty("tycho.localArtifacts"));
-            if (ignoreLocal) {
-                logger.debug("tycho.localArtifacts="
-                        + mavenContext.getSessionProperties().getProperty("tycho.localArtifacts")
-                        + " -> ignoring locally built artifacts");
-                return false;
-            }
-        }
-        // default: include locally installed artifacts in target platform
-        return true;
     }
 
     /**

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReaderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReaderTest.java
@@ -149,7 +149,7 @@ public class DefaultTargetPlatformConfigurationReaderTest extends AbstractTychoM
         res.addChild(opt);
         dom.addChild(res);
         try {
-            configurationReader.readDependencyResolutionConfiguration(new TargetPlatformConfiguration(), dom);
+            configurationReader.readDependencyResolutionConfiguration(new TargetPlatformConfiguration(), dom, null);
         } catch (BuildFailureException e) {
             fail(e.getMessage());
         }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryTest.java
@@ -262,7 +262,7 @@ public class TargetPlatformFactoryTest extends TychoPlexusTestCase {
         subject = factory.getTargetPlatformFactoryImpl();
         Collection<IInstallableUnit> iusIncludingLocalRepo = subject
                 .createTargetPlatform(tpConfig, NOOP_EE_RESOLUTION_HANDLER, null).getInstallableUnits();
-        tpConfig.setForceIgnoreLocalArtifacts(true);
+        tpConfig.setIgnoreLocalArtifacts(true);
         Collection<IInstallableUnit> iusWithoutLocalRepo = subject
                 .createTargetPlatform(tpConfig, NOOP_EE_RESOLUTION_HANDLER, null).getInstallableUnits();
         Set<IInstallableUnit> retainedIUs = new HashSet<>(iusIncludingLocalRepo);

--- a/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
@@ -334,7 +334,7 @@ public class EclipseRunMojo extends AbstractMojo {
 	private EquinoxInstallation createEclipseInstallation() throws MojoFailureException {
 		TargetPlatformConfigurationStub tpConfiguration = new TargetPlatformConfigurationStub();
 		// we want to resolve from remote repos only
-		tpConfiguration.setForceIgnoreLocalArtifacts(true);
+		tpConfiguration.setIgnoreLocalArtifacts(true);
 		for (Repository repository : repositories) {
 			tpConfiguration.addP2Repository(new MavenRepositoryLocation(repository.getId(), repository.getLocation()));
 		}

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -144,7 +144,7 @@ public class CompareWithBaselineMojo extends AbstractMojo {
         P2Resolver resolver = resolverFactory.createResolver(Collections.singletonList(runningEnvironment));
 
         TargetPlatformConfigurationStub baselineTPStub = new TargetPlatformConfigurationStub();
-        baselineTPStub.setForceIgnoreLocalArtifacts(true);
+        baselineTPStub.setIgnoreLocalArtifacts(true);
         baselineTPStub.setEnvironments(Collections.singletonList(runningEnvironment));
         for (String baselineRepo : this.baselines) {
             baselineTPStub.addP2Repository(toRepoURI(baselineRepo));


### PR DESCRIPTION
Currently the handling of local artifacts can only be configured with providing a property on the commandline with `-Dtycho.localArtifacts` what is quite limiting as it is a global on/off flag.

This change the handling in a way to configure it through the target platform configuration with the values "include" and "ignore".