### PR TITLE
Introduce a public static constant for the current eclipse release

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -16,6 +16,9 @@ package org.eclipse.tycho;
 import java.util.regex.Pattern;
 
 public interface TychoConstants {
+
+    public static final String ECLIPSE_LATEST = "https://download.eclipse.org/releases/2023-09/";
+
     static final String ANY_QUALIFIER = "qualifier";
 
     static final boolean USE_SMART_BUILDER = Boolean

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisMojo.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisMojo.java
@@ -77,8 +77,6 @@ public class ApiAnalysisMojo extends AbstractMojo {
 
 	static final String BUNDLE_CORE = "org.eclipse.core.runtime";
 
-	private static final String REPO_DEFAULT = "https://download.eclipse.org/releases/2023-06/";
-
 	@Parameter(property = "plugin.artifacts")
 	protected List<Artifact> pluginArtifacts;
 
@@ -183,7 +181,7 @@ public class ApiAnalysisMojo extends AbstractMojo {
 
 	private MavenRepositoryLocation getRepository() {
 		if (apiToolsRepository == null || apiToolsRepository.getUrl() == null) {
-			return new MavenRepositoryLocation(null, URI.create(REPO_DEFAULT));
+			return new MavenRepositoryLocation(null, URI.create(TychoConstants.ECLIPSE_LATEST));
 		}
 		return new MavenRepositoryLocation(apiToolsRepository.getId(), URI.create(apiToolsRepository.getUrl()));
 	}

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/DocApplicationManager.java
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/DocApplicationManager.java
@@ -20,16 +20,16 @@ import org.apache.maven.model.Repository;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.tycho.MavenRepositoryLocation;
+import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.osgi.framework.EclipseApplication;
 import org.eclipse.tycho.osgi.framework.EclipseApplicationFactory;
 
 @Component(role = DocApplicationManager.class)
 public class DocApplicationManager {
-	private static final String REPO_DEFAULT = "https://download.eclipse.org/releases/2023-03/";
 
 	static MavenRepositoryLocation getRepository(Repository location) {
 		if (location == null) {
-			return new MavenRepositoryLocation(null, URI.create(REPO_DEFAULT));
+			return new MavenRepositoryLocation(null, URI.create(TychoConstants.ECLIPSE_LATEST));
 		}
 		return new MavenRepositoryLocation(location.getId(), URI.create(location.getUrl()));
 	}


### PR DESCRIPTION
This should make it less cumbersome to update things in the future.