### PR TITLE
Add workaround for multiple calls of repo mojo using wrong URL

### DIFF
--- a/tycho-repository-plugin/src/main/java/org/eclipse/tycho/repository/plugin/OSGiRepositoryGenerator.java
+++ b/tycho-repository-plugin/src/main/java/org/eclipse/tycho/repository/plugin/OSGiRepositoryGenerator.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.repository.plugin;
 
+import static aQute.bnd.osgi.Constants.MIME_TYPE_BUNDLE;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -27,10 +29,13 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.eclipse.tycho.MavenArtifactNamespace;
 import org.eclipse.tycho.packaging.RepositoryGenerator;
+import org.osgi.resource.Resource;
 
+import aQute.bnd.osgi.Domain;
 import aQute.bnd.osgi.repository.XMLResourceGenerator;
 import aQute.bnd.osgi.resource.CapReqBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
+import aQute.libg.cryptography.SHA256;
 
 @Component(role = RepositoryGenerator.class, hint = OSGiRepositoryGenerator.HINT)
 public class OSGiRepositoryGenerator implements RepositoryGenerator {
@@ -44,8 +49,7 @@ public class OSGiRepositoryGenerator implements RepositoryGenerator {
 		resourceGenerator.name(repoConfig.getRepositoryName());
 		File folder;
 		PlexusConfiguration generatorConfig = repoConfig.getConfiguration();
-		String repositoryFileName = generatorConfig.getChild("repositoryFileName")
-				.getValue("repository.xml");
+		String repositoryFileName = generatorConfig.getChild("repositoryFileName").getValue("repository.xml");
 		if (repoConfig.getLayout() == RepositoryLayout.local) {
 			String folderName = generatorConfig.getChild("repositoryFolderName")
 					.getValue(FilenameUtils.getBaseName(repositoryFileName));
@@ -67,14 +71,17 @@ public class OSGiRepositoryGenerator implements RepositoryGenerator {
 				} else {
 					uri = new File(folder, file.getName()).toURI();
 				}
-				if (rb.addFile(project.getArtifact().getFile(), uri)) {
+
+				Resource resource = getResourceFromFile(file, uri);
+				if (resource != null) {
+					log.info("Adding " + project.getId());
+					rb.addResource(resource);
 					CapReqBuilder identity = new CapReqBuilder(MavenArtifactNamespace.MAVEN_ARTIFACT_NAMESPACE)
 							.addAttribute(MavenArtifactNamespace.CAPABILITY_GROUP_ATTRIBUTE, project.getGroupId())
 							.addAttribute(MavenArtifactNamespace.MAVEN_ARTIFACT_NAMESPACE, project.getArtifactId())
 							.addAttribute(MavenArtifactNamespace.CAPABILITY_VERSION_ATTRIBUTE, project.getVersion());
 					rb.addCapability(identity);
 					resourceGenerator.resource(rb.build());
-					log.info("Adding " + project.getId());
 					if (folder != null) {
 						FileUtils.copyFileToDirectory(file, folder);
 					}
@@ -94,6 +101,16 @@ public class OSGiRepositoryGenerator implements RepositoryGenerator {
 			resourceGenerator.save(location);
 			return location;
 		}
+	}
+
+	private Resource getResourceFromFile(File file, URI uri) throws Exception {
+		ResourceBuilder rb = new ResourceBuilder();
+		Domain manifest = Domain.domain(file);
+		if (manifest != null && rb.addManifest(manifest)) {
+			rb.addContentCapability(uri, SHA256.digest(file).asHex(), file.length(), MIME_TYPE_BUNDLE);
+			return rb.build();
+		}
+		return null;
 	}
 
 }


### PR DESCRIPTION
BND currently cache file resources but not using the URL (see https://github.com/bndtools/bnd/issues/5740) as the cache key, because of that it happens that if a mojo is called multiple times with the same underlying file that a wrong URL is used.

This replaces the convenient call with an equivalent one that uses no cache instead.