### PR TITLE
Return the maven location for missing junit bundles

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/BundlePublisher.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/BundlePublisher.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactDescriptor;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.publisher.IPublisherAdvice;
 import org.eclipse.equinox.p2.publisher.IPublisherInfo;
 import org.eclipse.equinox.p2.publisher.PublisherInfo;
 import org.eclipse.equinox.p2.publisher.actions.IPropertyAdvice;
@@ -37,13 +38,17 @@ public class BundlePublisher extends BundlesAction {
         super(new BundleDescription[] { bundleDescription });
     }
 
-    public static Optional<IInstallableUnit> getBundleIU(File bundleLocation) throws IOException, BundleException {
+    public static Optional<IInstallableUnit> getBundleIU(File bundleLocation, IPublisherAdvice... advices)
+            throws IOException, BundleException {
         BundleDescription bundleDescription = BundlesAction.createBundleDescription(bundleLocation);
         if (bundleDescription == null) {
             //seems it is not a bundle
             return Optional.empty();
         }
         PublisherInfo publisherInfo = new PublisherInfo();
+        for (IPublisherAdvice advice : advices) {
+            publisherInfo.addAdvice(advice);
+        }
         publisherInfo.setArtifactOptions(IPublisherInfo.A_INDEX);
         String symbolicName = bundleDescription.getSymbolicName();
         if (symbolicName == null) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/MissingBundlesArtifactFileProvider.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/MissingBundlesArtifactFileProvider.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2resolver;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
+import org.eclipse.equinox.p2.query.IQuery;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.tycho.ArtifactSinkException;
+import org.eclipse.tycho.IArtifactSink;
+import org.eclipse.tycho.IRawArtifactFileProvider;
+import org.eclipse.tycho.IRawArtifactSink;
+
+class MissingBundlesArtifactFileProvider implements IRawArtifactFileProvider {
+
+    private Map<IArtifactKey, File> mappedFiles = new HashMap<>();
+
+    @Override
+    public File getArtifactFile(IArtifactKey key) {
+        return mappedFiles.get(key);
+    }
+
+    @Override
+    public boolean isFileAlreadyAvailable(IArtifactKey artifactKey) {
+        return contains(artifactKey);
+    }
+
+    @Override
+    public boolean contains(IArtifactKey key) {
+        return mappedFiles.containsKey(key);
+    }
+
+    @Override
+    public IStatus getArtifact(IArtifactSink sink, IProgressMonitor monitor) throws ArtifactSinkException {
+        return Status.CANCEL_STATUS;
+    }
+
+    @Override
+    public IQueryResult<IArtifactKey> query(IQuery<IArtifactKey> query, IProgressMonitor monitor) {
+        return query.perform(mappedFiles.keySet().iterator());
+    }
+
+    @Override
+    public IArtifactDescriptor[] getArtifactDescriptors(IArtifactKey key) {
+        return new IArtifactDescriptor[0];
+    }
+
+    @Override
+    public boolean contains(IArtifactDescriptor descriptor) {
+        return false;
+    }
+
+    @Override
+    public IStatus getRawArtifact(IRawArtifactSink sink, IProgressMonitor monitor) throws ArtifactSinkException {
+        return Status.CANCEL_STATUS;
+    }
+
+    @Override
+    public File getArtifactFile(IArtifactDescriptor descriptor) {
+
+        return getArtifactFile(descriptor.getArtifactKey());
+    }
+
+    void add(IArtifactKey key, File file) {
+        mappedFiles.put(key, file);
+    }
+
+}


### PR DESCRIPTION
Currently we only publish the meta-data, what works for most of the time if a junit bundle is missing, but for the case where the bundle name does not match the artifact key (e.g. junit4/hamcrest) this leads to Tycho not find the file and injecting a dummy file that can confuse maven-surefire-plugin.

This now adds a new IRawArtifactFileProvider provider for such missing bundles that is asked as last resort if no other part of the system can answer for a file.