### PR TITLE
Simplify repository assembling and reference filtering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,9 +40,9 @@ can now be filtered by their location using exclusion and inclusion patterns and
 		<repositoryReferenceFilter>
 			<exclude>
 				<location>https://foo.bar.org/hidden/**</location>
-				<location>https://foo.bar.org/secret/**</location>
+				<location> %regex[http(s)?:\/\/foo\.bar\.org\/secret\/.*]</location>
+				<location>![https://foo.bar.org/**]</location>
 			</exclude>
-			<include>%regex[http(s)?:\/\/foo\.bar\.org\/.*]</include>
 		</repositoryReferenceFilter>
 	</configuration>
 </plugin>

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -111,7 +111,7 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     private Map<String, String> resolverProfileProperties = new HashMap<>();
 
-    List<Supplier<File>> lazyTargetFiles = new ArrayList<>();
+    private final List<Supplier<File>> lazyTargetFiles = new ArrayList<>();
 
     private LocalArtifactHandling localArtifactHandling;
 
@@ -240,10 +240,7 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     }
 
     public List<TargetPlatformFilter> getFilters() {
-        if (filters == null)
-            return Collections.emptyList();
-        else
-            return filters;
+        return filters == null ? Collections.emptyList() : filters;
     }
 
     public DependencyResolverConfiguration getDependencyResolverConfiguration() {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/DestinationRepositoryDescriptor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/DestinationRepositoryDescriptor.java
@@ -19,8 +19,8 @@ import java.util.Map;
 
 public class DestinationRepositoryDescriptor {
 
-    final File location;
-    final String name;
+    private final File location;
+    private final String name;
     private final boolean compress;
     private final boolean xzCompress;
     private final boolean keepNonXzIndexFiles;
@@ -43,8 +43,14 @@ public class DestinationRepositoryDescriptor {
         this.repositoryReferences = repositoryReferences;
     }
 
+    public DestinationRepositoryDescriptor(File location, String name, boolean compress, boolean xzCompress,
+            boolean keepNonXzIndexFiles, boolean metaDataOnly, boolean append) {
+        this(location, name, compress, xzCompress, keepNonXzIndexFiles, metaDataOnly, append, Collections.emptyMap(),
+                Collections.emptyList());
+    }
+
     public DestinationRepositoryDescriptor(File location, String name) {
-        this(location, name, true, true, false, false, true, Collections.emptyMap(), Collections.emptyList());
+        this(location, name, true, true, false, false, true);
     }
 
     public File getLocation() {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -236,8 +236,7 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
 
     private static TychoMirrorApplication createMirrorApplication(RepositoryReferences sources,
             DestinationRepositoryDescriptor destination, IProvisioningAgent agent) {
-        final TychoMirrorApplication mirrorApp = new TychoMirrorApplication(agent,
-                destination.getExtraArtifactRepositoryProperties(), destination.getRepositoryReferences());
+        final TychoMirrorApplication mirrorApp = new TychoMirrorApplication(agent, destination);
         mirrorApp.setRaw(false);
 
         List<RepositoryDescriptor> sourceDescriptors = createSourceDescriptors(sources);
@@ -438,7 +437,7 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
         repo.save();
         DestinationRepositoryDescriptor desc = new DestinationRepositoryDescriptor(repository, repo.getName(),
                 new File(repository, "artifacts.xml.xz").exists(), new File(repository, "artifacts.xml.xz").exists(),
-                true, false, false, Collections.emptyMap(), Collections.emptyList());
+                true, false, false);
         xzCompress(desc);
     }
 }

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
@@ -246,8 +246,7 @@ public class MirrorMojo extends AbstractMojo {
             name = "";
         }
         final DestinationRepositoryDescriptor destinationDescriptor = new DestinationRepositoryDescriptor(destination,
-                name, compress, xzCompress, keepNonXzIndexFiles, mirrorMetadataOnly, append, Collections.emptyMap(),
-                Collections.emptyList());
+                name, compress, xzCompress, keepNonXzIndexFiles, mirrorMetadataOnly, append);
         getLog().info("Mirroring to " + destination);
         try {
             mirrorService.mirrorStandalone(sourceDescriptor, destinationDescriptor, createIUDescriptions(),

--- a/tycho-its/projects/p2Repository.repositoryRef.filter/pom.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.filter/pom.xml
@@ -45,8 +45,8 @@
 						<exclude>
 							<location>https://download.eclipse.org/lsp4e/**</location>
 							<location>https://download.eclipse.org/lsp4j/**</location>
+							<location>![%regex[http(s)?:\/\/download\.eclipse\.org\/.*]]</location>
 						</exclude>
-						<include>%regex[http(s)?:\/\/download\.eclipse\.org\/.*]</include>
 					</repositoryReferenceFilter>
 				</configuration>
 			</plugin>

--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/FixArtifactsMetadataMetadataMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/FixArtifactsMetadataMetadataMojo.java
@@ -13,7 +13,6 @@
 package org.eclipse.tycho.plugins.p2.repository;
 
 import java.io.File;
-import java.util.Collections;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -73,8 +72,7 @@ public class FixArtifactsMetadataMetadataMojo extends AbstractRepositoryMojo {
                             "Could not update p2 repository, directory does not exist: " + destination);
                 }
                 DestinationRepositoryDescriptor destinationRepoDescriptor = new DestinationRepositoryDescriptor(
-                        destination, repositoryName, true, xzCompress, keepNonXzIndexFiles, false, true,
-                        Collections.emptyMap(), Collections.emptyList());
+                        destination, repositoryName, true, xzCompress, keepNonXzIndexFiles, false, true);
                 mirrorApp.recreateArtifactRepository(destinationRepoDescriptor);
             } catch (FacadeException e) {
                 throw new MojoExecutionException("Could not update p2 repository", e);


### PR DESCRIPTION
This PR contains the simplification parts of https://github.com/eclipse-tycho/tycho/pull/2744.
These are code simplifications and a simplification in the logic of how to specify the filters.

Instead of providing _inclusion_ and _exclusion_ patterns, just use exclusions, but add a simple way to negate a pattern.
A negated exclusion is effectively an inclusion but it should be more clear how inclusion and exclusions work together, as the current definition can be potentially confusing: https://github.com/eclipse-tycho/tycho/pull/2744#discussion_r1316689867
