### PR TITLE
Allow resolving mixed builds in eager resolve mode

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -156,11 +156,7 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     public PomDependencies getPomDependencies() {
         if (pomDependencies == null) {
-            if (isRequireEagerResolve()) {
-                return PomDependencies.ignore;
-            } else {
-                return PomDependencies.consider;
-            }
+            return PomDependencies.consider;
         }
         return pomDependencies;
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractTychoProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractTychoProject.java
@@ -171,7 +171,18 @@ public abstract class AbstractTychoProject extends AbstractLogEnabled implements
                         if (artifactReactorProject != null) {
                             MavenProject mavenProject = artifactReactorProject.adapt(MavenProject.class);
                             if (mavenProject != null) {
-                                return mavenProject.getArtifact();
+                                // TychoReactorReader or another custom WorkspaceReader might have returned a "dummy"
+                                // file in case the project is inside the workspace and not packaged/installed already.
+                                // Here we just make sure we copy the returned file if necessary
+                                final Artifact projectArtifact = mavenProject.getArtifact();
+
+                                if (projectArtifact == null) {
+                                    mavenProject.setArtifact(artifact);
+                                } else if (projectArtifact.getFile() == null) {
+                                    projectArtifact.setFile(artifact.getFile());
+                                }
+
+                                return projectArtifact;
                             }
                         }
                         return artifact;

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
@@ -227,9 +227,7 @@ public class P2ResolverImpl implements P2Resolver {
             if (project != null && p2ResolverFactoryImpl != null && pomDependencies != PomDependencies.ignore) {
                 TargetPlatformConfiguration configuration = p2ResolverFactoryImpl.getProjectManager()
                         .getTargetPlatformConfiguration(project);
-                if (!configuration.isRequireEagerResolve()) {
-                    data.setAdditionalUnitStore(p2ResolverFactoryImpl.getPomUnits().createPomQueryable(project));
-                }
+                data.setAdditionalUnitStore(p2ResolverFactoryImpl.getPomUnits().createPomQueryable(project));
             }
             newState = strategy.resolve(environment, monitor);
         } catch (ResolverException e) {


### PR DESCRIPTION
This reuse the same concept used in `TychoReactorReader`, more or less.

`InstallableUnitGenerator` takes for granted a JAR file has been built already for a project that is inside the same reactor.  
This is not always the case.