### PR TITLE
Fix DependencyComputer missing bundles when they have different versions

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DependencyComputer.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DependencyComputer.java
@@ -119,6 +119,11 @@ public class DependencyComputer {
         public Version getVersion() {
             return getRevision().getVersion();
         }
+
+        @Override
+        public String toString() {
+            return "DependencyEntry [module=" + module + ", rules=" + rules + "]";
+        }
     }
 
     private final class VisiblePackages {
@@ -182,7 +187,7 @@ public class DependencyComputer {
         // sort by symbolicName_version to get a consistent order
         Map<String, BundleRevision> resolvedImportPackages = new TreeMap<>();
         for (BundleRevision bundle : visiblePackages.getParticipatingModules()) {
-            resolvedImportPackages.put(bundle.getSymbolicName(), bundle);
+            resolvedImportPackages.put(bundle.getSymbolicName() + "_" + bundle.getVersion(), bundle);
         }
         for (BundleRevision bundle : resolvedImportPackages.values()) {
             addDependencyViaImportPackage(bundle, added, visiblePackages, entries);


### PR DESCRIPTION
Currently the DependencyComputer sorts only by bundle name (even though the comment for the code mentions the version as well) this can lead to the situation that if a bundle requires the same bundle in different versions (e.g. because it has actually different package names like javax -> jakarta) it only gets one of both on the classpath even though the P2 input suggests both.

This simply enhances the used key in the mak with the version as already suggested by the java comment.