### PR TITLE
Allow settings the output name with a property

### DIFF
--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -76,7 +76,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 	/**
 	 * Name of the generated JAR.
 	 */
-	@Parameter(property = "project.build.finalName", alias = "jarName", required = true)
+	@Parameter(defaultValue = "${project.build.finalName}", property = "jarName", required = true)
 	protected String finalName;
 
 	/**


### PR DESCRIPTION
Currently it seems not really possible to set the value for "project.build.finalName" on the commandline, also the alias jarName does not work.

This changes the PackagePluginMojo slightly to use a default value instead of a property and make jarName the property to override the default.