### PR TITLE
Suppress addition of unnecessary repo-refereces when assembling p2-repos

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,8 +28,11 @@ Repositories can contain references to other repositories (e.g. to find addition
 ```
 ### new option to filter added repository-references when assembling a p2-repository
 
-The repository references automatically added to a assembled p2-repository (via `tycho-p2-repository-plugin`'s `addIUTargetRepositoryReferences` or `addPomRepositoryReferences`) 
-can now be filtered by their location using exclusion and inclusion patterns and therefore allows more fine-grained control which references are added.
+If filtering provided artifacts is enabled, the repository references automatically added to a assembled p2-repository
+(via `tycho-p2-repository-plugin`'s `addIUTargetRepositoryReferences` or `addPomRepositoryReferences`) can now be filtered by their location
+using exclusion and inclusion patterns and therefore allows more fine-grained control which references are added.
+Additionally the automatically added references can be filter based on if they provide any of the filtered units or not.
+If `addOnlyProviding` is `true` repositories that don't provide any filtered unit are not added to the assembled repo.
 ```xml
 <plugin>
 	<groupId>org.eclipse.tycho</groupId>
@@ -38,6 +41,7 @@ can now be filtered by their location using exclusion and inclusion patterns and
 	<configuration>
 		... other configuration options ...
 		<repositoryReferenceFilter>
+			<addOnlyProviding>true</addOnlyProviding>
 			<exclude>
 				<location>https://foo.bar.org/hidden/**</location>
 				<location> %regex[http(s)?:\/\/foo\.bar\.org\/secret\/.*]</location>

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/DestinationRepositoryDescriptor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/DestinationRepositoryDescriptor.java
@@ -28,10 +28,12 @@ public class DestinationRepositoryDescriptor {
     private final boolean append;
     private final Map<String, String> extraArtifactRepositoryProperties;
     private final List<RepositoryReference> repositoryReferences;
+    private final List<RepositoryReference> filterablRepositoryReferences;
 
     public DestinationRepositoryDescriptor(File location, String name, boolean compress, boolean xzCompress,
             boolean keepNonXzIndexFiles, boolean metaDataOnly, boolean append,
-            Map<String, String> extraArtifactRepositoryProperties, List<RepositoryReference> repositoryReferences) {
+            Map<String, String> extraArtifactRepositoryProperties, List<RepositoryReference> repositoryReferences,
+            List<RepositoryReference> filterablRepositoryReferences) {
         this.location = location;
         this.name = name;
         this.compress = compress;
@@ -41,12 +43,13 @@ public class DestinationRepositoryDescriptor {
         this.append = append;
         this.extraArtifactRepositoryProperties = extraArtifactRepositoryProperties;
         this.repositoryReferences = repositoryReferences;
+        this.filterablRepositoryReferences = filterablRepositoryReferences;
     }
 
     public DestinationRepositoryDescriptor(File location, String name, boolean compress, boolean xzCompress,
             boolean keepNonXzIndexFiles, boolean metaDataOnly, boolean append) {
         this(location, name, compress, xzCompress, keepNonXzIndexFiles, metaDataOnly, append, Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(), Collections.emptyList());
     }
 
     public DestinationRepositoryDescriptor(File location, String name) {
@@ -87,5 +90,9 @@ public class DestinationRepositoryDescriptor {
 
     public List<RepositoryReference> getRepositoryReferences() {
         return repositoryReferences == null ? Collections.emptyList() : repositoryReferences;
+    }
+
+    public List<RepositoryReference> getFilterableRepositoryReferences() {
+        return filterablRepositoryReferences;
     }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
@@ -54,7 +54,11 @@ public interface MirrorApplicationService {
      *            Whether to include bundles mentioned in the require section of a feature
      * @param includeRequiredFeatures
      *            Whether to include features mentioned in the require section of a feature
-     * @param filterProvided Whether to filter IU/artifacts that are already provided by a referenced repository
+     * @param filterProvided
+     *            Whether to filter IU/artifacts that are already provided by a referenced
+     *            repository
+     * @param addOnlyProvidingRepoReferences
+     *            Whether to add only repository-references that provide any relevant IU
      * @param filterProperties
      *            additional filter properties to be set in the p2 slicing options. May be
      *            <code>null</code>
@@ -64,7 +68,8 @@ public interface MirrorApplicationService {
     public void mirrorReactor(RepositoryReferences sources, DestinationRepositoryDescriptor destination,
             Collection<DependencySeed> seeds, BuildContext context, boolean includeAllDependencies,
             boolean includeAllSource, boolean includeRequiredBundles, boolean includeRequiredFeatures,
-            boolean filterProvided, Map<String, String> filterProperties) throws FacadeException;
+            boolean filterProvided, boolean addOnlyProvidingRepoReferences, Map<String, String> filterProperties)
+            throws FacadeException;
 
     /**
      * recreates the metadata of an existing repository e.g. to account for changes in the contained

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -152,7 +152,8 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
     public void mirrorReactor(RepositoryReferences sources, DestinationRepositoryDescriptor destination,
             Collection<DependencySeed> projectSeeds, BuildContext context, boolean includeAllDependencies,
             boolean includeAllSource, boolean includeRequiredBundles, boolean includeRequiredFeatures,
-            boolean filterProvided, Map<String, String> filterProperties) throws FacadeException {
+            boolean filterProvided, boolean addOnlyProvidingRepoReferences, Map<String, String> filterProperties)
+            throws FacadeException {
         final TychoMirrorApplication mirrorApp = createMirrorApplication(sources, destination, agent);
 
         // mirror scope: seed units...
@@ -162,6 +163,7 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
         mirrorApp.setIncludeRequiredBundles(includeRequiredBundles);
         mirrorApp.setIncludeRequiredFeatures(includeRequiredFeatures);
         mirrorApp.setFilterProvided(filterProvided);
+        mirrorApp.setAddOnlyProvidingRepoReferences(addOnlyProvidingRepoReferences);
         mirrorApp.setEnvironments(context.getEnvironments());
         SlicingOptions options = new SlicingOptions();
         options.considerStrictDependencyOnly(!includeAllDependencies);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/TychoMirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/TychoMirrorApplication.java
@@ -64,9 +64,12 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.p2.tools.DestinationRepositoryDescriptor;
 import org.eclipse.tycho.p2.tools.RepositoryReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfromp2.MirrorApplication {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TychoMirrorApplication.class);
     private static final String SOURCE_SUFFIX = ".source";
     private static final String FEATURE_GROUP = ".feature.group";
     private final DestinationRepositoryDescriptor destination;
@@ -210,6 +213,16 @@ public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfrom
         // In order to avoid stripping of slashes from URI instances do it now before URIs are created.
         String location = r.getLocation();
         return URI.create(location.endsWith("/") ? location.substring(0, location.length() - 1) : location);
+    }
+
+    @Override
+    protected void finalizeRepositories() {
+        Collection<IRepositoryReference> references = getDestinationMetadataRepository().getReferences();
+        if (!references.isEmpty()) {
+            LOGGER.info("Adding references to the following repositories:");
+            references.stream().map(r -> r.getLocation()).distinct().forEach(loc -> LOGGER.info("  {}", loc));
+        }
+        super.finalizeRepositories();
     }
 
     @Override

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceTest.java
@@ -101,13 +101,13 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         Collection<DependencySeed> noSeeds = Collections.emptyList();
 
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, noSeeds, context, false, false, false,
-                false, false, null);
+                false, false, false, null);
     }
 
     @Test
     public void testMirrorFeatureWithContent() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false,
-                false, false, false, false, null);
+                false, false, false, false, false, null);
 
         logVerifier.expectNoWarnings();
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.4.0.v20080512.jar").exists());
@@ -121,9 +121,10 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         extraArtifactRepositoryProperties.put("p2.mirrorsURL", "http://some.where.else");
         extraArtifactRepositoryProperties.put("foo", "bar");
         destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest2"), DEFAULT_NAME, false, false,
-                false, false, true, extraArtifactRepositoryProperties, Collections.emptyList());
+                false, false, true, extraArtifactRepositoryProperties, Collections.emptyList(),
+                Collections.emptyList());
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false,
-                false, false, false, false, null);
+                false, false, false, false, false, null);
 
         logVerifier.expectNoWarnings();
         File artifactsXml = repoFile(destinationRepo, "artifacts.xml");
@@ -146,7 +147,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
     @Test
     public void testMirrorPatch() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e352"), destinationRepo, seedFor(FEATURE_PATCH_IU), context, false,
-                false, false, false, false, null);
+                false, false, false, false, false, null);
 
         //TODO why mirror tool emits a warning here?        logVerifier.expectNoWarnings();
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.5.0.v20090525.jar").exists());
@@ -156,7 +157,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
     @Test
     public void testMirrorFeatureAndPatch() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e352"), destinationRepo,
-                seedFor(SIMPLE_FEATURE_IU, FEATURE_PATCH_IU), context, false, false, false, false, false, null);
+                seedFor(SIMPLE_FEATURE_IU, FEATURE_PATCH_IU), context, false, false, false, false, false, false, null);
 
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.5.0.v20090525.jar").exists());
         assertTrue(repoFile(destinationRepo, "features/" + SIMPLE_FEATURE + "_1.0.0.jar").exists());
@@ -175,7 +176,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
          * warning is issued.
          */
         subject.mirrorReactor(sourceRepos("patch"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false, false,
-                false, false, false, null);
+                false, false, false, false, null);
 
         logVerifier.expectWarning(not(is("")));
     }
@@ -189,7 +190,8 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         List<DependencySeed> seeds = Collections
                 .singletonList(new DependencySeed(null, "org.eclipse.core.runtime", null));
 
-        subject.mirrorReactor(sourceRepos("e342"), destinationRepo, seeds, context, false, false, false, false, false, null);
+        subject.mirrorReactor(sourceRepos("e342"), destinationRepo, seeds, context, false, false, false, false, false,
+                false, null);
 
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.4.0.v20080512.jar").exists());
     }

--- a/tycho-its/projects/p2Repository.repositoryRef.filter.providing/category.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.filter.providing/category.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <bundle id="org.eclipse.emf.ecore"/>
+   <repository-reference location="https://download.eclipse.org/cbi/updates/license" enabled="true" />
+</site>

--- a/tycho-its/projects/p2Repository.repositoryRef.filter.providing/pom.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.filter.providing/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<version>1.0.0</version>
+	<groupId>tycho-its-project.p2Repository.repositoryRef.location</groupId>
+	<artifactId>repositoryRef.location</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<repositories>
+		<!-- Add one that is removed because it contributes nothing, it's content is entirly provided by another. And one that would be removed but is added to the  category explicity-->
+		<repository>
+			<id>repo0</id>
+			<url>https://download.eclipse.org/eclipse/updates/4.29/</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>repo-provided-by-others</id>
+			<url>https://download.eclipse.org/modeling/emf/emf/builds/release/2.35.0</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>an-unused-repo</id>
+			<url>https://download.eclipse.org/egit/updates-6.7/</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>an-unused-repo-but-added-explicitly-in-category-xml</id>
+			<url>https://download.eclipse.org/cbi/updates/license</url>
+			<layout>p2</layout>
+		</repository>
+		
+	</repositories>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<compress>false</compress>
+					<includeAllDependencies>true</includeAllDependencies>
+					<includeAllSources>true</includeAllSources>
+					<filterProvided>true</filterProvided>
+					<addPomRepositoryReferences>true</addPomRepositoryReferences>
+					<repositoryReferenceFilters>
+						<addOnlyProviding>true</addOnlyProviding>
+					</repositoryReferenceFilters>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
The main goal of this PR is to prevent the addition of repository references that don't provide any relevant artifact or are full duplicates (relating the relevant artifacts) to other repositories and thus reducing the number of references which speeds up querying the repo since less other repositories have to be queried.

I think this becomes more relevant since one can now add repository references automatically and for example not all repos referenced in the TP are actually relevant for a p2-repository build for a project.
While with one can explicitly filter references with https://github.com/eclipse-tycho/tycho/pull/2742, the user should not need to carry the burden to check manually which repos are relevant for the assembled repository. Instead Tycho should be smart enough to check that (and with this PR it can).

In detail  his PR consists of three commits
1. Minor code enhancements in p2-repository assembling code (will move that to a separate PR once settled)
2. Suppress addition of unnecessary repo-refereces when assembling p2-repos
3. Print added repository-references as info, when assembly a p2-repository

Adding some information about added repo-references in the log seems to be reasonable since it is now not obvious anymore with auto-addition, explicit and implicit filtering which references actually end up in the repo.

Similar to https://github.com/eclipse-tycho/tycho/pull/2742#issuecomment-1704421421 we could consider to activate this auto-filtering only for those references that are added automatically, because one might have added an effectively empty repo on purpose.
The logging could also only activated if automatic addition is enabled.



Btw. for M2E this reduces the list of added references from 9 to 6:
```
https://download.eclipse.org/eclipse/updates/4.28/
https://download.eclipse.org/egit/updates-6.6/
https://download.eclipse.org/modeling/emf/emf/builds/release/2.34.0
https://download.eclipse.org/webtools/downloads/drops/R3.28.0/R-3.28.0-20221120050827/repository/
https://download.eclipse.org/wildwebdeveloper/releases/1.3.0/
https://download.eclipse.org/tm4e/releases/0.8.1/
https://download.eclipse.org/lsp4e/releases/0.23.0/
https://download.eclipse.org/lsp4j/updates/releases/0.21.0/
https://download.eclipse.org/cbi/updates/license/
```
to
```
https://download.eclipse.org/lsp4j/updates/releases/0.21.0/
https://download.eclipse.org/eclipse/updates/4.28/
https://download.eclipse.org/webtools/downloads/drops/R3.28.0/R-3.28.0-20221120050827/repository/
https://download.eclipse.org/wildwebdeveloper/releases/1.3.0/
https://download.eclipse.org/modeling/emf/emf/builds/release/2.34.0
https://download.eclipse.org/tm4e/releases/0.8.1/
```


Currently this includes work-arounds for the following pending P2 PRs that are not available before December.
- https://github.com/eclipse-equinox/p2/pull/311
- https://github.com/eclipse-equinox/p2/pull/312
- https://github.com/eclipse-equinox/p2/pull/314 