### PR TITLE
Fix passing of redirectTestOutputToFile property in OsgiSurefireBooter

### DIFF
--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
@@ -84,8 +84,6 @@ public class OsgiSurefireBooter {
     private static final String JUNIT_PLATFORM_PROVIDER = "org.apache.maven.surefire.junitplatform.JUnitPlatformProvider";
 
     public static int run(String[] args, Properties testProps) throws Exception {
-        // TODO eventually make use of parameter redirectTestOutputToFile
-        @SuppressWarnings("unused")
         boolean redirectTestOutputToFile = Boolean
                 .parseBoolean(testProps.getProperty("redirectTestOutputToFile", "false"));
         String testPlugin = testProps.getProperty("testpluginname");
@@ -130,7 +128,7 @@ public class OsgiSurefireBooter {
                 extractProviderProperties(testProps), null, false, Collections.emptyList(), skipAfterFailureCount,
                 Shutdown.DEFAULT, 30);
         StartupReportConfiguration startupReportConfig = new StartupReportConfiguration(useFile, printSummary,
-                ConsoleReporter.PLAIN, false, reportsDir, trimStackTrace, null, new File(reportsDir, "TESTHASH"), false,
+                ConsoleReporter.PLAIN, redirectTestOutputToFile, reportsDir, trimStackTrace, null, new File(reportsDir, "TESTHASH"), false,
                 rerunFailingTestsCount, XSD, StandardCharsets.UTF_8.toString(), false,
                 getSurefireStatelessReporter(provider, disableXmlReport, null),
                 getSurefireConsoleOutputReporter(provider), getSurefireStatelessTestsetInfoReporter(provider));


### PR DESCRIPTION
Fixes issue https://github.com/eclipse-tycho/tycho/issues/2348

It is regression in 3.x.x line due to following commit https://github.com/eclipse-tycho/tycho/commit/36e85ace82fbbeffd4aa1959e6ebd41377765b97