### PR TITLE
Make sure that org.eclipse.equinox.app is always started for API-Tools

### DIFF
--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiWorkspaceManager.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiWorkspaceManager.java
@@ -38,7 +38,8 @@ import org.osgi.framework.BundleException;
 @Component(role = ApiWorkspaceManager.class)
 public class ApiWorkspaceManager implements Disposable {
 
-	private static final Set<String> START_BUNDLES = Set.of("org.eclipse.core.runtime", "org.apache.felix.scr");
+	private static final Set<String> START_BUNDLES = Set.of("org.eclipse.core.runtime", "org.apache.felix.scr",
+			"org.eclipse.equinox.app");
 
 	private final Map<Thread, Map<URI, ApiWorkspace>> cache = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
There are some strange cases where the ApiToolsApplication do not came up with the error "Unable to acquire application service. Ensure that the org.eclipse.core.runtime bundle is resolved and started (see config.ini).", this seems to because that if the org.eclipse.equinox.app is only in starting state (lazy) but not explicitly started (active).

This now ensures that the bundle org.eclipse.equinox.app is always started.