### PR TITLE
Add assertions and explicit configuration to junit test

### DIFF
--- a/tycho-its/projects/compiler.junitcontainer/junit4-in-bundle-with-dependencies/pom.xml
+++ b/tycho-its/projects/compiler.junitcontainer/junit4-in-bundle-with-dependencies/pom.xml
@@ -32,6 +32,15 @@
 						<version>3.0.0-M5</version>
 					</dependency>
 				</dependencies>
+				<executions>
+					<execution>
+						<id>surefire-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-its/projects/compiler.junitcontainer/junit4-in-bundle/pom.xml
+++ b/tycho-its/projects/compiler.junitcontainer/junit4-in-bundle/pom.xml
@@ -32,6 +32,15 @@
 						<version>3.0.0-M5</version>
 					</dependency>
 				</dependencies>
+				<executions>
+					<execution>
+						<id>surefire-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathEntryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathEntryTest.java
@@ -33,6 +33,7 @@ public class CompilerClasspathEntryTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = getVerifier("compiler.junitcontainer/junit4-in-bundle", true);
 		verifier.executeGoal("test");
 		verifier.verifyErrorFreeLog();
+		verifier.verifyTextInLog("Tests run: 5, Failures: 0, Errors: 0, Skipped: 0");
 	}
 
 	@Test
@@ -40,6 +41,7 @@ public class CompilerClasspathEntryTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = getVerifier("compiler.junitcontainer/junit4-in-bundle-with-dependencies", true);
 		verifier.executeGoal("test");
 		verifier.verifyErrorFreeLog();
+		verifier.verifyTextInLog("Tests run: 5, Failures: 0, Errors: 0, Skipped: 0");
 	}
 
 	@Test


### PR DESCRIPTION
Currently the tests in the build are not executed for the junit container, the testproject is only compiled because an execution is missing.

This adds the missing execution and an assertion that ensures the tests are run.