### PR TITLE
Enable building/running on macos-latest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Java


### PR DESCRIPTION
We see some unexpected build failures on macos nodes:
- https://github.com/eclipse-pde/eclipse.pde/pull/524

So the very first step seems to build Tycho on macos and run the integration test suite.