### PR TITLE
FileTargetDefinitionContent: Improve exception message

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/FileTargetDefinitionContent.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/FileTargetDefinitionContent.java
@@ -164,8 +164,8 @@ public class FileTargetDefinitionContent implements TargetDefinitionContent {
                             consumer.accept(FileArtifactRepository.forFile(bundleLocation, key),
                                     BundlesAction.createBundleIU(bundleDescription, key, publisherInfo));
                         }
-                    } catch (BundleException | IOException e) {
-                        throw new ResolverException("Reading bundle failed", e);
+                    } catch (BundleException | IOException | RuntimeException e) {
+                        throw new ResolverException("Reading " + bundleLocation + " bundle failed", e);
                     }
                     subMonitor.worked(1);
                 }


### PR DESCRIPTION
Improve exception message when BundlesAction.createBundleArtifactKey(...) fails with the below stack trace, to at least know which .jar file couldn't be read.

```
[ERROR] Could not resolve content of rcp.target
[ERROR] org.eclipse.core.runtime.AssertionFailedException: null argument:
[ERROR] 	at org.eclipse.core.runtime.Assert.isNotNull(Assert.java:88)
[ERROR] 	at org.eclipse.core.runtime.Assert.isNotNull(Assert.java:76)
[ERROR] 	at org.eclipse.equinox.internal.p2.metadata.ArtifactKey.<init>(ArtifactKey.java:79)
[ERROR] 	at org.eclipse.equinox.p2.publisher.eclipse.BundlesAction.createBundleArtifactKey(BundlesAction.java:134)
[ERROR] 	at org.eclipse.tycho.p2.resolver.FileTargetDefinitionContent.readBundles(FileTargetDefinitionContent.java:162)
[ERROR] 	at org.eclipse.tycho.p2.resolver.FileTargetDefinitionContent.preload(FileTargetDefinitionContent.java:87)
[ERROR] 	at org.eclipse.tycho.p2.resolver.FileTargetDefinitionContent.query(FileTargetDefinitionContent.java:71)
[ERROR] 	at org.eclipse.tycho.p2resolver.TargetDefinitionResolver.resolveContentWithExceptions(TargetDefinitionResolver.java:159)
[ERROR] 	at org.eclipse.tycho.p2resolver.TargetDefinitionResolver.resolveContent(TargetDefinitionResolver.java:102)
[ERROR] 	at org.eclipse.tycho.p2resolver.TargetDefinitionResolverService.resolveFromArguments(TargetDefinitionResolverService.java:93)
[ERROR] 	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
[ERROR] 	at org.eclipse.tycho.p2resolver.TargetDefinitionResolverService.getTargetDefinitionContent(TargetDefinitionResolverService.java:68)
[ERROR] 	at org.eclipse.tycho.p2resolver.TargetPlatformFactoryImpl.resolveTargetDefinitions(TargetPlatformFactoryImpl.java:214)
[ERROR] 	at org.eclipse.tycho.p2resolver.TargetPlatformFactoryImpl.createTargetPlatform(TargetPlatformFactoryImpl.java:164)
[ERROR] 	at org.eclipse.tycho.p2resolver.TargetPlatformFactoryImpl.createTargetPlatform(TargetPlatformFactoryImpl.java:137)
[ERROR] 	at org.eclipse.tycho.p2resolver.P2ResolverImpl.resolveMetadata(P2ResolverImpl.java:165)
[ERROR] 	at org.eclipse.tycho.extras.tpvalidator.TPValidationMojo.validateTarget(TPValidationMojo.java:225)
[ERROR] 	at org.eclipse.tycho.extras.tpvalidator.TPValidationMojo.execute(TPValidationMojo.java:155)
[ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:126)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:328)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:316)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:174)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:75)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:162)
[ERROR] 	at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:159)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:105)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:73)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:53)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:118)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:261)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:173)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:101)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:906)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:283)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:206)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[ERROR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:283)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:226)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:407)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:348)
```
Stack trace made with tycho 4.0.0 .