### PR TITLE
Add integration-test for Product with included JustJ JRE

### DIFF
--- a/tycho-its/projects/resolver.justjJRE/.gitignore
+++ b/tycho-its/projects/resolver.justjJRE/.gitignore
@@ -1,0 +1,1 @@
+.polyglot.*

--- a/tycho-its/projects/resolver.justjJRE/.mvn/extensions.xml
+++ b/tycho-its/projects/resolver.justjJRE/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>${tycho-version}</version>
+	</extension>
+</extensions>

--- a/tycho-its/projects/resolver.justjJRE/.mvn/maven.config
+++ b/tycho-its/projects/resolver.justjJRE/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho-version=4.0.0-SNAPSHOT

--- a/tycho-its/projects/resolver.justjJRE/bundles/simple1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.justjJRE/bundles/simple1/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: simple.bundle1
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/resolver.justjJRE/bundles/simple1/build.properties
+++ b/tycho-its/projects/resolver.justjJRE/bundles/simple1/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/resolver.justjJRE/bundles/simple2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.justjJRE/bundles/simple2/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: simple.bundle2
+Bundle-Version: 1.0.0.qualifier
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"

--- a/tycho-its/projects/resolver.justjJRE/bundles/simple2/build.properties
+++ b/tycho-its/projects/resolver.justjJRE/bundles/simple2/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/resolver.justjJRE/pom.xml
+++ b/tycho-its/projects/resolver.justjJRE/pom.xml
@@ -1,0 +1,74 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>foo</groupId>
+	<artifactId>bar</artifactId>
+	<version>4.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>bundles</module>
+		<module>simple.feature</module>
+		<module>simple.product</module>
+		<module>simple.target</module>
+	</modules>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>11</java.version><!-- Java version must not match version of JVM running the build, otherwise the intended parts are not tested -->
+	</properties>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-compiler-plugin</artifactId>
+					<version>${tycho-version}</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-director-plugin</artifactId>
+					<version>${tycho-version}</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-publisher-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<configuration>
+						<profiles>JavaSE-${java.version}</profiles>
+					</configuration>
+				</plugin>
+
+			</plugins>
+		</pluginManagement>
+
+		<plugins>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+
+			<!-- Target-Platform configuration -->
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!--The execution environment must match the include jre, see https://www.eclipse.org/justj/?page=documentation -->
+					<executionEnvironment>org.eclipse.justj.openjdk.hotspot.jre.full-${java.version}</executionEnvironment>
+					<target>
+						<file>${maven.multiModuleProjectDirectory}/simple.target/simple.target</file>
+					</target>
+				</configuration>
+			</plugin>
+
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/resolver.justjJRE/simple.feature/build.properties
+++ b/tycho-its/projects/resolver.justjJRE/simple.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/resolver.justjJRE/simple.feature/feature.xml
+++ b/tycho-its/projects/resolver.justjJRE/simple.feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="simple.feature"
+      version="1.0.0.qualifier">
+
+   <plugin
+         id="simple.bundle2"
+         version="0.0.0" />
+
+</feature>

--- a/tycho-its/projects/resolver.justjJRE/simple.product/simple.product
+++ b/tycho-its/projects/resolver.justjJRE/simple.product/simple.product
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="simple" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="1.0.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
+
+   <vm>
+      <linux include="true">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</linux>
+      <macos include="true">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</macos>
+      <windows include="true">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
+   </vm>
+
+   <plugins>
+      <plugin id="simple.bundle1"/>
+   </plugins>
+
+   <features>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full"/>
+      <feature id="simple.feature"/>
+   </features>
+
+</product>

--- a/tycho-its/projects/resolver.justjJRE/simple.target/simple.target
+++ b/tycho-its/projects/resolver.justjJRE/simple.target/simple.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="simple">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2022-12/"/>
+			<unit id="org.eclipse.osgi" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/justj/jres/11/updates/release/latest"/>
+			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/JustJJRETest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/JustJJRETest.java
@@ -1,0 +1,18 @@
+package org.eclipse.tycho.test.resolver;
+
+import java.util.List;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class JustJJRETest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testProductWithJustJJREdifferentToRunningJVM() throws Exception {
+		Verifier verifier = getVerifier("resolver.justjJRE");
+		verifier.executeGoals(List.of("clean", "verify"));
+		verifier.verifyErrorFreeLog();
+	}
+
+}


### PR DESCRIPTION
As suggested in https://github.com/eclipse-tycho/tycho/issues/1745#issuecomment-1467995723, this adds a minimal integration test for Bundles, Features build together with the JustJ JRE Feature into a product in the same reactor, using another JavaSE version than the one running the build.