### PR TITLE
Add an option to prevent repo-references from being added to a p2-repo

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,28 @@ Repositories can contain references to other repositories (e.g. to find addition
 </plugin>
 	
 ```
+### new option to filter added repository-references when assembling a p2-repository
+
+The repository references automatically added to a assembled p2-repository (via `tycho-p2-repository-plugin`'s `addIUTargetRepositoryReferences` or `addPomRepositoryReferences`) 
+can now be filtered by their location using exclusion and inclusion patterns and therefore allows more fine-grained control which references are added.
+```xml
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-p2-repository-plugin</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		... other configuration options ...
+		<repositoryReferenceFilter>
+			<exclude>
+				<location>https://foo.bar.org/hidden/**</location>
+				<location>https://foo.bar.org/secret/**</location>
+			</exclude>
+			<include>%regex[http(s)?:\/\/foo\.bar\.org\/.*]</include>
+		</repositoryReferenceFilter>
+	</configuration>
+</plugin>
+	
+```
 
 ## 4.0.0
 

--- a/tycho-its/projects/p2Repository.repositoryRef.filter/category.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.filter/category.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <category-def name="Test Category" label="Test Category Label">
+      <description>
+         Test Category Description
+      </description>
+   </category-def>
+   <repository-reference location="https://some.where/from/category" enabled="true" />
+</site>

--- a/tycho-its/projects/p2Repository.repositoryRef.filter/pom.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.filter/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<version>1.0.0</version>
+	<groupId>tycho-its-project.p2Repository.repositoryRef.location</groupId>
+	<artifactId>repositoryRef.location</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<repositories>
+		<repository>
+			<id>repo1</id>
+			<url>https://download.eclipse.org/tm4e/releases/0.8.1</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>repo2</id>
+			<url>https://download.eclipse.org/lsp4e/releases/0.24.1</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>repo3</id>
+			<url>https://download.eclipse.org/lsp4j/updates/releases/0.21.1</url>
+			<layout>p2</layout>
+		</repository>
+	</repositories>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<compress>false</compress>
+					<addPomRepositoryReferences>true</addPomRepositoryReferences>
+					<repositoryReferenceFilter>
+						<exclude>
+							<location>https://download.eclipse.org/lsp4e/**</location>
+							<location>https://download.eclipse.org/lsp4j/**</location>
+						</exclude>
+						<include>%regex[http(s)?:\/\/download\.eclipse\.org\/.*]</include>
+					</repositoryReferenceFilter>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepositoryIncludeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepositoryIncludeTest.java
@@ -31,7 +31,7 @@ public class RepositoryIncludeTest extends AbstractTychoIntegrationTest {
 		P2RepositoryTool p2Repo = P2RepositoryTool
 				.forEclipseRepositoryModule(new File(verifier.getBasedir(), "repository"));
 		p2Repo.getUniqueIU("bundle");
-		p2Repo.assertNumberOfUnits(1, u -> u.id.equals("a.jre.javase") || u.id.endsWith(".test.category"));
+		p2Repo.assertNumberOfUnits(1, u -> u.id().equals("a.jre.javase") || u.id().endsWith(".test.category"));
 		assertTrue("Bundle artifact not found!", p2Repo.findBundleArtifact("bundle").isPresent());
 		p2Repo.assertNumberOfBundles(1);
 		p2Repo.assertNumberOfFeatures(0);

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/P2RepositoryTool.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/P2RepositoryTool.java
@@ -7,11 +7,11 @@ import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -28,7 +28,7 @@ import org.w3c.dom.NodeList;
 
 public class P2RepositoryTool {
 
-    private static final ThreadLocal<XPath> xPathTool = ThreadLocal
+    private static final ThreadLocal<XPath> XPATH_TOOL = ThreadLocal
             .withInitial(() -> XPathFactory.newInstance().newXPath());
     private static final Pattern strictVersionRangePattern = Pattern.compile("\\[([^,]*),\\1\\]");
     private final File repoLocation;
@@ -213,6 +213,21 @@ public class P2RepositoryTool {
         return getValues(contentXml, "/repository/units/unit/provides/provided[@namespace='java.package']/@name");
     }
 
+    public List<RepositoryReference> getAllRepositoryReferences() throws Exception {
+        loadMetadata();
+        // See MetadataRepositoryIO.Writer#writeRepositoryReferences
+        List<Node> references = getNodes(contentXml, "/repository/references/repository");
+        List<RepositoryReference> result = new ArrayList<>();
+        for (Node reference : references) {
+            String uri = getAttribute(reference, "@uri");
+            int type = Integer.parseInt(getAttribute(reference, "@type"));
+            int options = Integer.parseInt(getAttribute(reference, "@options"));
+            result.add(new RepositoryReference(uri, type, options));
+        }
+
+        return result;
+    }
+
     private void loadMetadata() throws Exception {
         if (contentXml != null)
             return;
@@ -223,27 +238,17 @@ public class P2RepositoryTool {
     }
 
     private static XPath getXPathTool() {
-        return xPathTool.get();
+        return XPATH_TOOL.get();
     }
 
     static List<Node> getNodes(Object startingPoint, String expression) throws XPathExpressionException {
         NodeList nodeList = (NodeList) getXPathTool().evaluate(expression, startingPoint, XPathConstants.NODESET);
 
-        List<Node> result = new ArrayList<>(nodeList.getLength());
-        for (int ix = 0; ix < nodeList.getLength(); ++ix) {
-            result.add(nodeList.item(ix));
-        }
-        return result;
+        return IntStream.range(0, nodeList.getLength()).mapToObj(nodeList::item).toList();
     }
 
     static List<String> getValues(Object startingPoint, String expression) throws XPathExpressionException {
-        NodeList nodeList = (NodeList) getXPathTool().evaluate(expression, startingPoint, XPathConstants.NODESET);
-
-        List<String> result = new ArrayList<>(nodeList.getLength());
-        for (int ix = 0; ix < nodeList.getLength(); ++ix) {
-            result.add(nodeList.item(ix).getNodeValue());
-        }
-        return result;
+        return getNodes(startingPoint, expression).stream().map(Node::getNodeValue).toList();
     }
 
     static String getAttribute(Node node, String expression) throws XPathExpressionException {
@@ -300,14 +305,7 @@ public class P2RepositoryTool {
         }
 
         public List<String> getRequiredIds() throws Exception {
-            List<String> result = new ArrayList<>();
-
-            List<Node> requiredIds = getNodes(unitElement, "requires/required/@name");
-            for (Node id : requiredIds) {
-                result.add(id.getNodeValue());
-            }
-
-            return result;
+            return getValues(unitElement, "requires/required/@name");
         }
 
         /**
@@ -371,33 +369,10 @@ public class P2RepositoryTool {
         }
     }
 
-    public static final class IdAndVersion {
-        public final String id;
-        public final String version;
+    public static final record IdAndVersion(String id, String version) {
+    }
 
-        public IdAndVersion(String id, String version) {
-            this.id = id;
-            this.version = version;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(id, version);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return this == obj || //
-                    (obj instanceof IdAndVersion other && //
-                            Objects.equals(id, other.id) && //
-                            Objects.equals(version, other.version));
-        }
-
-        @Override
-        public String toString() {
-            return "id=" + id + ", version=" + version;
-        }
-
+    public static final record RepositoryReference(String uri, int type, int options) {
     }
 
     public static IdAndVersion withIdAndVersion(String id, String version) {


### PR DESCRIPTION
Add a new parameter named 'excludedRepositoryReferences' to the AssembleRepositoryMojo to prevent (mainly the automatic) addition of repository references with matching locations.
This can be used with ANT-style or Java RegEx patterns as follows:
```
<excludedRepositoryReferences>
	<excluded>https://foo.bar.org/component1/**</excluded>
	<excluded>%regex[http(s)?:\/\/bar\.org\/hidden.*]</excluded>
</excludedRepositoryReferences>
```

The is especially convenient in combination with the automatic addition of IU Target-Repository or POM-Repository references, if some but not all repos should be added.

One use-case of this is for example https://github.com/eclipse-m2e/m2e-core/pull/1222.