### PR TITLE
Use a more generic approach for line ending handling

### DIFF
--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/DefaultContentsComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/DefaultContentsComparator.java
@@ -13,6 +13,7 @@
 package org.eclipse.tycho.zipcomparator.internal;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
@@ -27,7 +28,32 @@ public class DefaultContentsComparator implements ContentsComparator {
     @Override
     public ArtifactDelta getDelta(ComparatorInputStream baseline, ComparatorInputStream reactor, ComparisonData data)
             throws IOException {
-        return baseline.compare(reactor);
+        if (isTextFile(baseline) && isTextFile(reactor)) {
+            //If both items a certainly a text file, we compare them ignoring line endings
+            return TextComparator.compareText(baseline, reactor);
+        }
+        return ArtifactDelta.DEFAULT;
+    }
+
+    /**
+     * This works like the git-diff tool that determine if a file is binary to look for any NULL
+     * byte in the file
+     * 
+     * @param stream
+     * @return
+     * @throws IOException
+     */
+    private static boolean isTextFile(ComparatorInputStream stream) throws IOException {
+        try (InputStream is = stream.asNewStream()) {
+            int i;
+            while ((i = is.read()) > -1) {
+                if (i == 0) {
+                    //seems to be a binary file...
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     @Override

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/TextComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/TextComparator.java
@@ -16,7 +16,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
@@ -37,10 +36,13 @@ public class TextComparator implements ContentsComparator {
 
     static final String HINT = "txt";
 
-    private static final Set<String> ALIAS = Set.of(HINT, "java", "javajet", "javajetinc", "html", "htm");
-
     @Override
     public ArtifactDelta getDelta(ComparatorInputStream baseline, ComparatorInputStream reactor, ComparisonData data)
+            throws IOException {
+        return compareText(baseline, reactor);
+    }
+
+    public static ArtifactDelta compareText(ComparatorInputStream baseline, ComparatorInputStream reactor)
             throws IOException {
         ByteIterator baselineIterator = new ByteIterator(baseline.asBytes());
         ByteIterator reactorIterator = new ByteIterator(reactor.asBytes());
@@ -94,15 +96,7 @@ public class TextComparator implements ContentsComparator {
 
     @Override
     public boolean matches(String nameOrExtension) {
-        if (ALIAS.contains(nameOrExtension.toLowerCase())) {
-            //a simple extension match
-            return true;
-        }
-        if (nameOrExtension.toLowerCase().endsWith("javax.inject.named")) {
-            //META-INF/sisu/javax.inject.Named ... 
-            return true;
-        }
-        return false;
+        return HINT.equalsIgnoreCase(nameOrExtension);
     }
 
     public static ArtifactDelta createDelta(String message, ComparatorInputStream baseline,

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ZipComparatorImpl.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ZipComparatorImpl.java
@@ -130,7 +130,7 @@ public class ZipComparatorImpl implements ArtifactComparator {
         }
         return comparators.values().stream() //
                 .filter(c -> c.matches(name) || c.matches(extension)) //
-                .findFirst().orElse(null);
+                .findFirst().orElseGet(() -> comparators.get(DefaultContentsComparator.TYPE));
     }
 
     private static Map<String, ZipEntry> toEntryMap(ZipFile zip, MatchPatterns ignored) {

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BundleArtifactBaselineComparator.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BundleArtifactBaselineComparator.java
@@ -50,6 +50,7 @@ import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 import org.eclipse.tycho.artifactcomparator.ComparatorInputStream;
 import org.eclipse.tycho.p2maven.repository.P2RepositoryManager;
 import org.eclipse.tycho.zipcomparator.internal.ContentsComparator;
+import org.eclipse.tycho.zipcomparator.internal.DefaultContentsComparator;
 import org.eclipse.tycho.zipcomparator.internal.ManifestComparator;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
@@ -455,6 +456,7 @@ public class BundleArtifactBaselineComparator implements ArtifactBaselineCompara
 					return alternative;
 				}
 			}
+			return contentComparators.get(DefaultContentsComparator.TYPE);
 		}
 		return comparator;
 	}

--- a/tycho-its/projects/baseline/api-bundle/MPL-1.1.txt
+++ b/tycho-its/projects/baseline/api-bundle/MPL-1.1.txt
@@ -1,0 +1,470 @@
+                          MOZILLA PUBLIC LICENSE
+                                Version 1.1
+
+                              ---------------
+
+1. Definitions.
+
+     1.0.1. "Commercial Use" means distribution or otherwise making the
+     Covered Code available to a third party.
+
+     1.1. "Contributor" means each entity that creates or contributes to
+     the creation of Modifications.
+
+     1.2. "Contributor Version" means the combination of the Original
+     Code, prior Modifications used by a Contributor, and the Modifications
+     made by that particular Contributor.
+
+     1.3. "Covered Code" means the Original Code or Modifications or the
+     combination of the Original Code and Modifications, in each case
+     including portions thereof.
+
+     1.4. "Electronic Distribution Mechanism" means a mechanism generally
+     accepted in the software development community for the electronic
+     transfer of data.
+
+     1.5. "Executable" means Covered Code in any form other than Source
+     Code.
+
+     1.6. "Initial Developer" means the individual or entity identified
+     as the Initial Developer in the Source Code notice required by Exhibit
+     A.
+
+     1.7. "Larger Work" means a work which combines Covered Code or
+     portions thereof with code not governed by the terms of this License.
+
+     1.8. "License" means this document.
+
+     1.8.1. "Licensable" means having the right to grant, to the maximum
+     extent possible, whether at the time of the initial grant or
+     subsequently acquired, any and all of the rights conveyed herein.
+
+     1.9. "Modifications" means any addition to or deletion from the
+     substance or structure of either the Original Code or any previous
+     Modifications. When Covered Code is released as a series of files, a
+     Modification is:
+          A. Any addition to or deletion from the contents of a file
+          containing Original Code or previous Modifications.
+
+          B. Any new file that contains any part of the Original Code or
+          previous Modifications.
+
+     1.10. "Original Code" means Source Code of computer software code
+     which is described in the Source Code notice required by Exhibit A as
+     Original Code, and which, at the time of its release under this
+     License is not already Covered Code governed by this License.
+
+     1.10.1. "Patent Claims" means any patent claim(s), now owned or
+     hereafter acquired, including without limitation,  method, process,
+     and apparatus claims, in any patent Licensable by grantor.
+
+     1.11. "Source Code" means the preferred form of the Covered Code for
+     making modifications to it, including all modules it contains, plus
+     any associated interface definition files, scripts used to control
+     compilation and installation of an Executable, or source code
+     differential comparisons against either the Original Code or another
+     well known, available Covered Code of the Contributor's choice. The
+     Source Code can be in a compressed or archival form, provided the
+     appropriate decompression or de-archiving software is widely available
+     for no charge.
+
+     1.12. "You" (or "Your")  means an individual or a legal entity
+     exercising rights under, and complying with all of the terms of, this
+     License or a future version of this License issued under Section 6.1.
+     For legal entities, "You" includes any entity which controls, is
+     controlled by, or is under common control with You. For purposes of
+     this definition, "control" means (a) the power, direct or indirect,
+     to cause the direction or management of such entity, whether by
+     contract or otherwise, or (b) ownership of more than fifty percent
+     (50%) of the outstanding shares or beneficial ownership of such
+     entity.
+
+2. Source Code License.
+
+     2.1. The Initial Developer Grant.
+     The Initial Developer hereby grants You a world-wide, royalty-free,
+     non-exclusive license, subject to third party intellectual property
+     claims:
+          (a)  under intellectual property rights (other than patent or
+          trademark) Licensable by Initial Developer to use, reproduce,
+          modify, display, perform, sublicense and distribute the Original
+          Code (or portions thereof) with or without Modifications, and/or
+          as part of a Larger Work; and
+
+          (b) under Patents Claims infringed by the making, using or
+          selling of Original Code, to make, have made, use, practice,
+          sell, and offer for sale, and/or otherwise dispose of the
+          Original Code (or portions thereof).
+
+          (c) the licenses granted in this Section 2.1(a) and (b) are
+          effective on the date Initial Developer first distributes
+          Original Code under the terms of this License.
+
+          (d) Notwithstanding Section 2.1(b) above, no patent license is
+          granted: 1) for code that You delete from the Original Code; 2)
+          separate from the Original Code;  or 3) for infringements caused
+          by: i) the modification of the Original Code or ii) the
+          combination of the Original Code with other software or devices.
+
+     2.2. Contributor Grant.
+     Subject to third party intellectual property claims, each Contributor
+     hereby grants You a world-wide, royalty-free, non-exclusive license
+
+          (a)  under intellectual property rights (other than patent or
+          trademark) Licensable by Contributor, to use, reproduce, modify,
+          display, perform, sublicense and distribute the Modifications
+          created by such Contributor (or portions thereof) either on an
+          unmodified basis, with other Modifications, as Covered Code
+          and/or as part of a Larger Work; and
+
+          (b) under Patent Claims infringed by the making, using, or
+          selling of  Modifications made by that Contributor either alone
+          and/or in combination with its Contributor Version (or portions
+          of such combination), to make, use, sell, offer for sale, have
+          made, and/or otherwise dispose of: 1) Modifications made by that
+          Contributor (or portions thereof); and 2) the combination of
+          Modifications made by that Contributor with its Contributor
+          Version (or portions of such combination).
+
+          (c) the licenses granted in Sections 2.2(a) and 2.2(b) are
+          effective on the date Contributor first makes Commercial Use of
+          the Covered Code.
+
+          (d)    Notwithstanding Section 2.2(b) above, no patent license is
+          granted: 1) for any code that Contributor has deleted from the
+          Contributor Version; 2)  separate from the Contributor Version;
+          3)  for infringements caused by: i) third party modifications of
+          Contributor Version or ii)  the combination of Modifications made
+          by that Contributor with other software  (except as part of the
+          Contributor Version) or other devices; or 4) under Patent Claims
+          infringed by Covered Code in the absence of Modifications made by
+          that Contributor.
+
+3. Distribution Obligations.
+
+     3.1. Application of License.
+     The Modifications which You create or to which You contribute are
+     governed by the terms of this License, including without limitation
+     Section 2.2. The Source Code version of Covered Code may be
+     distributed only under the terms of this License or a future version
+     of this License released under Section 6.1, and You must include a
+     copy of this License with every copy of the Source Code You
+     distribute. You may not offer or impose any terms on any Source Code
+     version that alters or restricts the applicable version of this
+     License or the recipients' rights hereunder. However, You may include
+     an additional document offering the additional rights described in
+     Section 3.5.
+
+     3.2. Availability of Source Code.
+     Any Modification which You create or to which You contribute must be
+     made available in Source Code form under the terms of this License
+     either on the same media as an Executable version or via an accepted
+     Electronic Distribution Mechanism to anyone to whom you made an
+     Executable version available; and if made available via Electronic
+     Distribution Mechanism, must remain available for at least twelve (12)
+     months after the date it initially became available, or at least six
+     (6) months after a subsequent version of that particular Modification
+     has been made available to such recipients. You are responsible for
+     ensuring that the Source Code version remains available even if the
+     Electronic Distribution Mechanism is maintained by a third party.
+
+     3.3. Description of Modifications.
+     You must cause all Covered Code to which You contribute to contain a
+     file documenting the changes You made to create that Covered Code and
+     the date of any change. You must include a prominent statement that
+     the Modification is derived, directly or indirectly, from Original
+     Code provided by the Initial Developer and including the name of the
+     Initial Developer in (a) the Source Code, and (b) in any notice in an
+     Executable version or related documentation in which You describe the
+     origin or ownership of the Covered Code.
+
+     3.4. Intellectual Property Matters
+          (a) Third Party Claims.
+          If Contributor has knowledge that a license under a third party's
+          intellectual property rights is required to exercise the rights
+          granted by such Contributor under Sections 2.1 or 2.2,
+          Contributor must include a text file with the Source Code
+          distribution titled "LEGAL" which describes the claim and the
+          party making the claim in sufficient detail that a recipient will
+          know whom to contact. If Contributor obtains such knowledge after
+          the Modification is made available as described in Section 3.2,
+          Contributor shall promptly modify the LEGAL file in all copies
+          Contributor makes available thereafter and shall take other steps
+          (such as notifying appropriate mailing lists or newsgroups)
+          reasonably calculated to inform those who received the Covered
+          Code that new knowledge has been obtained.
+
+          (b) Contributor APIs.
+          If Contributor's Modifications include an application programming
+          interface and Contributor has knowledge of patent licenses which
+          are reasonably necessary to implement that API, Contributor must
+          also include this information in the LEGAL file.
+
+               (c)    Representations.
+          Contributor represents that, except as disclosed pursuant to
+          Section 3.4(a) above, Contributor believes that Contributor's
+          Modifications are Contributor's original creation(s) and/or
+          Contributor has sufficient rights to grant the rights conveyed by
+          this License.
+
+     3.5. Required Notices.
+     You must duplicate the notice in Exhibit A in each file of the Source
+     Code.  If it is not possible to put such notice in a particular Source
+     Code file due to its structure, then You must include such notice in a
+     location (such as a relevant directory) where a user would be likely
+     to look for such a notice.  If You created one or more Modification(s)
+     You may add your name as a Contributor to the notice described in
+     Exhibit A.  You must also duplicate this License in any documentation
+     for the Source Code where You describe recipients' rights or ownership
+     rights relating to Covered Code.  You may choose to offer, and to
+     charge a fee for, warranty, support, indemnity or liability
+     obligations to one or more recipients of Covered Code. However, You
+     may do so only on Your own behalf, and not on behalf of the Initial
+     Developer or any Contributor. You must make it absolutely clear than
+     any such warranty, support, indemnity or liability obligation is
+     offered by You alone, and You hereby agree to indemnify the Initial
+     Developer and every Contributor for any liability incurred by the
+     Initial Developer or such Contributor as a result of warranty,
+     support, indemnity or liability terms You offer.
+
+     3.6. Distribution of Executable Versions.
+     You may distribute Covered Code in Executable form only if the
+     requirements of Section 3.1-3.5 have been met for that Covered Code,
+     and if You include a notice stating that the Source Code version of
+     the Covered Code is available under the terms of this License,
+     including a description of how and where You have fulfilled the
+     obligations of Section 3.2. The notice must be conspicuously included
+     in any notice in an Executable version, related documentation or
+     collateral in which You describe recipients' rights relating to the
+     Covered Code. You may distribute the Executable version of Covered
+     Code or ownership rights under a license of Your choice, which may
+     contain terms different from this License, provided that You are in
+     compliance with the terms of this License and that the license for the
+     Executable version does not attempt to limit or alter the recipient's
+     rights in the Source Code version from the rights set forth in this
+     License. If You distribute the Executable version under a different
+     license You must make it absolutely clear that any terms which differ
+     from this License are offered by You alone, not by the Initial
+     Developer or any Contributor. You hereby agree to indemnify the
+     Initial Developer and every Contributor for any liability incurred by
+     the Initial Developer or such Contributor as a result of any such
+     terms You offer.
+
+     3.7. Larger Works.
+     You may create a Larger Work by combining Covered Code with other code
+     not governed by the terms of this License and distribute the Larger
+     Work as a single product. In such a case, You must make sure the
+     requirements of this License are fulfilled for the Covered Code.
+
+4. Inability to Comply Due to Statute or Regulation.
+
+     If it is impossible for You to comply with any of the terms of this
+     License with respect to some or all of the Covered Code due to
+     statute, judicial order, or regulation then You must: (a) comply with
+     the terms of this License to the maximum extent possible; and (b)
+     describe the limitations and the code they affect. Such description
+     must be included in the LEGAL file described in Section 3.4 and must
+     be included with all distributions of the Source Code. Except to the
+     extent prohibited by statute or regulation, such description must be
+     sufficiently detailed for a recipient of ordinary skill to be able to
+     understand it.
+
+5. Application of this License.
+
+     This License applies to code to which the Initial Developer has
+     attached the notice in Exhibit A and to related Covered Code.
+
+6. Versions of the License.
+
+     6.1. New Versions.
+     Netscape Communications Corporation ("Netscape") may publish revised
+     and/or new versions of the License from time to time. Each version
+     will be given a distinguishing version number.
+
+     6.2. Effect of New Versions.
+     Once Covered Code has been published under a particular version of the
+     License, You may always continue to use it under the terms of that
+     version. You may also choose to use such Covered Code under the terms
+     of any subsequent version of the License published by Netscape. No one
+     other than Netscape has the right to modify the terms applicable to
+     Covered Code created under this License.
+
+     6.3. Derivative Works.
+     If You create or use a modified version of this License (which you may
+     only do in order to apply it to code which is not already Covered Code
+     governed by this License), You must (a) rename Your license so that
+     the phrases "Mozilla", "MOZILLAPL", "MOZPL", "Netscape",
+     "MPL", "NPL" or any confusingly similar phrase do not appear in your
+     license (except to note that your license differs from this License)
+     and (b) otherwise make it clear that Your version of the license
+     contains terms which differ from the Mozilla Public License and
+     Netscape Public License. (Filling in the name of the Initial
+     Developer, Original Code or Contributor in the notice described in
+     Exhibit A shall not of themselves be deemed to be modifications of
+     this License.)
+
+7. DISCLAIMER OF WARRANTY.
+
+     COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS,
+     WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+     WITHOUT LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF
+     DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING.
+     THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED CODE
+     IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT,
+     YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE
+     COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER
+     OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF
+     ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+8. TERMINATION.
+
+     8.1.  This License and the rights granted hereunder will terminate
+     automatically if You fail to comply with terms herein and fail to cure
+     such breach within 30 days of becoming aware of the breach. All
+     sublicenses to the Covered Code which are properly granted shall
+     survive any termination of this License. Provisions which, by their
+     nature, must remain in effect beyond the termination of this License
+     shall survive.
+
+     8.2.  If You initiate litigation by asserting a patent infringement
+     claim (excluding declatory judgment actions) against Initial Developer
+     or a Contributor (the Initial Developer or Contributor against whom
+     You file such action is referred to as "Participant")  alleging that:
+
+     (a)  such Participant's Contributor Version directly or indirectly
+     infringes any patent, then any and all rights granted by such
+     Participant to You under Sections 2.1 and/or 2.2 of this License
+     shall, upon 60 days notice from Participant terminate prospectively,
+     unless if within 60 days after receipt of notice You either: (i)
+     agree in writing to pay Participant a mutually agreeable reasonable
+     royalty for Your past and future use of Modifications made by such
+     Participant, or (ii) withdraw Your litigation claim with respect to
+     the Contributor Version against such Participant.  If within 60 days
+     of notice, a reasonable royalty and payment arrangement are not
+     mutually agreed upon in writing by the parties or the litigation claim
+     is not withdrawn, the rights granted by Participant to You under
+     Sections 2.1 and/or 2.2 automatically terminate at the expiration of
+     the 60 day notice period specified above.
+
+     (b)  any software, hardware, or device, other than such Participant's
+     Contributor Version, directly or indirectly infringes any patent, then
+     any rights granted to You by such Participant under Sections 2.1(b)
+     and 2.2(b) are revoked effective as of the date You first made, used,
+     sold, distributed, or had made, Modifications made by that
+     Participant.
+
+     8.3.  If You assert a patent infringement claim against Participant
+     alleging that such Participant's Contributor Version directly or
+     indirectly infringes any patent where such claim is resolved (such as
+     by license or settlement) prior to the initiation of patent
+     infringement litigation, then the reasonable value of the licenses
+     granted by such Participant under Sections 2.1 or 2.2 shall be taken
+     into account in determining the amount or value of any payment or
+     license.
+
+     8.4.  In the event of termination under Sections 8.1 or 8.2 above,
+     all end user license agreements (excluding distributors and resellers)
+     which have been validly granted by You or any distributor hereunder
+     prior to termination shall survive termination.
+
+9. LIMITATION OF LIABILITY.
+
+     UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+     (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL
+     DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE,
+     OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR
+     ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY
+     CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL,
+     WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+     COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+     INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
+     LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY
+     RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW
+     PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE
+     EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO
+     THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+10. U.S. GOVERNMENT END USERS.
+
+     The Covered Code is a "commercial item," as that term is defined in
+     48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer
+     software" and "commercial computer software documentation," as such
+     terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48
+     C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995),
+     all U.S. Government End Users acquire Covered Code with only those
+     rights set forth herein.
+
+11. MISCELLANEOUS.
+
+     This License represents the complete agreement concerning subject
+     matter hereof. If any provision of this License is held to be
+     unenforceable, such provision shall be reformed only to the extent
+     necessary to make it enforceable. This License shall be governed by
+     California law provisions (except to the extent applicable law, if
+     any, provides otherwise), excluding its conflict-of-law provisions.
+     With respect to disputes in which at least one party is a citizen of,
+     or an entity chartered or registered to do business in the United
+     States of America, any litigation relating to this License shall be
+     subject to the jurisdiction of the Federal Courts of the Northern
+     District of California, with venue lying in Santa Clara County,
+     California, with the losing party responsible for costs, including
+     without limitation, court costs and reasonable attorneys' fees and
+     expenses. The application of the United Nations Convention on
+     Contracts for the International Sale of Goods is expressly excluded.
+     Any law or regulation which provides that the language of a contract
+     shall be construed against the drafter shall not apply to this
+     License.
+
+12. RESPONSIBILITY FOR CLAIMS.
+
+     As between Initial Developer and the Contributors, each party is
+     responsible for claims and damages arising, directly or indirectly,
+     out of its utilization of rights under this License and You agree to
+     work with Initial Developer and Contributors to distribute such
+     responsibility on an equitable basis. Nothing herein is intended or
+     shall be deemed to constitute any admission of liability.
+
+13. MULTIPLE-LICENSED CODE.
+
+     Initial Developer may designate portions of the Covered Code as
+     "Multiple-Licensed".  "Multiple-Licensed" means that the Initial
+     Developer permits you to utilize portions of the Covered Code under
+     Your choice of the NPL or the alternative licenses, if any, specified
+     by the Initial Developer in the file described in Exhibit A.
+
+EXHIBIT A -Mozilla Public License.
+
+     ``The contents of this file are subject to the Mozilla Public License
+     Version 1.1 (the "License"); you may not use this file except in
+     compliance with the License. You may obtain a copy of the License at
+     http://www.mozilla.org/MPL/
+
+     Software distributed under the License is distributed on an "AS IS"
+     basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+     License for the specific language governing rights and limitations
+     under the License.
+
+     The Original Code is ______________________________________.
+
+     The Initial Developer of the Original Code is ________________________.
+     Portions created by ______________________ are Copyright (C) ______
+     _______________________. All Rights Reserved.
+
+     Contributor(s): ______________________________________.
+
+     Alternatively, the contents of this file may be used under the terms
+     of the _____ license (the  "[___] License"), in which case the
+     provisions of [______] License are applicable instead of those
+     above.  If you wish to allow use of your version of this file only
+     under the terms of the [____] License and not to allow others to use
+     your version of this file under the MPL, indicate your decision by
+     deleting  the provisions above and replace  them with the notice and
+     other provisions required by the [___] License.  If you do not delete
+     the provisions above, a recipient may use your version of this file
+     under either the MPL or the [___] License."
+
+     [NOTE: The text of this Exhibit A may differ slightly from the text of
+     the notices in the Source Code files of the Original Code. You should
+     use the text of this Exhibit A rather than the text found in the
+     Original Code Source Code for Your Modifications.]
+

