### PR TITLE
Let Tycho discover and provide classpath/buildpath entries from pde.bnd

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
@@ -46,6 +46,8 @@ import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
 import org.eclipse.tycho.model.project.EclipseProject;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
 
+import aQute.bnd.osgi.Processor;
+
 @Component(role = TychoProjectManager.class)
 @SessionScoped
 public class TychoProjectManager {
@@ -185,6 +187,20 @@ public class TychoProjectManager {
     private MavenSession getMavenSession() {
         MavenSession session = legacySupport.getSession();
         return session != null ? session : mavenSession;
+    }
+
+    public Optional<Processor> getBndTychoProject(MavenProject project) {
+        Optional<TychoProject> tychoProject = getTychoProject(project);
+        if (tychoProject.isEmpty()) {
+            return Optional.empty();
+        }
+        File bndFile = new File(project.getBasedir(), TychoConstants.PDE_BND);
+        if (bndFile.exists()) {
+            Processor processor = new Processor();
+            processor.setProperties(bndFile);
+            return Optional.of(processor);
+        }
+        return Optional.empty();
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/BndClasspathContributor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/BndClasspathContributor.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.core.bnd;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.tycho.ArtifactKey;
+import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.ClasspathEntry;
+import org.eclipse.tycho.ReactorProject;
+import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.classpath.ClasspathContributor;
+import org.eclipse.tycho.core.TychoProjectManager;
+import org.osgi.framework.Version;
+
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Processor;
+
+@Component(role = ClasspathContributor.class, hint = TychoConstants.PDE_BND)
+public class BndClasspathContributor implements ClasspathContributor {
+    @Requirement
+    private Logger logger;
+    @Requirement
+    private TychoProjectManager projectManager;
+
+    @Override
+    public List<ClasspathEntry> getAdditionalClasspathEntries(MavenProject project, String scope) {
+
+        Optional<Processor> bndTychoProject = projectManager.getBndTychoProject(project);
+        if (bndTychoProject.isPresent()) {
+            try (Processor processor = bndTychoProject.get()) {
+                //See https://bnd.bndtools.org/instructions/classpath.html
+                String classpath = processor.mergeProperties(Constants.CLASSPATH);
+                if (classpath != null && !classpath.isBlank()) {
+                    List<ClasspathEntry> additional = new ArrayList<>();
+                    for (String file : classpath.split(",")) {
+                        additional.add(new BndClasspathEntry(new File(project.getBasedir(), file.trim())));
+                    }
+                    return additional;
+                }
+            } catch (IOException e) {
+                logger.warn("Can't determine additional classpath for " + project.getId(), e);
+            }
+
+        }
+        return Collections.emptyList();
+    }
+
+    private static final class BndClasspathEntry implements ClasspathEntry, ArtifactKey {
+
+        private File file;
+
+        public BndClasspathEntry(File file) {
+            this.file = file;
+        }
+
+        @Override
+        public ArtifactKey getArtifactKey() {
+            return this;
+        }
+
+        @Override
+        public ReactorProject getMavenProject() {
+            return null;
+        }
+
+        @Override
+        public List<File> getLocations() {
+            return List.of(file);
+        }
+
+        @Override
+        public Collection<AccessRule> getAccessRules() {
+            return null;
+        }
+
+        @Override
+        public String getType() {
+            return ArtifactType.TYPE_ECLIPSE_PLUGIN;
+        }
+
+        @Override
+        public String getId() {
+            return file.getAbsolutePath();
+        }
+
+        @Override
+        public String getVersion() {
+            return Version.emptyVersion.toString();
+        }
+
+    }
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -73,6 +73,7 @@ import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.osgitools.targetplatform.DefaultDependencyArtifacts;
 import org.eclipse.tycho.core.osgitools.targetplatform.MultiEnvironmentDependencyArtifacts;
+import org.eclipse.tycho.core.resolver.AdditionalBundleRequirementsInstallableUnitProvider;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult;
 import org.eclipse.tycho.core.resolver.P2Resolver;
 import org.eclipse.tycho.core.resolver.P2ResolverFactory;
@@ -327,6 +328,10 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
         for (String additionalBundle : additionalBundles) {
             resolver.addAdditionalBundleDependency(additionalBundle);
         }
+        projectManager.getBndTychoProject(project).ifPresent(processor -> {
+            AdditionalBundleRequirementsInstallableUnitProvider.getBndClasspathRequirements(processor)
+                    .forEach(req -> resolver.addRequirement(req));
+        });
         // get reactor project with prepared optional dependencies // TODO use original IU and have the resolver create the modified IUs
         ReactorProject optionalDependencyPreparedProject = getThisReactorProject(session, project, configuration);
 


### PR DESCRIPTION
With the new feature of PDE to support automatic manifest generation Tycho must be aware of requirements defined in that file as well, this includes especially the -buildpath and -classpath entries.