### PR TITLE
[Tycho 4.0.x] Suppress addition of unnecessary repo-refereces when assembling p2-repos

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,11 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ### new option to filter added repository-references when assembling a p2-repository
 
-The repository references automatically added to a assembled p2-repository (via `tycho-p2-repository-plugin`'s `addIUTargetRepositoryReferences` or `addPomRepositoryReferences`) 
-can now be filtered by their location using exclusion and inclusion patterns and therefore allows more fine-grained control which references are added.
+If filtering provided artifacts is enabled, the repository references automatically added to a assembled p2-repository
+(via `tycho-p2-repository-plugin`'s `addIUTargetRepositoryReferences` or `addPomRepositoryReferences`) can now be filtered by their location
+using exclusion and inclusion patterns and therefore allows more fine-grained control which references are added.
+Additionally the automatically added references can be filter based on if they provide any of the filtered units or not.
+If `addOnlyProviding` is `true` repositories that don't provide any filtered unit are not added to the assembled repo.
 ```xml
 <plugin>
 	<groupId>org.eclipse.tycho</groupId>
@@ -16,6 +19,7 @@ can now be filtered by their location using exclusion and inclusion patterns and
 	<configuration>
 		... other configuration options ...
 		<repositoryReferenceFilter>
+			<addOnlyProviding>true</addOnlyProviding>
 			<exclude>
 				<location>https://foo.bar.org/hidden/**</location>
 				<location>%regex[http(s)?:\/\/foo\.bar\.org\/secret\/.*]</location>

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/DestinationRepositoryDescriptor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/DestinationRepositoryDescriptor.java
@@ -28,10 +28,12 @@ public class DestinationRepositoryDescriptor {
     private final boolean append;
     private final Map<String, String> extraArtifactRepositoryProperties;
     private final List<RepositoryReference> repositoryReferences;
+    private final List<RepositoryReference> filterablRepositoryReferences;
 
     public DestinationRepositoryDescriptor(File location, String name, boolean compress, boolean xzCompress,
             boolean keepNonXzIndexFiles, boolean metaDataOnly, boolean append,
-            Map<String, String> extraArtifactRepositoryProperties, List<RepositoryReference> repositoryReferences) {
+            Map<String, String> extraArtifactRepositoryProperties, List<RepositoryReference> repositoryReferences,
+            List<RepositoryReference> filterablRepositoryReferences) {
         this.location = location;
         this.name = name;
         this.compress = compress;
@@ -41,12 +43,13 @@ public class DestinationRepositoryDescriptor {
         this.append = append;
         this.extraArtifactRepositoryProperties = extraArtifactRepositoryProperties;
         this.repositoryReferences = repositoryReferences;
+        this.filterablRepositoryReferences = filterablRepositoryReferences;
     }
 
     public DestinationRepositoryDescriptor(File location, String name, boolean compress, boolean xzCompress,
             boolean keepNonXzIndexFiles, boolean metaDataOnly, boolean append) {
         this(location, name, compress, xzCompress, keepNonXzIndexFiles, metaDataOnly, append, Collections.emptyMap(),
-                Collections.emptyList());
+                Collections.emptyList(), Collections.emptyList());
     }
 
     public DestinationRepositoryDescriptor(File location, String name) {
@@ -87,5 +90,9 @@ public class DestinationRepositoryDescriptor {
 
     public List<RepositoryReference> getRepositoryReferences() {
         return repositoryReferences == null ? Collections.emptyList() : repositoryReferences;
+    }
+
+    public List<RepositoryReference> getFilterableRepositoryReferences() {
+        return filterablRepositoryReferences;
     }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
@@ -54,7 +54,11 @@ public interface MirrorApplicationService {
      *            Whether to include bundles mentioned in the require section of a feature
      * @param includeRequiredFeatures
      *            Whether to include features mentioned in the require section of a feature
-     * @param filterProvided Whether to filter IU/artifacts that are already provided by a referenced repository
+     * @param filterProvided
+     *            Whether to filter IU/artifacts that are already provided by a referenced
+     *            repository
+     * @param addOnlyProvidingRepoReferences
+     *            Whether to add only repository-references that provide any relevant IU
      * @param filterProperties
      *            additional filter properties to be set in the p2 slicing options. May be
      *            <code>null</code>
@@ -64,7 +68,8 @@ public interface MirrorApplicationService {
     public void mirrorReactor(RepositoryReferences sources, DestinationRepositoryDescriptor destination,
             Collection<DependencySeed> seeds, BuildContext context, boolean includeAllDependencies,
             boolean includeAllSource, boolean includeRequiredBundles, boolean includeRequiredFeatures,
-            boolean filterProvided, Map<String, String> filterProperties) throws FacadeException;
+            boolean filterProvided, boolean addOnlyProvidingRepoReferences, Map<String, String> filterProperties)
+            throws FacadeException;
 
     /**
      * recreates the metadata of an existing repository e.g. to account for changes in the contained

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -152,7 +152,8 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
     public void mirrorReactor(RepositoryReferences sources, DestinationRepositoryDescriptor destination,
             Collection<DependencySeed> projectSeeds, BuildContext context, boolean includeAllDependencies,
             boolean includeAllSource, boolean includeRequiredBundles, boolean includeRequiredFeatures,
-            boolean filterProvided, Map<String, String> filterProperties) throws FacadeException {
+            boolean filterProvided, boolean addOnlyProvidingRepoReferences, Map<String, String> filterProperties)
+            throws FacadeException {
         final TychoMirrorApplication mirrorApp = createMirrorApplication(sources, destination, agent);
 
         // mirror scope: seed units...
@@ -163,6 +164,7 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
         mirrorApp.setIncludeRequiredFeatures(includeRequiredFeatures);
         mirrorApp.setIncludePacked(false); // no way, Tycho do no longer support packed artifacts anyways
         mirrorApp.setFilterProvided(filterProvided);
+        mirrorApp.setAddOnlyProvidingRepoReferences(addOnlyProvidingRepoReferences);
         mirrorApp.setEnvironments(context.getEnvironments());
         SlicingOptions options = new SlicingOptions();
         options.considerStrictDependencyOnly(!includeAllDependencies);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/TychoMirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/TychoMirrorApplication.java
@@ -64,9 +64,12 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.p2.tools.DestinationRepositoryDescriptor;
 import org.eclipse.tycho.p2.tools.RepositoryReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfromp2.MirrorApplication {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TychoMirrorApplication.class);
     private static final String SOURCE_SUFFIX = ".source";
     private static final String FEATURE_GROUP = ".feature.group";
     private final DestinationRepositoryDescriptor destination;
@@ -210,6 +213,16 @@ public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfrom
         // In order to avoid stripping of slashes from URI instances do it now before URIs are created.
         String location = r.getLocation();
         return URI.create(location.endsWith("/") ? location.substring(0, location.length() - 1) : location);
+    }
+
+    @Override
+    protected void finalizeRepositories() {
+        Collection<IRepositoryReference> references = getDestinationMetadataRepository().getReferences();
+        if (!references.isEmpty()) {
+            LOGGER.info("Adding references to the following repositories:");
+            references.stream().map(r -> r.getLocation()).distinct().forEach(loc -> LOGGER.info("  {}", loc));
+        }
+        super.finalizeRepositories();
     }
 
     @Override

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceTest.java
@@ -101,13 +101,13 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         Collection<DependencySeed> noSeeds = Collections.emptyList();
 
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, noSeeds, context, false, false, false,
-                false, false, null);
+                false, false, false, null);
     }
 
     @Test
     public void testMirrorFeatureWithContent() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false,
-                false, false, false, false, null);
+                false, false, false, false, false, null);
 
         logVerifier.expectNoWarnings();
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.4.0.v20080512.jar").exists());
@@ -121,9 +121,10 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         extraArtifactRepositoryProperties.put("p2.mirrorsURL", "http://some.where.else");
         extraArtifactRepositoryProperties.put("foo", "bar");
         destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest2"), DEFAULT_NAME, false, false,
-                false, false, true, extraArtifactRepositoryProperties, Collections.emptyList());
+                false, false, true, extraArtifactRepositoryProperties, Collections.emptyList(),
+                Collections.emptyList());
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false,
-                false, false, false, false, null);
+                false, false, false, false, false, null);
 
         logVerifier.expectNoWarnings();
         File artifactsXml = repoFile(destinationRepo, "artifacts.xml");
@@ -146,7 +147,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
     @Test
     public void testMirrorPatch() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e352"), destinationRepo, seedFor(FEATURE_PATCH_IU), context, false,
-                false, false, false, false, null);
+                false, false, false, false, false, null);
 
         //TODO why mirror tool emits a warning here?        logVerifier.expectNoWarnings();
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.5.0.v20090525.jar").exists());
@@ -156,7 +157,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
     @Test
     public void testMirrorFeatureAndPatch() throws Exception {
         subject.mirrorReactor(sourceRepos("patch", "e352"), destinationRepo,
-                seedFor(SIMPLE_FEATURE_IU, FEATURE_PATCH_IU), context, false, false, false, false, false, null);
+                seedFor(SIMPLE_FEATURE_IU, FEATURE_PATCH_IU), context, false, false, false, false, false, false, null);
 
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.5.0.v20090525.jar").exists());
         assertTrue(repoFile(destinationRepo, "features/" + SIMPLE_FEATURE + "_1.0.0.jar").exists());
@@ -175,7 +176,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
          * warning is issued.
          */
         subject.mirrorReactor(sourceRepos("patch"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false, false,
-                false, false, false, null);
+                false, false, false, false, null);
 
         logVerifier.expectWarning(not(is("")));
     }
@@ -189,7 +190,8 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         List<DependencySeed> seeds = Collections
                 .singletonList(new DependencySeed(null, "org.eclipse.core.runtime", null));
 
-        subject.mirrorReactor(sourceRepos("e342"), destinationRepo, seeds, context, false, false, false, false, false, null);
+        subject.mirrorReactor(sourceRepos("e342"), destinationRepo, seeds, context, false, false, false, false, false,
+                false, null);
 
         assertTrue(repoFile(destinationRepo, "plugins/org.eclipse.core.runtime_3.4.0.v20080512.jar").exists());
     }

--- a/tycho-its/projects/p2Repository.repositoryRef.filter.providing/category.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.filter.providing/category.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <bundle id="org.eclipse.emf.ecore"/>
+   <repository-reference location="https://download.eclipse.org/cbi/updates/license" enabled="true" />
+</site>

--- a/tycho-its/projects/p2Repository.repositoryRef.filter.providing/pom.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.filter.providing/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<version>1.0.0</version>
+	<groupId>tycho-its-project.p2Repository.repositoryRef.location</groupId>
+	<artifactId>repositoryRef.location</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<repositories>
+		<!-- Add one that is removed because it contributes nothing, it's content is entirly provided by another. And one that would be removed but is added to the  category explicity-->
+		<repository>
+			<id>repo0</id>
+			<url>https://download.eclipse.org/eclipse/updates/4.29/</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>repo-provided-by-others</id>
+			<url>https://download.eclipse.org/modeling/emf/emf/builds/release/2.35.0</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>an-unused-repo</id>
+			<url>https://download.eclipse.org/egit/updates-6.7/</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>an-unused-repo-but-added-explicitly-in-category-xml</id>
+			<url>https://download.eclipse.org/cbi/updates/license</url>
+			<layout>p2</layout>
+		</repository>
+		
+	</repositories>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<compress>false</compress>
+					<includeAllDependencies>true</includeAllDependencies>
+					<includeAllSources>true</includeAllSources>
+					<filterProvided>true</filterProvided>
+					<addPomRepositoryReferences>true</addPomRepositoryReferences>
+					<repositoryReferenceFilter>
+						<addOnlyProviding>true</addOnlyProviding>
+					</repositoryReferenceFilter>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -75,8 +74,17 @@ import aQute.bnd.repository.fileset.FileSetRepository;
 public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
 
     public static class RepositoryReferenceFilter {
+        /**
+         * If {@link #filterProvided} is {@code true} and repository references are added
+         * automatically via {@link #addIUTargetRepositoryReferences} or
+         * {@link #addPomRepositoryReferences}, then this property controls if from the
+         * automatically added ones only references to those repositories are added, that provide
+         * relevant content, which is not provided by any other referenced repositories. If this is
+         * set to {@code false} all automatically added references are added as they are available.
+         */
+        public boolean addOnlyProviding = false;
         /** The list of location patterns that exclude matching repository references. */
-        List<String> exclude = List.of();
+        public List<String> exclude = List.of();
     }
 
     private static final Object LOCK = new Object();
@@ -224,20 +232,32 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
     private boolean addIUTargetRepositoryReferences;
 
     /**
-     * A list of patterns to exclude automatically derived repository references from being added to
-     * the assembled repository.
+     * Filters to exclude automatically derived repository references from being added to the
+     * assembled repository.
+     * 
      * <p>
+     * Repository references can be filtered based on their location URI using a list of exclusion
+     * pattern:<br>
      * The location of a reference must not be matched by any pattern, in order to be eventually
-     * added to the assembled repository. An arbitrary number of patterns can be specified.<br>
-     * The specified filters are only applied to those repository references derived from the
+     * added to the assembled repository. An arbitrary number of patterns can be specified.
+     * </p>
+     * <p>
+     * If the sub-property {@code addOnlyProviding} is set to {@code true}, references to
+     * repositories that don't provide any relevant unit are excluded from being added to the
+     * assembled repository.
+     * </p>
+     * <p>
+     * All those filters are only applied to those repository references derived from the
      * target-definition or pom file, when {@link #addIUTargetRepositoryReferences} respectively
-     * {@link #addPomRepositoryReferences} is set to {@code true}.
+     * {@link #addPomRepositoryReferences} is set {@code true}. References explicitly listed in the
+     * repository file ({@code category.xml}) are always added.
      * </p>
      * <p>
      * Configuration example 1
      * 
      * <pre>
      * &lt;repositoryReferenceFilter&gt;
+     *   &lt;addOnlyProviding&gt;true&lt;/addOnlyProviding&gt;
      *   &lt;exclude&gt;https://foo.bar.org/hidden/**&lt;/exclude&gt;
      * &lt;/repositoryReferenceFilter&gt;
      * </pre>
@@ -246,6 +266,7 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
      * 
      * <pre>
      * &lt;repositoryReferenceFilter&gt;
+     *   &lt;addOnlyProviding&gt;false&lt;/addOnlyProviding&gt;
      *   &lt;exclude&gt;
      *     &lt;location&gt;https://foo.bar.org/hidden/**&lt;/location&gt;
      *     &lt;location&gt;%regex[http(s)?:\/\/foo\.bar\.org\/secret\/.*]&lt;/location&gt;
@@ -259,7 +280,8 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
      * {@code %regex[<the-regex-pattern>]}). <br>
      * The third pattern is a negated (enclosed in {@code ![<the-negated-pattern>]}), which
      * effectively makes it an <em>inclusion</em> pattern that all references must match in order to
-     * be added.
+     * be added. Unlike in the first example, in the second example all references that pass the
+     * location filter are added, regardless of if the provide any unit or not.
      * </p>
      */
     @Parameter
@@ -312,14 +334,15 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
                         .map(Category::getRepositoryReferences)//
                         .flatMap(List::stream)//
                         .map(ref -> new RepositoryReference(ref.getName(), ref.getLocation(), ref.isEnabled()))//
-                        .collect(Collectors.toCollection(ArrayList::new));
+                        .toList();
                 Predicate<String> autoReferencesFilter = buildRepositoryReferenceLocationFilter();
+                List<RepositoryReference> autoRepositoryRefeferences = new ArrayList<>();
                 if (addPomRepositoryReferences) {
                     getProject().getRepositories().stream() //
                             .filter(pomRepo -> "p2".equals(pomRepo.getLayout()))
                             .filter(pomRepo -> autoReferencesFilter.test(pomRepo.getUrl()))
                             .map(pomRepo -> new RepositoryReference(pomRepo.getName(), pomRepo.getUrl(), true))
-                            .forEach(repositoryReferences::add);
+                            .forEach(autoRepositoryRefeferences::add);
                 }
                 if (addIUTargetRepositoryReferences) {
                     projectManager.getTargetPlatformConfiguration(getProject()).getTargets().stream()
@@ -328,14 +351,15 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
                             .flatMap(iu -> iu.getRepositories().stream())
                             .filter(iuRepo -> autoReferencesFilter.test(iuRepo.getLocation()))
                             .map(iuRepo -> new RepositoryReference(null, iuRepo.getLocation(), true))
-                            .forEach(repositoryReferences::add);
+                            .forEach(autoRepositoryRefeferences::add);
                 }
                 DestinationRepositoryDescriptor destinationRepoDescriptor = new DestinationRepositoryDescriptor(
                         destination, repositoryName, compress, xzCompress, keepNonXzIndexFiles,
-                        !createArtifactRepository, true, extraArtifactRepositoryProperties, repositoryReferences);
+                        !createArtifactRepository, true, extraArtifactRepositoryProperties, repositoryReferences,
+                        autoRepositoryRefeferences);
                 mirrorApp.mirrorReactor(sources, destinationRepoDescriptor, projectSeeds, getBuildContext(),
                         includeAllDependencies, includeAllSources, includeRequiredPlugins, includeRequiredFeatures,
-                        filterProvided, profileProperties);
+                        filterProvided, repositoryReferenceFilter.addOnlyProviding, profileProperties);
                 if (generateOSGiRepository) {
                     XMLResourceGenerator resourceGenerator = new XMLResourceGenerator();
                     resourceGenerator.name(repositoryName);


### PR DESCRIPTION
Backport of https://github.com/eclipse-tycho/tycho/pull/2744 to the `tycho_4.0.x` branch.

As discussed in #2744, `repositoryReferenceFilter.addOnlyProviding` is false by default for Tycho 4 (as it was implicitly before), and will only be true for Tycho-5.