--- a/tycho-its/projects/baseline/api-bundle/about.html
+++ b/tycho-its/projects/baseline/api-bundle/about.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+<h3>Third Party Content</h3>
+
+<p>
+The Content includes items that have been sourced from third parties as set out below. If you 
+did not receive this Content directly from the Eclipse Foundation, the following is provided 
+for informational purposes only, and you should look to the Redistributor&rsquo;s license for 
+terms and conditions of use.
+</p>
+
+<h4>Archetype 2.0-alpha-4</h4>
+<p>
+The plug-in includes software developed by The Apache Software Foundation as part of the Maven project.
+Your use of Archetype 2.0-alpha-4 in binary code form contained in the plug-in is subject to the terms and conditions of the 
+The Apache Software License, Version 2.0 (&quot;ASL&quot;).  
+A copy of the ASL is available at <a href="http://maven.apache.org/license.html">http://maven.apache.org/license.html</a>.
+(a local copy can be found <a href="about_files/LICENSE-2.0.txt">here</a>)
+</p>
+<p>The original binaries are available at the <a href="http://maven.org">Maven Central Repository</a>.</p>
+
+
+<h4>Apache Commons Collections 3.2, Apache Commons I/O 1.3.2, Apache Commons Lang 2.1</h4>
+<p>
+The plug-in includes software developed by The Apache Software Foundation as part of the Apache Commons project.
+Your use of Apache Commons Collections 3.2, Apache Commons I/O 1.3.2, Apache Commons Lang 2.1 in binary code form contained in the plug-in is subject to the terms and conditions of the 
+The Apache Software License, Version 2.0 (&quot;ASL&quot;).  
+A copy of the ASL is available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
+(a local copy can be found <a href="about_files/LICENSE-2.0.txt">here</a>)
+</p>
+<p>The original binaries are available at the <a href="http://maven.org">Maven Central Repository</a>.</p>
+                                                                                                                
+
+
+<h4>dom4j 2.1.3</h4>
+<p>
+Your use of dom4j 2.1.3 in binary code form contained in the plug-in is subject to the terms and conditions of 
+BSD style license (&quot;BSD&quot;).  
+A local copy of the license can be found <a href="about_files/dom4j-LICENSE.txt ">here</a>.
+</p>
+<p>The original binaries are available at the <a href="http://maven.org">Maven Central Repository</a>.</p>
+
+
+<h4>jchardet 1.0</h4>
+<p>
+Your use of jchardet 1.0 in binary code form contained in the plug-in is subject to the terms and conditions of the 
+Mozilla Public License 1.1 (&quot;MPL&quot;).  
+A copy of the ASL is available at <a href="http://www.mozilla.org/MPL/MPL-1.1.html">http://www.mozilla.org/MPL/MPL-1.1.html</a>.
+(a local copy can be found <a href="about_files/MPL-1.1.txt">here</a>)
+</p>
+<p>The original binaries are available at the <a href="http://maven.org">Maven Central Repository</a>.</p>
+
+
+<h4>JDOM 1.0</h4>                                                                                                                                                    
+<p>JDOM is available under an Apache-style open source license, with the acknowledgment clause removed..                                                             
+This license is among the least restrictive license available, enabling developers to use JDOM in.                                                                   
+creating new products without requiring them to release their own products as open source..                                                                          
+This is the license model used by the Apache Project, which created the Apache server..                                                                              
+A copy of the license is contained in the file <a href="about_files/LICENSE.txt">jdom-LICENSE.txt</a>.                                                                
+</p>
+
+
+
+<h4>Jakarta-Oro 2.0.8</h4>                                                                                                                                           
+<p>The plug-in includes Jakarta-Oro 2.0.8 (&quot;Jakarta-Oro&quot;) developed by the Apache Software Foundation as part of the Jakarta project.                      
+Your use of Jakarta-Oro 2.0.8 in binary code form contained in the plug-in is subject to the terms and conditions of the 
+The Apache Software License, Version 1.1 (&quot;ASL-1.1&quot;).  
+A copy of the ASL 1.1 is available at <a href="http://www.apache.org/licenses/LICENSE-1.1">http://www.apache.org/licenses/LICENSE-1.1</a>.
+(a local copy can be found <a href="about_files/LICENSE-1.1.txt">here</a>)
+</p>
+
+
+
+<h4>Apache Velocity 1.5</h4>                                                                                                                                         
+<p>The plug-in includes Apache Velocity 1.5 developed by the Apache Software Foundation.                                                                        
+Your use of Apache Velocity is subject to the terms and conditions of the                                                                                         
+Apache Software License 2.0. A copy of the license                                                                                                                   
+ is contained in the file <a href="about_files/LICENSE.txt">LICENSE-2.0.txt</a>                                                                                          
+and is also available at <a href="http://www.apache.org/licenses/LICENSE-2.0.txt">                                                                               
+http://www.apache.org/licenses/LICENSE-2.0.txt</a>.</p>                                                                                                              
+
+
+
+<h4>Plexus Velocity 1.1.3</h4>
+<p>
+Your use of Plexus Velocity 1.1.3 in binary code form contained in the plug-in is subject to the terms and conditions of the 
+The Apache Software License, Version 2.0 (&quot;ASL&quot;).  
+A copy of the ASL is available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
+(a local copy can be found <a href="about_files/LICENSE-2.0.txt">here</a>)
+</p>
+<p>The original binaries are available at the <a href="http://maven.org">Maven Central Repository</a>.</p>
+
+
+
+</body>
+</html>

