### PR TITLE
Update documentation of Tycho-compiler/sufire-plugin's 'useJDK' property and minor improvments

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -142,18 +142,21 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
      * JDK. If BREE is specified, MANIFEST header <code>Bundle-RequiredExecutionEnvironment</code>
      * is used to define the JDK to compile against. In this case, you need to provide a
      * <a href="https://maven.apache.org/guides/mini/guide-using-toolchains.html">toolchains.xml</a>
-     * configuration file. The value of BREE will be matched against the id of the toolchain
-     * elements in toolchains.xml. Example:
+     * configuration file. The value of BREE will be matched against the id of the JDK toolchain
+     * elements in <code>toolchains.xml</code>. If the BREEs version is 9 or later and the ID did
+     * not match any element, the version of the BREE will be matched against the version of the JDK
+     * toolchain elements. Example:
      * 
      * <pre>
      * &lt;toolchains&gt;
      *   &lt;toolchain&gt;
      *      &lt;type&gt;jdk&lt;/type&gt;
      *      &lt;provides&gt;
-     *          &lt;id&gt;J2SE-1.5&lt;/id&gt;
+     *          &lt;id&gt;JavaSE-11&lt;/id&gt;
+     *          &lt;version&gt;11&lt;/version&gt;
      *      &lt;/provides&gt;
      *      &lt;configuration&gt;
-     *         &lt;jdkHome&gt;/path/to/jdk/1.5&lt;/jdkHome&gt;
+     *         &lt;jdkHome&gt;/path/to/jdk/11&lt;/jdkHome&gt;
      *      &lt;/configuration&gt;
      *   &lt;/toolchain&gt;
      * &lt;/toolchains&gt;

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -144,30 +144,33 @@ public abstract class AbstractTestMojo extends AbstractMojo {
      * <li>BREE: use MANIFEST header <code>Bundle-RequiredExecutionEnvironment</code> to lookup the
      * JDK from <a href=
      * "https://maven.apache.org/guides/mini/guide-using-toolchains.html">toolchains.xml</a>. The
-     * value of BREE will be matched against the id of the toolchain elements in
-     * toolchains.xml.</li>
+     * value of BREE will be matched against the id of the JDK toolchain elements in
+     * <code>toolchains.xml</code>. If the BREEs version is 9 or later and the ID did not match any
+     * element, the version of the BREE will be matched against the version of the JDK toolchain
+     * elements.</li>
      * </ul>
      *
      * Example for BREE: <br>
      * In <code>META-INF/MANIFEST.MF</code>:
      *
      * <pre>
-     * Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+     * Bundle-RequiredExecutionEnvironment: JavaSE-11
      * </pre>
      *
      * In toolchains.xml:
      *
      * <pre>
      * &lt;toolchains&gt;
-     *    &lt;toolchain&gt;
-     *       &lt;type&gt;jdk&lt;/type&gt;
-     *       &lt;provides&gt;
-     *          &lt;id&gt;JavaSE-1.7&lt;/id&gt;
-     *       &lt;/provides&gt;
-     *       &lt;configuration&gt;
-     *          &lt;jdkHome&gt;/path/to/jdk/1.7&lt;/jdkHome&gt;
-     *       &lt;/configuration&gt;
-     *    &lt;/toolchain&gt;
+     *   &lt;toolchain&gt;
+     *      &lt;type&gt;jdk&lt;/type&gt;
+     *      &lt;provides&gt;
+     *          &lt;id&gt;JavaSE-11&lt;/id&gt;
+     *          &lt;version&gt;11&lt;/version&gt;
+     *      &lt;/provides&gt;
+     *      &lt;configuration&gt;
+     *         &lt;jdkHome&gt;/path/to/jdk/11&lt;/jdkHome&gt;
+     *      &lt;/configuration&gt;
+     *   &lt;/toolchain&gt;
      * &lt;/toolchains&gt;
      * </pre>
      */
@@ -390,9 +393,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
         final var value = attributes.getValue(Constants.BUNDLE_SYMBOLICNAME);
         final var separatorIndex = value.indexOf(';');
         final var hostSymbolicName = separatorIndex > -1 ? value.substring(0, separatorIndex) : value;
-        final var fragmentHost = "%s;%s=\"%s\"".formatted(hostSymbolicName, Constants.BUNDLE_VERSION_ATTRIBUTE,
-                hostVersion);
-        return fragmentHost;
+        return "%s;%s=\"%s\"".formatted(hostSymbolicName, Constants.BUNDLE_VERSION_ATTRIBUTE, hostVersion);
     }
 
     protected List<TargetEnvironment> getTestTargetEnvironments() {
@@ -423,8 +424,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
     }
 
     protected String getTestProfileName() {
-        String profileName = projectManager.getExecutionEnvironmentConfiguration(project).getProfileName();
-        return profileName;
+        return projectManager.getExecutionEnvironmentConfiguration(project).getProfileName();
     }
 
     protected String getJavaExecutable() throws MojoExecutionException {


### PR DESCRIPTION
Update documentation of the tycho-compiler/sufire-plugin's 'useJDK' property to fix https://github.com/eclipse-tycho/tycho/issues/2377.

Additionally apply some minor code improvements in the Toolchains processing, for example
- Replace deprecated DefaultJavaToolChain by JavaToolchainImpl
- Don't walk the entire directory when searching `JDK_HOME/bin` for a toolname case insensitive.