### PR TITLE
Support assembling and archiving repositories in parallel

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/FileLockService.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/FileLockService.java
@@ -37,4 +37,10 @@ public interface FileLockService {
      * advisory only, i.e. all processes must use the same locking mechanism.
      */
     Closeable lock(File file, long timeout);
+
+    /**
+     * Locks the given file for this JVM to protect read/write access from multiple threads in this
+     * JVM on it.
+     */
+    Closeable lockVirtually(File file);
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/locking/FileLockServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/locking/FileLockServiceImpl.java
@@ -19,30 +19,56 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.FileLockService;
+import org.eclipse.tycho.LockTimeoutException;
 
 @Component(role = FileLockService.class)
 public class FileLockServiceImpl implements FileLockService {
+    record FileLocks(FileLockerImpl fileLocker, Lock vmLock) {
+    }
 
-    private final Map<Path, FileLockerImpl> lockers = new ConcurrentHashMap<>();
+    private final Map<Path, FileLocks> lockers = new ConcurrentHashMap<>();
 
     @Override
     public Closeable lock(File file, long timeout) {
-        FileLockerImpl locker = getFileLocker(file.toPath());
+        FileLocks locks = getFileLocker(file.toPath());
+        FileLockerImpl locker = locks.fileLocker();
+        try {
+            if (!locks.vmLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                throw new LockTimeoutException("lock timeout: Could not acquire lock on file " + locker.lockMarkerFile
+                        + " for " + timeout + " msec");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LockTimeoutException("Interrupted", e);
+        }
         locker.lock(timeout);
-        return locker::release;
+        return () -> {
+            locks.fileLocker().release();
+            locks.vmLock().unlock();
+        };
     }
 
-    FileLockerImpl getFileLocker(Path file) {
+    @Override
+    public Closeable lockVirtually(File file) {
+        FileLocks locks = getFileLocker(file.toPath());
+        locks.vmLock().lock();
+        return locks.vmLock()::unlock;
+    }
+
+    FileLocks getFileLocker(Path file) {
         Path key;
         try {
             key = file.toRealPath();
         } catch (IOException e) {
             key = file.toAbsolutePath().normalize();
         }
-        return lockers.computeIfAbsent(key, FileLockerImpl::new);
+        return lockers.computeIfAbsent(key, f -> new FileLocks(new FileLockerImpl(f), new ReentrantLock()));
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/locking/FileLockServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/locking/FileLockServiceTest.java
@@ -149,7 +149,7 @@ public class FileLockServiceTest {
     }
 
     private Path getLockMarkerFile(File file) {
-        return subject.getFileLocker(file.toPath()).lockMarkerFile;
+        return subject.getFileLocker(file.toPath()).fileLocker().lockMarkerFile;
     }
 
     private boolean isLocked(File file) throws IOException {

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/NoopFileLockService.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/NoopFileLockService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2012 SAP SE and others.
+ * Copyright (c) 2011, 2023 SAP SE and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,11 @@ public class NoopFileLockService implements FileLockService {
 
     @Override
     public Closeable lock(File file, long timeout) {
+        return lockVirtually(file);
+    }
+
+    @Override
+    public Closeable lockVirtually(File file) {
         return () -> {
         };
     }


### PR DESCRIPTION
Assembling and arching repositories is a relatively long running task and repository-projects are usually build as one of the last projects in the reactor. So the chances are relatively high, that (if multiple projects are present) multiple repositories are assembled at the same. Therefore it should be possible to build multiple repositories in parallel and there should not be one global lock for each repository-related mojo.