### PR TITLE
Minor simplifications and clean-ups in Toolchain processing

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -882,12 +882,12 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
 
     @Override
     public List<ClasspathEntry> getClasspath() throws MojoExecutionException {
-        ReactorProject reactorProject = DefaultReactorProject.adapt(project);
         List<ClasspathEntry> classpath;
         String dependencyScope = getDependencyScope();
         if (Artifact.SCOPE_TEST.equals(dependencyScope)) {
             classpath = new ArrayList<>(getBundleProject().getTestClasspath(DefaultReactorProject.adapt(project)));
         } else {
+            ReactorProject reactorProject = DefaultReactorProject.adapt(project);
             classpath = new ArrayList<>(getBundleProject().getClasspath(reactorProject));
         }
         if (extraClasspathElements != null) {
@@ -939,7 +939,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
                 }
             }
         }
-        List<ClasspathEntry> uniqueClasspath = classpathMap.entrySet().stream().flatMap(entry -> {
+        return classpathMap.entrySet().stream().flatMap(entry -> {
             List<ClasspathEntry> list = entry.getValue();
             if (list.isEmpty()) {
                 return Stream.empty();
@@ -948,7 +948,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
                 return list.stream();
             }
             ArtifactKey key = entry.getKey();
-            ReactorProject compositeProject = findProjectForKey(reactorProject, key);
+            ReactorProject compositeProject = findProjectForKey(key);
             List<File> compositeFiles = list.stream().flatMap(cpe -> cpe.getLocations().stream()).toList();
             Collection<AccessRule> compositeRules = mergeRules(list);
             return Stream.of(new ClasspathEntry() {
@@ -983,7 +983,6 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
 
             });
         }).toList();
-        return uniqueClasspath;
     }
 
     private ArtifactKey normalizedKey(ArtifactKey key) {
@@ -1013,7 +1012,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
         return joinedRules;
     }
 
-    private ReactorProject findProjectForKey(ReactorProject root, ArtifactKey key) {
+    private ReactorProject findProjectForKey(ArtifactKey key) {
         for (MavenProject p : session.getProjects()) {
             ReactorProject rp = DefaultReactorProject.adapt(p);
             try {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentUtils.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentUtils.java
@@ -18,7 +18,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +30,6 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
-import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
 import org.eclipse.tycho.ExecutionEnvironment;
 import org.eclipse.tycho.TargetEnvironment;
@@ -39,7 +37,6 @@ import org.eclipse.tycho.ExecutionEnvironment.SystemPackageEntry;
 import org.eclipse.tycho.core.ee.StandardExecutionEnvironment.JavaInfo;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.Constants;
-import org.osgi.framework.Version;
 
 /**
  * Creative copy&paste from org.eclipse.osgi.framework.internal.core.Framework
@@ -166,15 +163,14 @@ public class ExecutionEnvironmentUtils {
         if (manager != null) {
             logger.debug("Searching profile " + profileName + " in ToolchainManager");
             //First try to find it by ID
-            for (Toolchain toolchain : manager.getToolchains(session, "jdk",
-                    Collections.singletonMap("id", profileName))) {
+            for (Toolchain toolchain : manager.getToolchains(session, "jdk", Map.of("id", profileName))) {
                 return toolchain;
             }
             //Try find by version
             int version = getVersion(profileName);
             if (version > 8) {
                 for (Toolchain toolchain : manager.getToolchains(session, "jdk",
-                        Collections.singletonMap("version", String.valueOf(version)))) {
+                        Map.of("version", String.valueOf(version)))) {
                     return toolchain;
                 }
             }
@@ -195,11 +191,8 @@ public class ExecutionEnvironmentUtils {
         String[] split = profileName.split("-");
         if (split.length == 2) {
             try {
-                double v = Double.parseDouble(split[split.length - 1]);
-                if (v < 8) {
-                    return (int) ((v - 1.0) * 10);
-                }
-                return (int) v;
+                String version = split[1];
+                return Integer.parseInt(version.startsWith("1.") ? version.substring(2) : version);
             } catch (NumberFormatException e) {
                 //can't check then...
             }
@@ -288,24 +281,5 @@ public class ExecutionEnvironmentUtils {
         props.setProperty("org.eclipse.jdt.core.compiler.problem.assertIdentifier", "error");
         props.setProperty("org.eclipse.jdt.core.compiler.problem.enumIdentifier", "error");
         return props;
-    }
-
-    public static boolean isCompatibleIU(IInstallableUnit iu, String profileName) {
-        if (iu.getArtifacts().isEmpty()) {
-            return false;
-        }
-        int version = getVersion(profileName);
-        int maxEE = iu.getProvidedCapabilities().stream().filter(cap -> "osgi.ee".equals(cap.getNamespace()))
-                .mapToInt(cap -> {
-                    if (cap.getVersion().isOSGiCompatible()) {
-                        Version v = new Version(cap.getVersion().toString());
-                        if (v.getMajor() < 8) {
-                            return v.getMinor();
-                        }
-                        return v.getMajor();
-                    }
-                    return -1;
-                }).max().orElse(-1);
-        return maxEE == version;
     }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/OSGiJavaToolchain.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/OSGiJavaToolchain.java
@@ -16,6 +16,7 @@ import java.io.File;
 
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainPrivate;
+import org.apache.maven.toolchain.java.JavaToolchainImpl;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 public class OSGiJavaToolchain implements Toolchain {
@@ -37,7 +38,7 @@ public class OSGiJavaToolchain implements Toolchain {
     }
 
     public String getJavaHome() {
-        if (base instanceof @SuppressWarnings("deprecation") org.apache.maven.toolchain.java.DefaultJavaToolChain defaultToolchain) {
+        if (base instanceof JavaToolchainImpl defaultToolchain) {
             return defaultToolchain.getJavaHome();
         }
         if (base instanceof JavaHomeToolchain javaHomeToolchain) {
@@ -52,10 +53,9 @@ public class OSGiJavaToolchain implements Toolchain {
     }
 
     public Xpp3Dom getConfiguration() {
-        if (base instanceof ToolchainPrivate privateToolchain) {
-            if (privateToolchain.getModel().getConfiguration() instanceof Xpp3Dom xpp3) {
-                return xpp3;
-            }
+        if (base instanceof ToolchainPrivate privateToolchain
+                && privateToolchain.getModel().getConfiguration() instanceof Xpp3Dom xpp3) {
+            return xpp3;
         }
         return null;
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/ToolchainProvider.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/ToolchainProvider.java
@@ -28,7 +28,7 @@ import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.apache.maven.toolchain.ToolchainManagerPrivate;
 import org.apache.maven.toolchain.ToolchainPrivate;
-import org.apache.maven.toolchain.java.DefaultJavaToolChain;
+import org.apache.maven.toolchain.java.JavaToolchainImpl;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -123,8 +123,8 @@ public class ToolchainProvider {
     }
 
     /**
-     * Finds a matching {@link DefaultJavaToolChain} in the maven toolchains for a given maven
-     * session and toolchain id. Returns the toolchain or null if no toolchain could be found.
+     * Finds a matching {@link JavaToolchainImpl} in the maven toolchains for a given maven session
+     * and toolchain id. Returns the toolchain or null if no toolchain could be found.
      * 
      * @param session
      *            The maven session
@@ -134,15 +134,14 @@ public class ToolchainProvider {
      * @throws MojoExecutionException
      *             if the toolchains are misconfigured
      */
-    public DefaultJavaToolChain findMatchingJavaToolChain(final MavenSession session, final String toolchainId)
+    public JavaToolchainImpl findMatchingJavaToolChain(final MavenSession session, final String toolchainId)
             throws MojoExecutionException {
         try {
             final Map<String, String> requirements = Collections.singletonMap("id", toolchainId);
             for (ToolchainPrivate javaToolChain : toolChainManager.getToolchainsForType("jdk", session)) {
-                if (javaToolChain.matchesRequirements(requirements)) {
-                    if (javaToolChain instanceof DefaultJavaToolChain defaultJavaToolchain) {
-                        return defaultJavaToolchain;
-                    }
+                if (javaToolChain.matchesRequirements(requirements)
+                        && javaToolChain instanceof JavaToolchainImpl javaToolchain) {
+                    return javaToolchain;
                 }
             }
             return null;

--- a/tycho-extras/tycho-eclipserun-plugin/src/test/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojoTest.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/test/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojoTest.java
@@ -27,6 +27,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.SilentLog;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.toolchain.java.JavaToolchainImpl;
 import org.eclipse.sisu.equinox.launching.EquinoxInstallation;
 import org.eclipse.sisu.equinox.launching.EquinoxLauncher;
 import org.eclipse.sisu.equinox.launching.LaunchConfiguration;
@@ -153,9 +154,7 @@ public class EclipseRunMojoTest extends AbstractTychoMojoTestCase {
 	}
 
 	public void testExecutionEnvironmentIsRespectedDuringEclipseExecution() throws Exception {
-		@SuppressWarnings("deprecation")
-		org.apache.maven.toolchain.java.DefaultJavaToolChain mockToolchainForCustomEE = mock(
-				org.apache.maven.toolchain.java.DefaultJavaToolChain.class);
+		JavaToolchainImpl mockToolchainForCustomEE = mock(JavaToolchainImpl.class);
 		when(mockToolchainForCustomEE.findTool("java")).thenReturn("/path/to/custom-ee-jdk/bin/java");
 		when(toolchainProvider.findMatchingJavaToolChain(any(), eq("custom-ee"))).thenReturn(mockToolchainForCustomEE);
 


### PR DESCRIPTION
Replace deprecated DefaultJavaToolChain by JavaToolchainImpl.

Initially part of https://github.com/eclipse-tycho/tycho/pull/2379, but there seem to be some bugs in this change.
@laeubi do you directly have any hot hint?