### PR TITLE
PR for issue 1711

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverTest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -393,13 +392,13 @@ public class TargetDefinitionResolverTest {
         }
 
         @Override
-        public URI getLocation() {
+        public String getLocation() {
             try {
                 if (repository != null) {
                     File repo = ResourceUtil.resourceFile(basedir + repository + "/content.xml").getParentFile();
-                    return repo.toURI();
+                    return repo.toURI().toString();
                 }
-                return URI.create("invalid:hello");
+                return URI.create("invalid:hello").toString();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/target/facade/TargetDefinition.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/target/facade/TargetDefinition.java
@@ -18,7 +18,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.target.facade;
 
-import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
@@ -185,7 +184,7 @@ public interface TargetDefinition {
     }
 
     public interface Repository {
-        URI getLocation();
+        String getLocation();
 
         String getId();
     }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/target/facade/TargetDefinitionFile.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/target/facade/TargetDefinitionFile.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -406,9 +405,9 @@ public final class TargetDefinitionFile implements TargetDefinition {
     private static final class Repository implements TargetDefinition.Repository {
 
         private final String id;
-        private final URI uri;
+        private final String uri;
 
-        Repository(String id, URI uri) {
+        Repository(String id, String uri) {
             this.id = id;
             this.uri = uri;
         }
@@ -420,7 +419,7 @@ public final class TargetDefinitionFile implements TargetDefinition {
         }
 
         @Override
-        public URI getLocation() {
+        public String getLocation() {
             return uri;
         }
 
@@ -523,6 +522,10 @@ public final class TargetDefinitionFile implements TargetDefinition {
         return new TargetDefinitionFile(document, origin);
     }
 
+    public static TargetDefinition.Repository repository(String id, String location) {
+        return new Repository(id, location);
+    }
+
     @Override
     public String getTargetEE() {
         return targetEE;
@@ -610,12 +613,7 @@ public final class TargetDefinitionFile implements TargetDefinition {
         final List<Repository> repositories = new ArrayList<>();
         for (Element node : getChildren(dom, "repository")) {
             String id = node.getAttribute("id");
-            URI uri;
-            try {
-                uri = new URI(node.getAttribute("location"));
-            } catch (URISyntaxException e) {
-                throw new TargetDefinitionSyntaxException("invalid URI", e);
-            }
+            String uri = node.getAttribute("location");
             repositories.add(new Repository(id, uri));
         }
         return new IULocation(Collections.unmodifiableList(units), Collections.unmodifiableList(repositories),

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/target/facade/TargetDefinitionVariableResolver.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/target/facade/TargetDefinitionVariableResolver.java
@@ -1,0 +1,100 @@
+package org.eclipse.tycho.p2.target.facade;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.tycho.ReactorProject;
+import org.eclipse.tycho.core.shared.MavenContext;
+import org.eclipse.tycho.core.shared.MavenLogger;
+
+public class TargetDefinitionVariableResolver {
+
+    private static final Pattern SYSTEM_PROPERTY_PATTERN = createVariablePatternArgument("system_property");
+    private static final Pattern PROJECT_LOC_PATTERN = createVariablePatternArgument("project_loc");
+    private static final Pattern ENV_VAR_PATTERN = createVariablePatternArgument("env_var");
+
+    private final MavenContext mavenContext;
+    private final MavenLogger logger;
+
+    public TargetDefinitionVariableResolver(MavenContext mavenContext) {
+        this.mavenContext = mavenContext;
+        this.logger = mavenContext.getLogger();
+    }
+
+    public URI resolveRepositoryLocation(String location) {
+        location = resolvePattern(location, SYSTEM_PROPERTY_PATTERN,
+                key -> mavenContext.getSessionProperties().getProperty(key, ""));
+        location = resolvePattern(location, ENV_VAR_PATTERN, key -> {
+            String env = System.getenv(key);
+            return env == null ? "" : env;
+        });
+
+        try {
+            return new URI(location);
+        } catch (URISyntaxException e) {
+            throw new TargetDefinitionSyntaxException("Invalid URI: " + location);
+        }
+    }
+
+    public String resolvePath(String path, TargetDefinition definition) {
+        path = resolvePattern(path, SYSTEM_PROPERTY_PATTERN,
+                key -> mavenContext.getSessionProperties().getProperty(key, ""));
+        path = resolvePattern(path, ENV_VAR_PATTERN, key -> {
+            String env = System.getenv(key);
+            return env == null ? "" : env;
+        });
+        path = resolvePattern(path, PROJECT_LOC_PATTERN, this::findProjectLocation);
+        return path;
+    }
+
+    private String findProjectLocation(String projectName) {
+        if (projectName.startsWith("/")) {
+            projectName = projectName.substring(1);
+        }
+        logger.debug("Find project location for project " + projectName);
+        for (ReactorProject project : mavenContext.getProjects()) {
+            String name = project.getName();
+            logger.debug("check reactor project name: " + name);
+            if (name.equals(projectName)) {
+                return project.getBasedir().getAbsolutePath();
+            }
+        }
+        for (ReactorProject project : mavenContext.getProjects()) {
+            String artifactId = project.getArtifactId();
+            logger.debug("check reactor project artifact id: " + artifactId);
+            if (artifactId.equals(projectName)) {
+                return project.getBasedir().getAbsolutePath();
+            }
+        }
+        for (ReactorProject project : mavenContext.getProjects()) {
+            String name = project.getBasedir().getName();
+            logger.debug("check reactor project base directory: " + name);
+            if (name.equals(projectName)) {
+                return project.getBasedir().getAbsolutePath();
+            }
+        }
+        //if we can't resolve this, we will return the original one as this might be intentional to not include the project in the build
+        String defaultValue = "${project_loc:" + projectName + "}";
+        logger.warn("Can't resolve " + defaultValue + " target resoloution might be incomplete");
+        return defaultValue;
+    }
+
+    private static String resolvePattern(String input, Pattern pattern, Function<String, String> parameterResolver) {
+        Matcher matcher = pattern.matcher(input);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String group = matcher.group(1);
+            String resolved = parameterResolver.apply(group);
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(resolved));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static Pattern createVariablePatternArgument(String variableName) {
+        return Pattern.compile("\\$\\{" + variableName + ":([^}]+)\\}", Pattern.CASE_INSENSITIVE);
+    }
+}

--- a/tycho-its/projects/target.variables-env/pom.xml
+++ b/tycho-its/projects/target.variables-env/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>tycho-its-project.variables.env</groupId>
+    <artifactId>aggregator</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-maven-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <resolver>p2</resolver>
+                    <pomDependencies>consider</pomDependencies>
+                    <executionEnvironment>JavaSE-11</executionEnvironment>
+                    <target>
+                        <artifact>
+                            <groupId>tycho-its-project.variables.env</groupId>
+                            <artifactId>targetplatform</artifactId>
+                            <version>1.0.0</version>
+                        </artifact>
+                    </target>
+                    <environments>
+                        <environment>
+                            <os>win32</os>
+                            <ws>win32</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                        <environment>
+                            <os>linux</os>
+                            <ws>gtk</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                    </environments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <modules>
+        <module>targetplatform</module>
+        <module>project</module>
+    </modules>
+
+</project>

--- a/tycho-its/projects/target.variables-env/project/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.variables-env/project/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: project
+Bundle-Version: 1.0.0
+Automatic-Module-Name: project
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Require-Bundle: javax.xml

--- a/tycho-its/projects/target.variables-env/project/build.properties
+++ b/tycho-its/projects/target.variables-env/project/build.properties
@@ -1,0 +1,2 @@
+source.. = src/
+bin.includes = META-INF/,.

--- a/tycho-its/projects/target.variables-env/project/pom.xml
+++ b/tycho-its/projects/target.variables-env/project/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>project</artifactId>
+    <version>1.0.0</version>
+    <packaging>eclipse-plugin</packaging>
+    <parent>
+        <groupId>tycho-its-project.variables.env</groupId>
+        <artifactId>aggregator</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+</project>

--- a/tycho-its/projects/target.variables-env/targetplatform/pom.xml
+++ b/tycho-its/projects/target.variables-env/targetplatform/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>targetplatform</artifactId>
+    <packaging>eclipse-target-definition</packaging>
+    <parent>
+        <groupId>tycho-its-project.variables.env</groupId>
+        <artifactId>aggregator</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho.extras</groupId>
+                <artifactId>target-platform-validation-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>validate-target-platform</goal>
+                        </goals>
+                        <configuration>
+                            <checkDependencies>true</checkDependencies>
+                            <checkProvisioning>true</checkProvisioning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tycho-its/projects/target.variables-env/targetplatform/targetplatform.target
+++ b/tycho-its/projects/target.variables-env/targetplatform/targetplatform.target
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<target name="tycho-its-project.variables.env" sequenceNumber="1">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="${env_var:MY_MIRROR}/repo"/>
+
+            <unit id="javax.xml" version="0.0.0"/>
+        </location>
+    </locations>
+</target>

--- a/tycho-its/projects/target.variables-sysprop/pom.xml
+++ b/tycho-its/projects/target.variables-sysprop/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>tycho-its-project.variables.sysprop</groupId>
+    <artifactId>aggregator</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-maven-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <resolver>p2</resolver>
+                    <pomDependencies>consider</pomDependencies>
+                    <executionEnvironment>JavaSE-11</executionEnvironment>
+                    <target>
+                        <artifact>
+                            <groupId>tycho-its-project.variables.sysprop</groupId>
+                            <artifactId>targetplatform</artifactId>
+                            <version>1.0.0</version>
+                        </artifact>
+                    </target>
+                    <environments>
+                        <environment>
+                            <os>win32</os>
+                            <ws>win32</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                        <environment>
+                            <os>linux</os>
+                            <ws>gtk</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                    </environments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <modules>
+        <module>targetplatform</module>
+        <module>project</module>
+    </modules>
+
+</project>

--- a/tycho-its/projects/target.variables-sysprop/project/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.variables-sysprop/project/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: project
+Bundle-Version: 1.0.0
+Automatic-Module-Name: project
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Require-Bundle: javax.xml

--- a/tycho-its/projects/target.variables-sysprop/project/build.properties
+++ b/tycho-its/projects/target.variables-sysprop/project/build.properties
@@ -1,0 +1,2 @@
+source.. = src/
+bin.includes = META-INF/,.

--- a/tycho-its/projects/target.variables-sysprop/project/pom.xml
+++ b/tycho-its/projects/target.variables-sysprop/project/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>project</artifactId>
+    <version>1.0.0</version>
+    <packaging>eclipse-plugin</packaging>
+    <parent>
+        <groupId>tycho-its-project.variables.sysprop</groupId>
+        <artifactId>aggregator</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+</project>

--- a/tycho-its/projects/target.variables-sysprop/targetplatform/pom.xml
+++ b/tycho-its/projects/target.variables-sysprop/targetplatform/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>targetplatform</artifactId>
+    <packaging>eclipse-target-definition</packaging>
+    <parent>
+        <groupId>tycho-its-project.variables.sysprop</groupId>
+        <artifactId>aggregator</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho.extras</groupId>
+                <artifactId>target-platform-validation-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>validate-target-platform</goal>
+                        </goals>
+                        <configuration>
+                            <checkDependencies>true</checkDependencies>
+                            <checkProvisioning>true</checkProvisioning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tycho-its/projects/target.variables-sysprop/targetplatform/targetplatform.target
+++ b/tycho-its/projects/target.variables-sysprop/targetplatform/targetplatform.target
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<target name="tycho-its-project.variables.sysprop" sequenceNumber="1">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="${system_property:myMirror}/repo"/>
+
+            <unit id="javax.xml" version="0.0.0"/>
+        </location>
+    </locations>
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetVariableResolutionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetVariableResolutionTest.java
@@ -1,0 +1,49 @@
+package org.eclipse.tycho.test.target;
+
+import java.util.Arrays;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.eclipse.tycho.test.util.HttpServer;
+import org.eclipse.tycho.test.util.ResourceUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TargetVariableResolutionTest extends AbstractTychoIntegrationTest {
+	private HttpServer server;
+	private String baseurl;
+
+	@Before
+	public void startServer() throws Exception {
+		server = HttpServer.startServer();
+		server.addServer("repo", ResourceUtil.resolveTestResource("repositories/javax.xml"));
+		var urlWithContextPath = server.getUrl("");
+		baseurl = urlWithContextPath.endsWith("/") // double slash causes trouble in RepositoryTransport.download
+				? urlWithContextPath.substring(0, urlWithContextPath.length() - 1)
+				: urlWithContextPath;
+	}
+
+	@After
+	public void stopServer() throws Exception {
+		server.stop();
+	}
+
+	@Test
+	public void repositoryUrlCanContainEnvVarVariable() throws Exception {
+		Verifier verifier = getVerifier("target.variables-env", false);
+		verifier.setEnvironmentVariable("MY_MIRROR", baseurl);
+		verifier.executeGoals(Arrays.asList("package"));
+		verifier.verifyErrorFreeLog();
+		verifier.verifyTextInLog("validate-target-platform");
+	}
+
+	@Test
+	public void repositoryUrlCanContainSystemPropertyVariable() throws Exception {
+		Verifier verifier = getVerifier("target.variables-sysprop", false);
+		verifier.setSystemProperty("myMirror", baseurl);
+		verifier.executeGoals(Arrays.asList("package"));
+		verifier.verifyErrorFreeLog();
+		verifier.verifyTextInLog("validate-target-platform");
+	}
+}

--- a/tycho-p2/tycho-p2-facade/src/test/java/org/eclipse/tycho/p2/resolver/TargetDefinitionFileTest.java
+++ b/tycho-p2/tycho-p2-facade/src/test/java/org/eclipse/tycho/p2/resolver/TargetDefinitionFileTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.util.List;
 
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
@@ -44,7 +43,7 @@ public class TargetDefinitionFileTest {
 
         InstallableUnitLocation location = (InstallableUnitLocation) locations.get(0);
         assertEquals(1, location.getRepositories().size());
-        assertEquals(URI.create("https://download.eclipse.org/eclipse/updates/3.5/"),
+        assertEquals("https://download.eclipse.org/eclipse/updates/3.5/",
                 location.getRepositories().get(0).getLocation());
         assertEquals(1, location.getUnits().size());
         assertEquals("org.eclipse.platform.sdk", location.getUnits().get(0).getId());
@@ -53,9 +52,8 @@ public class TargetDefinitionFileTest {
         InstallableUnitLocation l02 = (InstallableUnitLocation) locations.get(1);
         assertEquals(5, l02.getUnits().size());
         assertEquals(2, l02.getRepositories().size());
-        assertEquals(URI.create("http://subclipse.tigris.org/update_1.6.x/"),
-                l02.getRepositories().get(0).getLocation());
-        assertEquals(URI.create("https://download.eclipse.org/tools/mylyn/update/e3.4/"),
+        assertEquals("http://subclipse.tigris.org/update_1.6.x/", l02.getRepositories().get(0).getLocation());
+        assertEquals("https://download.eclipse.org/tools/mylyn/update/e3.4/",
                 l02.getRepositories().get(1).getLocation());
     }
 


### PR DESCRIPTION
I had to extract the part which does variable resolution from TargetDefinitionResolver into the .shared bundle
so it is available both in TargetDefinitionResolver but also in Mojos which deal with repository location.

Also had to make some public access to TargetDefinition.Repository implementation in TargetDefinitionFile.
This is very ugly, I feel the problem here is the Repository in TargetDefinition and TargetDefinitionFile
should in fact not be the same class as one represents the repository element as present in .target file
(potentially with unresolved variables) and the other is resolved repository with valid URI.
Changing this would be a bigger refactoring I felt would be too invasive to do here.

I did not find any test for update-target and am not sure how to write one (since it updates files in place)
but at least tested that one manually and seems to work fine.
The other affected plugin, target validation Mojo, is tested in IT along with testing the locations resolve correctly.