### PR TITLE
Add support for cleaning the workdir after testrun

### DIFF
--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -30,6 +30,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
@@ -78,6 +79,12 @@ public abstract class AbstractTestMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "${project.build.directory}/work")
     protected File work;
+
+    /**
+     * If enabled, deletes the workarea after test execution
+     */
+    @Parameter(property = "tycho.surefire.deleteWorkDir")
+    private boolean deleteWorkDirAfterTest;
 
     @Parameter(property = "project", readonly = true)
     protected MavenProject project;
@@ -222,7 +229,13 @@ public abstract class AbstractTestMojo extends AbstractMojo {
             handleNoTestsFound();
             return;
         }
-        runTests(result);
+        try {
+            runTests(result);
+        } finally {
+            if (deleteWorkDirAfterTest) {
+                FileUtils.deleteQuietly(work);
+            }
+        }
     }
 
     protected ScanResult scanForTests() {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/BndTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/BndTestMojo.java
@@ -319,6 +319,12 @@ public class BndTestMojo extends AbstractTestMojo {
                 throw new MojoExecutionException("resolve bundles failed!");
             }
         } catch (Exception e) {
+            if (e instanceof MojoExecutionException mee) {
+                throw mee;
+            }
+            if (e instanceof MojoFailureException mfe) {
+                throw mfe;
+            }
             throw new MojoExecutionException("executing test container failed!", e);
         }
 


### PR DESCRIPTION
The workdir is actually only a temporary area, in some cases it might be useful to delete it after the test (e.g. to conserver space).