### PR TITLE
Improve CI Friendly Versions

### DIFF
--- a/src/site/markdown/TychoCiFriendly.md
+++ b/src/site/markdown/TychoCiFriendly.md
@@ -11,7 +11,9 @@ Starting with Maven 3.8.5 Tycho now supports an enhanced form of the [Maven CI F
 These uses the usual semantics that you can use them in a version string e.g. `<version>${releaseVersion}${qualifier}</version>` and pass them on the commandline.
 
 Beside this, Tycho supports some useful default calculation for `qualifier` if you give a format on the commandline with `-Dtycho.buildqualifier.format=yyyyMMddHHmm` 
-(or [any other format supported](https://www.eclipse.org/tycho/sitedocs/tycho-packaging-plugin/build-qualifier-mojo.html#format)). Tycho will also make the build qualifier available in your Maven model!
+(or [any other format supported](https://tycho.eclipseprojects.io/doc/latest/tycho-packaging-plugin/build-qualifier-mojo.html#format)). Tycho will also make the build qualifier available in your Maven model!
+
+Alternatively, if you want that your qualifier matches the one from maven you can specify `-DforceContextQualifier=abc`
 
 That way you can configure your pom in the following way:
 

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -78,7 +79,10 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 			if (mapping instanceof AbstractTychoMapping tychoMapping) {
 				tychoMapping.setExtensionMode(true);
 				tychoMapping.setMultiModuleProjectDirectory(session.getRequest().getMultiModuleProjectDirectory());
-				if (session.getRequest().getSystemProperties().getProperty("tycho.buildqualifier.format") != null) {
+				Properties properties = session.getRequest().getSystemProperties();
+				if (properties.getProperty(TychoCiFriendlyVersions.PROPERTY_BUILDQUALIFIER_FORMAT) != null
+						|| properties.getProperty(TychoCiFriendlyVersions.PROPERTY_FORCE_QUALIFIER) != null
+						|| properties.getProperty(TychoCiFriendlyVersions.BUILD_QUALIFIER) != null) {
 					tychoMapping.setSnapshotFormat("${" + TychoCiFriendlyVersions.BUILD_QUALIFIER + "}");
 				}
 			}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
@@ -1,17 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.tycho.test.buildextension;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.jar.JarFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
+import org.osgi.framework.Constants;
 
 public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 
@@ -25,7 +40,7 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		int year = Calendar.getInstance(TimeZone.getTimeZone("UTC")).get(Calendar.YEAR);
 		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0." + year + ".jar");
 		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
-
+		checkManifestVersion(file, "1.0.0." + year);
 	}
 
 	@Test
@@ -36,8 +51,6 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		verifier.addCliOption("-Dtycho.buildqualifier.format=yyyyMM");
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
-		// XXX Must be updated if the test is changed but should remain constant
-		// otherwise as this is the git timestamp!
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
 		File targetDir = new File(verifier.getBasedir(), "bundle/target");
 		String[] jarFiles = targetDir.list((dir, name) -> name.endsWith(".jar"));
@@ -47,6 +60,19 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		String qualifier = jarFiles[0].substring(13, jarFiles[0].lastIndexOf('.'));
 		// if formatter fails to parse it will throw exception and thus fail the test
 		formatter.parse(qualifier);
+		checkManifestVersion(file, "1.0.0." + qualifier);
+	}
+
+	@Test
+	public void testForcedBuildQualifier() throws Exception {
+		Verifier verifier = getVerifier("ci-friendly/buildqualifier", false, true);
+		// this uses a forced qualifier
+		verifier.addCliOption("-DforceContextQualifier=abc");
+		verifier.executeGoals(List.of("clean", "package"));
+		verifier.verifyErrorFreeLog();
+		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0.abc.jar");
+		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		checkManifestVersion(file, "1.0.0.abc");
 	}
 
 	@Test
@@ -57,5 +83,25 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0-SNAPSHOT.jar");
 		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+	}
+
+	@Test
+	public void testMilestoneBuildQualifier() throws Exception {
+		Verifier verifier = getVerifier("ci-friendly/buildqualifier", false, true);
+		// this used the default build qualifier
+		verifier.addCliOption("-Dqualifier=-M1");
+		verifier.addCliOption("-DforceContextQualifier=zzz");
+		verifier.addCliOption("-Dtycho.strictVersions=false");
+		verifier.executeGoals(List.of("clean", "package"));
+		verifier.verifyErrorFreeLog();
+		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0-M1.jar");
+		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		checkManifestVersion(file, "1.0.0.zzz");
+	}
+
+	private static void checkManifestVersion(File file, String expectedVersion) throws IOException {
+		try (JarFile jarFile = new JarFile(file)) {
+			assertEquals(expectedVersion, jarFile.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+		}
 	}
 }

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/ValidateVersionMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/ValidateVersionMojo.java
@@ -43,7 +43,7 @@ public class ValidateVersionMojo extends AbstractVersionMojo {
 	 * project versions do not match. If <code>false</code> will issue a warning but
 	 * will not fail the build if Maven and OSGi project versions do not match.
 	 */
-	@Parameter(defaultValue = "true")
+	@Parameter(defaultValue = "true", property = "tycho.strictVersions")
 	private boolean strictVersions = true;
 
 	@Component

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
@@ -163,6 +163,12 @@ public class UpdateConsumerPomMojo extends AbstractMojo {
 	@Parameter(defaultValue = "true")
 	protected boolean relativePathFromParent = true;
 
+	/**
+	 * If enabled, removes the parent and resolves version and group id directly
+	 */
+	@Parameter(defaultValue = "true")
+	protected boolean removeParent = true;
+
 	@Parameter
 	private MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
 
@@ -191,6 +197,12 @@ public class UpdateConsumerPomMojo extends AbstractMojo {
 		} catch (IOException e) {
 			throw new MojoExecutionException("reading the model failed!", e);
 		}
+		// just in case this is a CI-Friendly version replace it with actual value
+		projectModel.setVersion(project.getVersion());
+		if (removeParent) {
+			projectModel.setGroupId(project.getGroupId());
+			projectModel.setParent(null);
+		}
 		List<Dependency> dependencies = projectModel.getDependencies();
 		dependencies.clear();
 		List<Dependency> list = Objects.requireNonNullElse(project.getDependencies(), Collections.emptyList());
@@ -217,6 +229,11 @@ public class UpdateConsumerPomMojo extends AbstractMojo {
 		}
 		Parent parent = projectModel.getParent();
 		if (parent != null) {
+			MavenProject parentmavenProject = project.getParent();
+			if (parentmavenProject != null) {
+				// just in case this is a CI-Friendly version replace it with actual value
+				parent.setVersion(parentmavenProject.getVersion());
+			}
 			if (relativePathFromParent) {
 				parent.setRelativePath("../pom.xml"); // will be treated as default and then removed...
 			} else {


### PR DESCRIPTION
Currently there is an issue if a maven version is supposed to contain a non usual qualifier in which case Tycho generates an invalid OSGi version.

Fix https://github.com/eclipse-tycho/tycho/issues/1806