### PR TITLE
Add table of contents

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Eclipse Tycho: Release notes
 
-This page describes the noteworthy improvements provided by each release of Eclipse Tycho.
+This page describes the noteworthy improvements provided by each release of Eclipse Tycho. Please use the [generated table of contents](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/) to jump to specific versions.
 
 ## 4.0.0 (under development)
 


### PR DESCRIPTION
Mention the generated table of contents, because it's too easy to miss this github feature, and the releases notes are quite large meanwhile. Alternatively we could split the file into multiple files.