### PR TITLE
Add support for automatic adding repository references to p2 sites

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -226,6 +226,29 @@ The parameters of the `tycho-apitools-plugin:generate` goal have been completed 
 The `tycho-p2-repository-plugin:assemble-repository` mojo has now a new configuration parameter `filterProvided` that (if enabled) filter units and artifacts that are already present in one of the referenced repositories.
 That way one can prevent including items that are already present in the same form in another repository.
 
+If you want to include repository references automatically, there are two other new options:
+
+- `addPomRepositoryReferences` - all P2 repositories from the pom are added as a reference
+- `addIUTargetRepositoryReferences` - all P2 repositories defined in target files IU-location types are added as a reference
+
+so now one can produce a self-contained update-site that only includes what is not already available from the target content used by specify:
+
+
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-p2-repository-plugin</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		<includeAllDependencies>true</includeAllDependencies>
+		<filterProvided>true</filterProvided>
+		<addPomRepositoryReferences>true</addPomRepositoryReferences>
+		<addIUTargetRepositoryReferences>true</addIUTargetRepositoryReferences>
+	</configuration>
+</plugin>
+
+```
+
 ### New parameter in tycho-packaging-plugin:package-plugin
 
 The `tycho-packaging-plugin:package-plugin` mojo has now a new configuration parameter `deriveHeaderFromSource` (default true), that allows Tycho to discover additional headers declared in the source (e.g. from annotations).

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/AbstractP2Mojo.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/AbstractP2Mojo.java
@@ -40,7 +40,7 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
     private String qualifier;
 
     @Component
-    private TychoProjectManager projectManager;
+    protected TychoProjectManager projectManager;
 
     protected MavenProject getProject() {
         return project;


### PR DESCRIPTION
This adds two new options to automatically include repository references from the target / pom repositories.

FYI @akurtakov @merks @vrubezhny  @mickaelistria 

This should ease the usage of `<filterProvided>` as it automatically derive the referenced repositories from the target file or pom configuration, so one usually want to use:

```
<plugin>
	<groupId>org.eclipse.tycho</groupId>
	<artifactId>tycho-p2-repository-plugin</artifactId>
	<version>${tycho-version}</version>
	<configuration>
		<includeAllDependencies>true</includeAllDependencies>
		<filterProvided>true</filterProvided>
		<addPomRepositoryReferences>true</addPomRepositoryReferences>
		<addIUTargetRepositoryReferences>true</addIUTargetRepositoryReferences>
	</configuration>
</plugin>
```

that is both self-contained but minimal in the sense of that it excludes everything already available by one of the sites used in the projects target definition (what actually is the initial intent of a "targetplatform" to specify what is already available in the runtime).