### PR TITLE
Add dummy parameter to prevent warnings with jgit as timestamp provider

### DIFF
--- a/tycho-buildtimestamp-jgit/src/main/java/org/eclipse/tycho/extras/buildtimestamp/jgit/JGitBuildTimestampProvider.java
+++ b/tycho-buildtimestamp-jgit/src/main/java/org/eclipse/tycho/extras/buildtimestamp/jgit/JGitBuildTimestampProvider.java
@@ -93,6 +93,9 @@ import org.eclipse.tycho.build.BuildTimestampProvider;
  */
 @Component(role = BuildTimestampProvider.class, hint = "jgit")
 public class JGitBuildTimestampProvider implements BuildTimestampProvider {
+	private static final String PARAMETER_JGIT_IGNORE = "jgit.ignore";
+
+	private static final String PARAMETER_JGIT_DIRTY_WORKING_TREE = "jgit.dirtyWorkingTree";
 
 	@Requirement(hint = "default")
 	private BuildTimestampProvider defaultTimestampProvider;
@@ -112,7 +115,7 @@ public class JGitBuildTimestampProvider implements BuildTimestampProvider {
 			if (pluginConfiguration == null) {
 				return defaultBehaviour;
 			}
-			Xpp3Dom dirtyWorkingTreeDom = pluginConfiguration.getChild("jgit.dirtyWorkingTree");
+			Xpp3Dom dirtyWorkingTreeDom = pluginConfiguration.getChild(PARAMETER_JGIT_DIRTY_WORKING_TREE);
 			if (dirtyWorkingTreeDom == null) {
 				return defaultBehaviour;
 			}
@@ -219,7 +222,7 @@ public class JGitBuildTimestampProvider implements BuildTimestampProvider {
 		if (pluginConfiguration == null) {
 			return null;
 		}
-		Xpp3Dom ignoreDom = pluginConfiguration.getChild("jgit.ignore");
+		Xpp3Dom ignoreDom = pluginConfiguration.getChild(PARAMETER_JGIT_IGNORE);
 		if (ignoreDom == null) {
 			return null;
 		}

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
@@ -116,11 +116,25 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
     @Parameter(property = "mojoExecution", readonly = true)
     protected MojoExecution execution;
 
-    @Component(role = BuildTimestampProvider.class)
-    protected Map<String, BuildTimestampProvider> timestampProviders;
+	@Component(role = BuildTimestampProvider.class)
+	protected Map<String, BuildTimestampProvider> timestampProviders;
 
 	@Component
 	private BuildPropertiesParser buildPropertiesParser;
+
+	/**
+	 * This is only a dummy parameter used to prevent maven from complaining about
+	 * "unknown" parameters when using the jgit extension
+	 */
+	@Parameter(alias = "jgit.dirtyWorkingTree")
+	private String dummy1;
+
+	/**
+	 * This is only a dummy parameter used to prevent maven from complaining about
+	 * "unknown" parameters when using the jgit extension
+	 */
+	@Parameter(alias = "jgit.ignore")
+	private String dummy2;
 
     // setter is needed to make sure we always use UTC
     public void setFormat(String formatString) {


### PR DESCRIPTION
Maven 3.9 complains of "missing" parameters even if we need them for the jgit provider.

This adds two dummy parameters so maven is happy again.

Fix https://github.com/eclipse-tycho/tycho/issues/2080

FYI @Bananeweizen @merks this is a bit band-aid but probably most pragmatic solution until this is refactored in Tycho 5 ...