### PR TITLE
Disable multithread build for now

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,7 +49,7 @@ jobs:
        JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
       run: | 
         cp .github/toolchains.xml ~/.m2/toolchains.xml
-        mvn -U -V -e -B -ntp clean install --file pom.xml -T1C -DtrimStackTrace=false -Pits -fae
+        mvn -U -V -e -B -ntp clean install --file pom.xml -DtrimStackTrace=false -Pits -fae
     - name: Upload Test Results
       uses: actions/upload-artifact@v3
       if: always()


### PR DESCRIPTION
Currently this leads to some of the module scoped integration test failure, on the long run we should adjust / convert these ITs but for now it seems best to disable the multithread build even though it is a bit slower.