### PR TITLE
Support repository references in IU target locations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,22 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 Tycho now contains a new `tycho-repository-plugin` that can be used to package OSGi repositories.
 
+### new option to include referenced repositories when resolving the target platform
+
+Repositories can contain references to other repositories (e.g. to find additional dependencies), from now on there is a new option to also consider these references:
+
+```xml
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>target-platform-configuration</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		... other configuration options ...
+		<referencedRepositoryMode>include</referencedRepositoryMode>
+	</configuration>
+</plugin>
+	
+```
 
 ## 4.0.0
 

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/ListCompositeArtifactRepository.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/ListCompositeArtifactRepository.java
@@ -37,6 +37,7 @@ import org.eclipse.equinox.p2.query.Collector;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryResult;
 import org.eclipse.equinox.p2.query.IQueryable;
+import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.ICompositeRepository;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
@@ -57,8 +58,8 @@ public class ListCompositeArtifactRepository extends AbstractArtifactRepository
 
     public final List<IArtifactRepository> artifactRepositories;
 
-    public ListCompositeArtifactRepository(IProvisioningAgent agent,
-            List<? extends IArtifactRepository> artifactRepositories) {
+    public ListCompositeArtifactRepository(List<? extends IArtifactRepository> artifactRepositories,
+            IProvisioningAgent agent) {
         super(agent, null, IArtifactRepositoryManager.TYPE_COMPOSITE_REPOSITORY, null, null, null, null, null);
         try {
             setLocation(new URI("list:" + UUID.randomUUID()));
@@ -74,12 +75,7 @@ public class ListCompositeArtifactRepository extends AbstractArtifactRepository
         if (size == 1) {
             return artifactRepositories.get(0).query(query, monitor);
         }
-        Collector<IArtifactKey> collector = new Collector<>();
-        SubMonitor subMonitor = SubMonitor.convert(monitor, size);
-        for (IArtifactRepository repository : artifactRepositories) {
-            collector.addAll(repository.query(query, subMonitor.split(1)));
-        }
-        return collector;
+		return QueryUtil.compoundQueryable(artifactRepositories).query(query, IProgressMonitor.nullSafe(monitor));
     }
 
     @Override

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2RepositoryManager.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2RepositoryManager.java
@@ -93,7 +93,7 @@ public class P2RepositoryManager {
 		for (Repository repository : repositories) {
 			childs.add(getArtifactRepository(repository));
 		}
-		return new ListCompositeArtifactRepository(agent, childs);
+		return new ListCompositeArtifactRepository(childs, agent);
 	}
 
 	/**

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
@@ -26,6 +26,7 @@ import org.eclipse.tycho.core.TargetPlatformConfiguration.BREEHeaderSelectionPol
 import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
 import org.eclipse.tycho.core.resolver.shared.PomDependencies;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.targetplatform.TargetPlatformFilter.CapabilityPattern;
 
 /**
@@ -45,11 +46,11 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
      * List of .target artifacts to use for dependency resolution.<br>
      * Could either be
      * <ul>
-     * <li><code>&lt;artifact></code> to define a target GAV (either local to the reactor or a remote
-     * one)</li>
+     * <li><code>&lt;artifact></code> to define a target GAV (either local to the reactor or a
+     * remote one)</li>
      * <li><code>&lt;file></code> to define a file local to the build</li>
-     * <li><code>&lt;uri></code> to define a (remote) URI that specifies a target, currently only URIs
-     * that can be converted to URLs are supported (e.g. file:/.... http://..., )</li>
+     * <li><code>&lt;uri></code> to define a (remote) URI that specifies a target, currently only
+     * URIs that can be converted to URLs are supported (e.g. file:/.... http://..., )</li>
      * </ul>
      */
     @Parameter(name = DefaultTargetPlatformConfigurationReader.TARGET)
@@ -60,21 +61,21 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
      * <p>
      * If <code>consider</code> or <code>wrapAsBundle</code>, the effect is:
      * <ul>
-     * <li>First, Maven resolves the GAV dependencies according to the normal Maven rules. This results
-     * in a list of artifacts consisting of the specified artifacts and their transitive Maven
-     * dependencies.</li>
-     * <li>Tycho then checks each of these artifacts, and if the artifact is an OSGi bundle, it is added
-     * to the target platform. Other artifacts are ignored in case of <code>consider</code>, or get some
-     * OSGi metadata generated and an OSGi bundle created from them.</li>
+     * <li>First, Maven resolves the GAV dependencies according to the normal Maven rules. This
+     * results in a list of artifacts consisting of the specified artifacts and their transitive
+     * Maven dependencies.</li>
+     * <li>Tycho then checks each of these artifacts, and if the artifact is an OSGi bundle, it is
+     * added to the target platform. Other artifacts are ignored in case of <code>consider</code>,
+     * or get some OSGi metadata generated and an OSGi bundle created from them.</li>
      * <li>OSGi bundles which become part of the target platform in this way are then available to
      * resolve the project's OSGi dependencies.</li>
      * </ul>
      * </p>
      * <p>
-     * 📝 Tycho always attempts to resolve transitive dependencies, so if you need a POM dependency in
-     * the target platform of one module, you will also need it in all downstream modules. Therefore the
-     * POM dependencies (and the pomDependencies=consider configuration) typically need to be added in
-     * the parent POM.
+     * 📝 Tycho always attempts to resolve transitive dependencies, so if you need a POM dependency
+     * in the target platform of one module, you will also need it in all downstream modules.
+     * Therefore the POM dependencies (and the pomDependencies=consider configuration) typically
+     * need to be added in the parent POM.
      * </p>
      * <p>
      * If no explicit value is configured Tycho uses {@link PomDependencies#ignore} if eager
@@ -85,8 +86,8 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
     private PomDependencies pomDependencies;
 
     /**
-     * Force an execution environment for dependency resolution. If unset, use the default JRE of your
-     * computer.
+     * Force an execution environment for dependency resolution. If unset, use the default JRE of
+     * your computer.
      * <p>
      * Set to <code>none</code> to force the resolution to happen <b>without</b> any execution
      * environment, typically when the module is supposed to use system packages coming from some
@@ -122,15 +123,15 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
     /**
      * Selectively remove content from the target platform.
      * <p>
-     * This for example allows to restrict the version of a bundle, or to select one particular provider
-     * for a package. Filtering is done as last step in the target platform computation, so the filters
-     * apply to all sources listed above.
+     * This for example allows to restrict the version of a bundle, or to select one particular
+     * provider for a package. Filtering is done as last step in the target platform computation, so
+     * the filters apply to all sources listed above.
      * </p>
      * <p>
      * The filters will only remove content from the target platform; they will not add new content.
      * {@code dependency-resolution} should be used for addition of extra content. If you specify a
-     * restriction that is not fulfilled by any of the units from the target platform sources, all units
-     * that the filter applies to (i.e. units that match the filter.type, filter.id, and
+     * restriction that is not fulfilled by any of the units from the target platform sources, all
+     * units that the filter applies to (i.e. units that match the filter.type, filter.id, and
      * filter.version/versionRange criteria) will be removed from the target platform.
      * </p>
      * <p>
@@ -169,10 +170,10 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
     private List<CapabilityPattern> filters;
 
     /**
-     * Exclusions could be used together with {@link #pomDependencies} setting to exclude certain maven
-     * dependencies from being considered. This is useful for example if there is an offending
-     * (transitive) dependency needed for compilation but not for the runtime that would cause problems
-     * otherwise.
+     * Exclusions could be used together with {@link #pomDependencies} setting to exclude certain
+     * maven dependencies from being considered. This is useful for example if there is an offending
+     * (transitive) dependency needed for compilation but not for the runtime that would cause
+     * problems otherwise.
      */
     @Parameter(name = DefaultTargetPlatformConfigurationReader.EXCLUSIONS)
     private List<Exclusion> exclusions;
@@ -205,6 +206,12 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
 
     @Parameter(name = DefaultTargetPlatformConfigurationReader.TARGET_DEFINITION_INCLUDE_SOURCE)
     private IncludeSourceMode targetDefinionIncludeSource;
+
+    /**
+     * Configures if referenced repositories should be included in when fetching repositories.
+     */
+    @Parameter(name = DefaultTargetPlatformConfigurationReader.REFERENCED_REPOSITORY_MODE)
+    private ReferencedRepositoryMode referencedRepositoryMode;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -34,6 +34,7 @@ import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
 import org.eclipse.tycho.core.resolver.shared.PomDependencies;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
 import org.eclipse.tycho.targetplatform.TargetPlatformFilter;
 
@@ -117,6 +118,8 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     private boolean requireEagerResolve;
 
     private InjectP2MavenMetadataHandling p2MavenMetadataHandling;
+
+    private ReferencedRepositoryMode referencedRepositoryMode = ReferencedRepositoryMode.ignore;
 
     /**
      * Returns the list of configured target environments, or the running environment if no
@@ -309,6 +312,14 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     public void setLocalArtifactHandling(LocalArtifactHandling localArtifactHandling) {
         this.localArtifactHandling = localArtifactHandling;
+    }
+
+    public ReferencedRepositoryMode getReferencedRepositoryMode() {
+        return referencedRepositoryMode;
+    }
+
+    public void setReferencedRepositoryMode(ReferencedRepositoryMode referencedRepositoryMode) {
+        this.referencedRepositoryMode = referencedRepositoryMode;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -50,6 +50,7 @@ import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
 import org.eclipse.tycho.core.resolver.shared.PomDependencies;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolver;
 import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
 import org.eclipse.tycho.targetplatform.TargetPlatformArtifactResolver;
@@ -59,6 +60,7 @@ import org.osgi.framework.Filter;
 @Component(role = DefaultTargetPlatformConfigurationReader.class)
 public class DefaultTargetPlatformConfigurationReader {
     public static final String TARGET_DEFINITION_INCLUDE_SOURCE = "targetDefinitionIncludeSource";
+    public static final String REFERENCED_REPOSITORY_MODE = "referencedRepositoryMode";
     public static final String DEPENDENCY_RESOLUTION = "dependency-resolution";
     public static final String OPTIONAL_DEPENDENCIES = "optionalDependencies";
     public static final String LOCAL_ARTIFACTS = "localArtifacts";
@@ -137,6 +139,7 @@ public class DefaultTargetPlatformConfigurationReader {
                 readDependencyResolutionConfiguration(result, configuration, session);
 
                 setTargetDefinitionIncludeSources(result, configuration);
+                setReferencedRepositoryMode(result, configuration);
             }
         }
         //consider items set in the pom repositories
@@ -188,6 +191,20 @@ public class DefaultTargetPlatformConfigurationReader {
                     "Illegal value of <targetDefinitionIncludeSource> target platform configuration parameter: "
                             + value,
                     e);
+        }
+    }
+
+    private void setReferencedRepositoryMode(TargetPlatformConfiguration result, Xpp3Dom configuration)
+            throws BuildFailureException {
+        String value = getStringValue(configuration.getChild(REFERENCED_REPOSITORY_MODE));
+        if (value == null) {
+            return;
+        }
+        try {
+            result.setReferencedRepositoryMode(ReferencedRepositoryMode.valueOf(value));
+        } catch (IllegalArgumentException e) {
+            throw new BuildFailureException("Illegal value of <" + REFERENCED_REPOSITORY_MODE
+                    + "> target platform configuration parameter: " + value, e);
         }
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/shared/ReferencedRepositoryMode.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/shared/ReferencedRepositoryMode.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.core.resolver.shared;
+
+public enum ReferencedRepositoryMode {
+
+    /**
+     * Repository references are ignored
+     */
+    ignore,
+    /**
+     * Repository references are included
+     */
+    include;
+
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/ListCompositeMetadataRepository.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/ListCompositeMetadataRepository.java
@@ -20,12 +20,12 @@ import java.util.List;
 import java.util.UUID;
 
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-import org.eclipse.equinox.p2.query.Collector;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.IQueryable;
+import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.ICompositeRepository;
 import org.eclipse.equinox.p2.repository.IRepositoryReference;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
@@ -61,12 +61,7 @@ public class ListCompositeMetadataRepository extends AbstractMetadataRepository
         if (size == 1) {
             return metadataRepositories.get(0).query(query, monitor);
         }
-        Collector<IInstallableUnit> collector = new Collector<>();
-        SubMonitor subMonitor = SubMonitor.convert(monitor, size);
-        for (IMetadataRepository repository : metadataRepositories) {
-            collector.addAll(repository.query(query, subMonitor.split(1)));
-        }
-        return collector;
+        return QueryUtil.compoundQueryable(metadataRepositories).query(query, IProgressMonitor.nullSafe(monitor));
     }
 
     @Override

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/URITargetDefinitionContent.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/URITargetDefinitionContent.java
@@ -13,6 +13,10 @@
 package org.eclipse.tycho.p2.resolver;
 
 import java.net.URI;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
@@ -21,30 +25,35 @@ import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.repository.IRepository;
+import org.eclipse.equinox.p2.repository.IRepositoryReference;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.IRepositoryIdManager;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.p2.repository.LazyArtifactRepository;
+import org.eclipse.tycho.p2.repository.ListCompositeMetadataRepository;
 import org.eclipse.tycho.p2.repository.RepositoryArtifactProvider;
+import org.eclipse.tycho.p2maven.ListCompositeArtifactRepository;
 import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 
 public class URITargetDefinitionContent implements TargetDefinitionContent {
 
-    private final IArtifactRepository artifactRepository;
+    private IArtifactRepository artifactRepository;
     private IProvisioningAgent agent;
     private URI location;
     private String id;
     private IMetadataRepository metadataRepository;
+    private ReferencedRepositoryMode referencedRepositoryMode;
 
-    public URITargetDefinitionContent(IProvisioningAgent agent, URI location, String id) {
+    public URITargetDefinitionContent(IProvisioningAgent agent, URI location, String id,
+            ReferencedRepositoryMode referencedRepositoryMode) {
         this.agent = agent;
         this.location = location;
         this.id = id;
-        //artifact repositories are resolved lazy here as loading them might not be always necessary (e.g only dependency resolution required) and could be expensive (net I/O)
-        artifactRepository = new LazyArtifactRepository(agent, location, RepositoryArtifactProvider::loadRepository);
-
+        this.referencedRepositoryMode = referencedRepositoryMode;
     }
 
     @Override
@@ -61,28 +70,86 @@ public class URITargetDefinitionContent implements TargetDefinitionContent {
         return metadataRepository;
     }
 
-    public synchronized void preload(IProgressMonitor monitor) {
+    private synchronized void preload(IProgressMonitor monitor) {
         if (metadataRepository == null) {
-            IMetadataRepositoryManager metadataManager = agent.getService(IMetadataRepositoryManager.class);
-            if (metadataManager == null) {
-                throw new TargetDefinitionResolutionException(
-                        "IMetadataRepositoryManager is null in IProvisioningAgent");
+            Map<URI, IMetadataRepository> metadataRepositoriesMap = new LinkedHashMap<>();
+            Map<URI, IArtifactRepository> artifactRepositoriesMap = new LinkedHashMap<>();
+            loadMetadataRepositories(location, id, metadataRepositoriesMap, artifactRepositoriesMap,
+                    referencedRepositoryMode == ReferencedRepositoryMode.include, agent, monitor);
+            loadArtifactRepositories(location, artifactRepositoriesMap, agent);
+            Collection<IMetadataRepository> metadataRepositories = metadataRepositoriesMap.values();
+            if (metadataRepositories.size() == 1) {
+                metadataRepository = metadataRepositories.iterator().next();
+            } else {
+                metadataRepository = new ListCompositeMetadataRepository(List.copyOf(metadataRepositories), agent);
             }
-            IRepositoryIdManager repositoryIdManager = agent.getService(IRepositoryIdManager.class);
-            if (repositoryIdManager != null) {
-                repositoryIdManager.addMapping(id, location);
-            }
-            try {
-                metadataRepository = metadataManager.loadRepository(location, monitor);
-            } catch (ProvisionException e) {
-                throw new TargetDefinitionResolutionException(
-                        "Failed to load p2 metadata repository from location " + location, e);
+            Collection<IArtifactRepository> artifactRepositories = artifactRepositoriesMap.values();
+            if (artifactRepositories.size() == 1) {
+                artifactRepository = artifactRepositories.iterator().next();
+            } else {
+                artifactRepository = new ListCompositeArtifactRepository(List.copyOf(artifactRepositories), agent);
             }
         }
     }
 
+    private static void loadMetadataRepositories(URI uri, String id, Map<URI, IMetadataRepository> metadataRepositories,
+            Map<URI, IArtifactRepository> artifactRepositories, boolean includeReferenced, IProvisioningAgent agent,
+            IProgressMonitor monitor) {
+        URI key = uri.normalize();
+        if (metadataRepositories.containsKey(key)) {
+            //already loaded...
+            return;
+        }
+        SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
+        IMetadataRepositoryManager metadataManager = agent.getService(IMetadataRepositoryManager.class);
+        if (metadataManager == null) {
+            throw new TargetDefinitionResolutionException("IMetadataRepositoryManager is null in IProvisioningAgent");
+        }
+        try {
+            IRepositoryIdManager repositoryIdManager = agent.getService(IRepositoryIdManager.class);
+            if (repositoryIdManager != null) {
+                repositoryIdManager.addMapping(id, uri);
+            }
+            IMetadataRepository repository = metadataManager.loadRepository(uri, subMonitor.split(50));
+            metadataRepositories.put(key, repository);
+            if (includeReferenced) {
+                Collection<IRepositoryReference> references = repository.getReferences();
+                subMonitor.setWorkRemaining(references.size());
+                for (IRepositoryReference reference : references) {
+                    if ((reference.getOptions() | IRepository.ENABLED) != 0) {
+                        if (reference.getType() == IRepository.TYPE_METADATA) {
+                            loadMetadataRepositories(reference.getLocation(), reference.getNickname(),
+                                    metadataRepositories, artifactRepositories, includeReferenced, agent,
+                                    subMonitor.split(1));
+                        } else if (reference.getType() == IRepository.TYPE_ARTIFACT) {
+                            loadArtifactRepositories(reference.getLocation(), artifactRepositories, agent);
+                            subMonitor.worked(1);
+                        }
+                    }
+                }
+            }
+        } catch (ProvisionException e) {
+            throw new TargetDefinitionResolutionException("Failed to load p2 metadata repository from location " + uri,
+                    e);
+        }
+
+    }
+
+    private static void loadArtifactRepositories(URI uri, Map<URI, IArtifactRepository> artifactRepositories,
+            IProvisioningAgent agent) {
+        URI key = uri.normalize();
+        if (artifactRepositories.containsKey(key)) {
+            //already loaded...
+            return;
+        }
+        //artifact repositories are resolved lazy here as loading them might not be always necessary (e.g only dependency resolution required) and could be expensive (net I/O)
+        artifactRepositories.put(key,
+                new LazyArtifactRepository(agent, uri, RepositoryArtifactProvider::loadRepository));
+    }
+
     @Override
     public IArtifactRepository getArtifactRepository() {
+        preload(null);
         return artifactRepository;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/target/facade/TargetPlatformConfigurationStub.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/target/facade/TargetPlatformConfigurationStub.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.eclipse.tycho.MavenRepositoryLocation;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
 import org.eclipse.tycho.targetplatform.TargetPlatformFilter;
 
@@ -35,6 +36,7 @@ public class TargetPlatformConfigurationStub {
     private final List<TargetDefinition> targetDefinitions = new ArrayList<>();
     private boolean forceIgnoreLocalArtifacts = false;
     private IncludeSourceMode includeSourceMode = IncludeSourceMode.honor;
+    private ReferencedRepositoryMode referencedRepositoryMode = ReferencedRepositoryMode.ignore;
 
     public TargetPlatformConfigurationStub() {
         // TODO Auto-generated constructor stub
@@ -91,6 +93,14 @@ public class TargetPlatformConfigurationStub {
 
     public void setIncludeSourceMode(IncludeSourceMode includeSourceMode) {
         this.includeSourceMode = includeSourceMode;
+    }
+
+    public ReferencedRepositoryMode getIncludeRefererenced() {
+        return referencedRepositoryMode;
+    }
+
+    public void setReferencedRepositoryMode(ReferencedRepositoryMode referencedRepositoryMode) {
+        this.referencedRepositoryMode = referencedRepositoryMode;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -210,6 +210,7 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
         tpConfiguration.setIncludeSourceMode(configuration.getTargetDefinitionIncludeSourceMode());
         tpConfiguration
                 .setIgnoreLocalArtifacts(configuration.getIgnoreLocalArtifacts() == LocalArtifactHandling.ignore);
+        tpConfiguration.setReferencedRepositoryMode(configuration.getReferencedRepositoryMode());
 
         return reactorRepositoryManager.computePreliminaryTargetPlatform(reactorProject, tpConfiguration, ee,
                 reactorProjects);

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverExecutionEnvironmentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverExecutionEnvironmentTest.java
@@ -34,6 +34,7 @@ import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.tycho.core.ee.impl.StandardEEResolutionHints;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentStub;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolverIncludeModeTest.PlannerLocationStub;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.RepositoryStub;
@@ -60,7 +61,7 @@ public class TargetDefinitionResolverExecutionEnvironmentTest extends TychoPlexu
         MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
         return new TargetDefinitionResolver(defaultEnvironments(),
                 new StandardEEResolutionHints(new ExecutionEnvironmentStub(executionEnvironmentName, systemPackages)),
-                IncludeSourceMode.honor, mavenCtx, null,
+                IncludeSourceMode.honor, ReferencedRepositoryMode.ignore, mavenCtx, null,
                 new DefaultTargetDefinitionVariableResolver(mavenCtx, logVerifier.getLogger()));
     }
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeModeTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeModeTest.java
@@ -30,13 +30,14 @@ import static org.hamcrest.core.StringContains.containsString;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.p2.resolver.ResolverException;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.LocationStub;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.TestRepositories;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
-import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinition.IncludeMode;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
@@ -59,7 +60,8 @@ public class TargetDefinitionResolverIncludeModeTest extends TychoPlexusTestCase
     public void initSubject() throws Exception {
         MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
         subject = new TargetDefinitionResolver(defaultEnvironments(),
-                ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor, mavenCtx, null,
+                ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
+                ReferencedRepositoryMode.ignore, mavenCtx, null,
                 new DefaultTargetDefinitionVariableResolver(mavenCtx, logVerifier.getLogger()));
     }
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeSourceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeSourceTest.java
@@ -26,12 +26,13 @@ import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.LocationStub;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.TestRepositories;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
-import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinition.IncludeMode;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
@@ -59,7 +60,8 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
     public void initSubject() throws Exception {
         MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
         subject = new TargetDefinitionResolver(defaultEnvironments(),
-                ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor, mavenCtx, null,
+                ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
+                ReferencedRepositoryMode.ignore, mavenCtx, null,
                 new DefaultTargetDefinitionVariableResolver(mavenCtx, logVerifier.getLogger()));
     }
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverTest.java
@@ -37,15 +37,16 @@ import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
-import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinition.IncludeMode;
 import org.eclipse.tycho.targetplatform.TargetDefinition.InstallableUnitLocation;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Location;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Repository;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Unit;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 import org.eclipse.tycho.targetplatform.TargetDefinitionSyntaxException;
 import org.eclipse.tycho.test.util.LogVerifier;
@@ -91,7 +92,8 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
     public void initContext() throws Exception {
         MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
         subject = new TargetDefinitionResolver(defaultEnvironments(),
-                ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor, mavenCtx, null,
+                ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
+                ReferencedRepositoryMode.ignore, mavenCtx, null,
                 new DefaultTargetDefinitionVariableResolver(mavenCtx, logVerifier.getLogger()));
     }
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverWithPlatformSpecificUnitsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverWithPlatformSpecificUnitsTest.java
@@ -30,14 +30,15 @@ import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.RepositoryStub;
 import org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.UnitStub;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
-import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinition.IncludeMode;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Repository;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Unit;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
@@ -155,7 +156,7 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
             throws ProvisionException, IOException {
         MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
         return new TargetDefinitionResolver(environments, ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS,
-                IncludeSourceMode.honor, mavenCtx, null,
+                IncludeSourceMode.honor, ReferencedRepositoryMode.ignore, mavenCtx, null,
                 new DefaultTargetDefinitionVariableResolver(mavenCtx, logVerifier.getLogger()));
     }
 


### PR DESCRIPTION
Currently Tycho ignores repository references when resolving IU locations.

This now adds support for referenced repositories so Tycho can resolve from there as well.