--- a/tycho-its/projects/baseline/api-bundle/build.properties
+++ b/tycho-its/projects/baseline/api-bundle/build.properties
@@ -1,4 +1,6 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               about.html,\
+               MPL-1.1.txt

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/baseline/BaselineMojoTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/baseline/BaselineMojoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Christoph Läubrich and others.
+ * Copyright (c) 2022, 2023 Christoph Läubrich and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -75,7 +75,7 @@ public class BaselineMojoTest extends AbstractTychoIntegrationTest {
 	/**
 	 * Compares the baseline against itself...
 	 *
-	 * @throws Exception
+	 * @throws Throwable
 	 */
 	@Test
 	public void testUnchangedApi() throws Throwable {
@@ -84,9 +84,32 @@ public class BaselineMojoTest extends AbstractTychoIntegrationTest {
 	}
 
 	/**
+	 * Compares the baseline against itself... but modify the line endings!
+	 *
+	 * @throws Throwable
+	 */
+	@Test
+	public void testChangedLineEndings() throws Throwable {
+		buildBaselineProject(false, projectPath -> {
+			for (String file : new String[] { "about.html", "MPL-1.1.txt" }) {
+				Path about = projectPath.resolve(file);
+				String string = Files.readString(about);
+				if (string.contains("\r\n")) {
+					string = string.replace("\r\n", "\n");
+				} else if (string.contains("\r")) {
+					string = string.replace("\r", "\n");
+				} else if (string.contains("\n")) {
+					string = string.replace("\n", "\r");
+				}
+				Files.writeString(about, string);
+			}
+		});
+	}
+
+	/**
 	 * This adds a method to the interface
 	 *
-	 * @throws Exception
+	 * @throws Throwable
 	 */
 	@Test
 	public void testAddMethod() throws Throwable {
@@ -110,7 +133,7 @@ public class BaselineMojoTest extends AbstractTychoIntegrationTest {
 	/**
 	 * This adds a internal method to the interface
 	 *
-	 * @throws Exception
+	 * @throws Throwable
 	 */
 	@Test
 	public void testAddInternalMethod() throws Throwable {
@@ -135,7 +158,7 @@ public class BaselineMojoTest extends AbstractTychoIntegrationTest {
 	/**
 	 * This adds a resource to the bundle
 	 *
-	 * @throws Exception
+	 * @throws Throwable
 	 */
 	@Test
 	public void testAddResource() throws Throwable {


### PR DESCRIPTION
For the compare-with-baseline we usually try our best to detect if a real change is there but we can't get 100% confidence, therefore this adds support for detecting line-ending-only changes in a wide rage of file using a common heuristic (e.g. git / grep) by check if the file contains a NULL-byte.

If we found that both files are probably text, we compare them ignoring the line endings, otherwise they are assumed binary an assumed to be different.