### PR TITLE
Assemble repository for all environments at once

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,6 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.equinox.p2.planner.IPlanner;
 import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
-import org.eclipse.equinox.p2.query.CompoundQueryable;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryResult;
 import org.eclipse.equinox.p2.query.IQueryable;
@@ -52,6 +52,7 @@ import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.tycho.TargetEnvironment;
 
 public class MirrorApplication extends AbstractApplication implements IApplication, IExecutableExtension {
     private static final String DEFAULT_COMPARATOR = ArtifactChecksumComparator.COMPARATOR_ID + ".sha-256"; //$NON-NLS-1$
@@ -59,6 +60,7 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
     private static final String MIRROR_MODE = "metadataOrArtifacts"; //$NON-NLS-1$
 
     protected SlicingOptions slicingOptions = new SlicingOptions();
+    protected List<TargetEnvironment> environments = new ArrayList<>();
 
     private URI baseline;
     private String comparatorID;
@@ -397,22 +399,35 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
     }
 
     private IQueryable<IInstallableUnit> performResolution(IProgressMonitor monitor) throws ProvisionException {
+        List<Map<String, String>> filters = getContextFilters();
         IProfileRegistry registry = getProfileRegistry();
         String profileId = "MirrorApplication-" + System.currentTimeMillis(); //$NON-NLS-1$
-        IProfile profile = registry.addProfile(profileId, slicingOptions.getFilter());
-        IPlanner planner = agent.getService(IPlanner.class);
-        if (planner == null)
-            throw new IllegalStateException();
-        IProfileChangeRequest pcr = planner.createChangeRequest(profile);
-        pcr.addAll(sourceIUs);
-        IProvisioningPlan plan = planner.getProvisioningPlan(pcr, null, monitor);
-        registry.removeProfile(profileId);
-        @SuppressWarnings("unchecked")
-        IQueryable<IInstallableUnit>[] arr = new IQueryable[plan.getInstallerPlan() == null ? 1 : 2];
-        arr[0] = plan.getAdditions();
-        if (plan.getInstallerPlan() != null)
-            arr[1] = plan.getInstallerPlan().getAdditions();
-        return new CompoundQueryable<>(arr);
+        List<IQueryable<IInstallableUnit>> queryables = new ArrayList<>();
+        for (Map<String, String> filter : filters) {
+            IProfile profile = registry.addProfile(profileId, filter);
+            IPlanner planner = agent.getService(IPlanner.class);
+            if (planner == null) {
+                throw new IllegalStateException();
+            }
+            IProfileChangeRequest pcr = planner.createChangeRequest(profile);
+            pcr.addAll(sourceIUs);
+            IProvisioningPlan plan = planner.getProvisioningPlan(pcr, null, monitor);
+            registry.removeProfile(profileId);
+            queryables.add(plan.getAdditions());
+            IProvisioningPlan installerPlan = plan.getInstallerPlan();
+            if (installerPlan != null) {
+                queryables.add(installerPlan.getAdditions());
+            }
+        }
+        return QueryUtil.compoundQueryable(queryables);
+    }
+
+    protected List<Map<String, String>> getContextFilters() {
+        return environments.isEmpty() ? List.of(slicingOptions.getFilter()) : environments.stream().map(environment -> {
+            Map<String, String> filter = new HashMap<>(slicingOptions.getFilter());
+            filter.putAll(environment.toFilterProperties());
+            return filter;
+        }).toList();
     }
 
     private IProfileRegistry getProfileRegistry() throws ProvisionException {
@@ -450,6 +465,10 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
                 options.includeOptionalDependencies(), options.isEverythingGreedy(), options.forceFilterTo(),
                 options.considerStrictDependencyOnly(), options.followOnlyFilteredRequirements());
         return slicer;
+    }
+
+    public void setEnvironments(List<TargetEnvironment> environments) {
+        this.environments = environments;
     }
 
     public void setSlicingOptions(SlicingOptions options) {


### PR DESCRIPTION
This is helpful for https://github.com/eclipse-tycho/tycho/pull/2744 since the full resulting repository is available on the first pass.

Additionally it can improve the performance since all IUs are only processed once instead of once per environment (which applies for all IUs without environment filter) and it avoids multiplication of print-outs for each environment.