### PR TITLE
Tell plexus-component-metadata to only scan the class files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,9 @@
 							</goals>
 						</execution>
 					</executions>
+					<configuration>
+						<extractors>class</extractors>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
plexus-component-metadata does not support Java 17 source codes and bail out if it finds some constructs, as we should not rely on source annotations anyways we can safly disable this and even save some time on the build.