### PR TITLE
Publish preliminary metadata for manifest generated bundles

### DIFF
--- a/tycho-core/pom.xml
+++ b/tycho-core/pom.xml
@@ -307,6 +307,11 @@
 			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jdt</groupId>
+			<artifactId>org.eclipse.jdt.core</artifactId>
+			<version>3.33.0</version>
+		</dependency>
 
 	</dependencies>
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/BndP2MetadataProvider.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/BndP2MetadataProvider.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.core.bnd;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.tycho.IDependencyMetadata;
+import org.eclipse.tycho.OptionalResolutionAction;
+import org.eclipse.tycho.TargetEnvironment;
+import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.resolver.InstallableUnitProvider;
+import org.eclipse.tycho.resolver.P2MetadataProvider;
+
+@Component(role = P2MetadataProvider.class, hint = TychoConstants.PDE_BND)
+public class BndP2MetadataProvider implements P2MetadataProvider {
+
+    @Requirement(hint = TychoConstants.PDE_BND)
+    InstallableUnitProvider installableUnitProvider;
+
+    @Override
+    public Map<String, IDependencyMetadata> getDependencyMetadata(MavenSession session, MavenProject project,
+            List<TargetEnvironment> environments, OptionalResolutionAction optionalAction) {
+        Set<IInstallableUnit> units;
+        try {
+            units = Set.copyOf(installableUnitProvider.getInstallableUnits(project, session));
+        } catch (CoreException e) {
+            return Collections.emptyMap();
+        }
+        if (units.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        IDependencyMetadata metadata = new IDependencyMetadata() {
+
+            @Override
+            public Set<IInstallableUnit> getDependencyMetadata(DependencyMetadataType type) {
+                if (type == DependencyMetadataType.INITIAL) {
+                    return getDependencyMetadata();
+                }
+                return Collections.emptySet();
+            }
+
+            @Override
+            public Set<IInstallableUnit> getDependencyMetadata() {
+                return units;
+            }
+
+            @Override
+            public void setDependencyMetadata(DependencyMetadataType type, Collection<IInstallableUnit> units) {
+                throw new UnsupportedOperationException();
+            }
+
+        };
+        return Map.of(TychoConstants.PDE_BND, metadata);
+    }
+
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/PdeInstallableUnitProvider.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/PdeInstallableUnitProvider.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.core.bnd;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.Manifest;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.TychoProjectManager;
+import org.eclipse.tycho.p2maven.InstallableUnitGenerator;
+import org.eclipse.tycho.resolver.InstallableUnitProvider;
+
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.lib.manifest.ManifestUtil;
+
+/**
+ * This provides the basics we need to sort the build by scanning the sourcecode for packages
+ * provided and compute a preliminary manifest
+ */
+@Component(role = InstallableUnitProvider.class, hint = TychoConstants.PDE_BND)
+public class PdeInstallableUnitProvider implements InstallableUnitProvider {
+
+    @Requirement
+    private Logger logger;
+    @Requirement
+    private TychoProjectManager projectManager;
+    @Requirement
+    private InstallableUnitGenerator installableUnitGenerator;
+
+    private Map<MavenProject, Collection<IInstallableUnit>> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public Collection<IInstallableUnit> getInstallableUnits(MavenProject project, MavenSession session)
+            throws CoreException {
+        return cache.computeIfAbsent(project, p -> {
+            Optional<Processor> bndTychoProject = projectManager.getBndTychoProject(project);
+            if (bndTychoProject.isPresent()) {
+                try (Processor processor = bndTychoProject.get(); Analyzer analyzer = new Analyzer(processor)) {
+                    Jar jar = new Jar(project.getArtifactId());
+                    analyzer.setJar(jar);
+                    analyzer.addBasicPlugin(new SourceCodeAnalyzerPlugin(
+                            project.getCompileSourceRoots().stream().map(Path::of).toList()));
+                    analyzer.setProperty(Constants.NOEXTRAHEADERS, "true");
+                    Manifest manifest = analyzer.calcManifest();
+                    if (logger.isDebugEnabled()) {
+                        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                        ManifestUtil.write(manifest, outputStream);
+                        String str = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+                        logger.info("Generated preliminary manifest for " + project.getId() + ":\r\n" + str);
+                    }
+                    return installableUnitGenerator.getInstallableUnits(manifest);
+                } catch (Exception e) {
+                    logger.warn("Can't determine additional units for " + project.getId(), e);
+                }
+            }
+            return Collections.emptyList();
+        });
+    }
+
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/SourceCodeAnalyzerPlugin.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/SourceCodeAnalyzerPlugin.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.core.bnd;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.MemberValuePair;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.StringLiteral;
+
+import aQute.bnd.header.Attrs;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Descriptors;
+import aQute.bnd.osgi.Descriptors.PackageRef;
+import aQute.bnd.service.AnalyzerPlugin;
+
+/**
+ * Enhances the analyzed classes by information obtained from the source code
+ */
+class SourceCodeAnalyzerPlugin implements AnalyzerPlugin {
+
+    private static final String ANNOTATION_VERSION = "org.osgi.annotation.versioning.Version";
+    private static final String ANNOTATION_EXPORT = "org.osgi.annotation.bundle.Export";
+    private static final String PACKAGE_INFO_JAVA = "package-info.java";
+    private List<Path> sourcePaths;
+
+    public SourceCodeAnalyzerPlugin(List<Path> sourcePaths) {
+        this.sourcePaths = sourcePaths;
+    }
+
+    @Override
+    public boolean analyzeJar(Analyzer analyzer) throws Exception {
+        ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+        Descriptors descriptors = new Descriptors();
+        Set<String> seenPackages = new HashSet<>();
+        Set<Path> analyzedPath = new HashSet<>();
+        for (Path sourcePath : sourcePaths) {
+            Files.walkFileTree(sourcePath, new FileVisitor<Path>() {
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    String fileName = file.getFileName().toString().toLowerCase();
+                    if (fileName.endsWith(".java")) {
+                        boolean packageInfo = fileName.equals(PACKAGE_INFO_JAVA);
+                        if (packageInfo || analyzedPath.add(file.getParent())) {
+                            String source = Files.readString(file);
+                            parser.setSource(source.toCharArray());
+                            ASTNode ast = parser.createAST(null);
+                            if (ast instanceof CompilationUnit cu) {
+                                PackageDeclaration packageDecl = cu.getPackage();
+                                if (packageDecl != null) {
+                                    String packageFqdn = packageDecl.getName().getFullyQualifiedName();
+                                    if (seenPackages.add(packageFqdn)) {
+                                        //make the package available to bnd analyzer
+                                        PackageRef packageRef = descriptors.getPackageRef(packageFqdn);
+                                        analyzer.getContained().put(packageRef);
+                                    }
+                                    if (packageInfo) {
+                                        //check for export annotations
+                                        boolean export = false;
+                                        String version = null;
+                                        for (Object raw : packageDecl.annotations()) {
+                                            if (raw instanceof Annotation annot) {
+                                                String annotationFqdn = annot.getTypeName().getFullyQualifiedName();
+                                                if (ANNOTATION_EXPORT.equals(annotationFqdn)) {
+                                                    export = true;
+                                                } else if (ANNOTATION_VERSION.equals(annotationFqdn)) {
+                                                    if (annot instanceof NormalAnnotation normal) {
+                                                        for (Object vp : normal.values()) {
+                                                            MemberValuePair pair = (MemberValuePair) vp;
+                                                            if ("value"
+                                                                    .equals(pair.getName().getFullyQualifiedName())) {
+                                                                StringLiteral value = (StringLiteral) pair.getValue();
+                                                                version = value.getLiteralValue();
+                                                            }
+                                                        }
+                                                    } else if (annot instanceof SingleMemberAnnotation single) {
+                                                        StringLiteral value = (StringLiteral) single.getValue();
+                                                        version = value.getLiteralValue();
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        if (export) {
+                                            PackageRef packageRef = descriptors.getPackageRef(packageFqdn);
+                                            if (version == null) {
+                                                analyzer.getContained().put(packageRef);
+                                            } else {
+                                                analyzer.getContained().put(packageRef,
+                                                        Attrs.create("version", version));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        return false;
+    }
+
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -136,13 +136,13 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
             final ReactorProject reactorProject) {
         TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
         List<TargetEnvironment> environments = configuration.getEnvironments();
-        Map<String, IDependencyMetadata> metadataMap = getDependencyMetadata(session, project, environments,
+        Collection<IDependencyMetadata> metadataMap = getDependencyMetadata(session, project, environments,
                 OptionalResolutionAction.OPTIONAL);
         Map<DependencyMetadataType, Set<IInstallableUnit>> typeMap = new TreeMap<>();
         for (DependencyMetadataType type : DependencyMetadataType.values()) {
             typeMap.put(type, new LinkedHashSet<>());
         }
-        for (IDependencyMetadata metadata : metadataMap.values()) {
+        for (IDependencyMetadata metadata : metadataMap) {
             typeMap.forEach((key, value) -> value.addAll(metadata.getDependencyMetadata(key)));
         }
         Set<IInstallableUnit> initial = new HashSet<>();
@@ -153,7 +153,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
         reactorProject.setDependencyMetadata(DependencyMetadataType.INITIAL, initial);
     }
 
-    protected Map<String, IDependencyMetadata> getDependencyMetadata(final MavenSession session,
+    protected Collection<IDependencyMetadata> getDependencyMetadata(final MavenSession session,
             final MavenProject project, final List<TargetEnvironment> environments,
             final OptionalResolutionAction optionalAction) {
         final ReactorProject reactorProject = DefaultReactorProject.adapt(project);
@@ -177,7 +177,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
             throw new RuntimeException(e);
         }
 
-        return metadata;
+        return metadata.values();
     }
 
     @Override
@@ -213,10 +213,10 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
         final List<TargetEnvironment> environments = configuration.getEnvironments();
         final OptionalResolutionAction optionalAction = configuration.getDependencyResolverConfiguration()
                 .getOptionalResolutionAction();
-        Map<String, IDependencyMetadata> dependencyMetadata = getDependencyMetadata(session, project, environments,
+        Collection<IDependencyMetadata> dependencyMetadata = getDependencyMetadata(session, project, environments,
                 optionalAction);
         Map<DependencyMetadataType, Set<IInstallableUnit>> typeMap = new TreeMap<>();
-        for (IDependencyMetadata value : dependencyMetadata.values()) {
+        for (IDependencyMetadata value : dependencyMetadata) {
             for (DependencyMetadataType type : DependencyMetadataType.values()) {
                 typeMap.computeIfAbsent(type, t -> new LinkedHashSet<>()).addAll(value.getDependencyMetadata(type));
             }


### PR DESCRIPTION
With the new generated manifest feature in PDE there is one problem for Tycho that we actually need to know what packages are provided by a plugin to compute if it can provide something required by a "traditional" manifest first project. The same applies to the bundle-name if one is using require bundle the final bundle name must be known.

This adds new meta-dataprovider, that inject the basic information about potential packages and ones used with export annotations and then computes a preliminary manifest from this. This gives enough information to Tycho for the dependency resolution process.