### PR TITLE
Remove logEnabled property from comment

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -330,7 +330,6 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
      * And a configuration:
      * 
      * &lt;configuration&gt;
-     *   &lt;logEnabled&gt;true&lt;/logEnabled&gt;
      *   &lt;logDirectory&gt;${project.build.directory}/logfiles&lt;/logDirectory&gt;
      *   &lt;log&gt;xml&lt;/log&gt; 
      * &lt;/configuration&gt;


### PR DESCRIPTION
This property no longer exists so it shouldn't be documented. I can't even find when it _ever_ existed. Maybe it was left here from some initial implementation that never made it to a release? This comment was added 11 years ago by https://github.com/eclipse-tycho/tycho/commit/983d89e0a1bcc3ace56de2df62dc25b3da80d205 with no corresponding logEnabled property.