### PR TITLE
Simplify JUnit5Test and make it always use ECLIPSE_LATEST p2 repo

### DIFF
--- a/tycho-its/projects/surefire.junit4and54/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit4and54/bundle.test/pom.xml
@@ -10,7 +10,7 @@
     <repository>
       <id>eclipse201903</id>
       <layout>p2</layout>
-      <url>${repo-2019-03}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
   

--- a/tycho-its/projects/surefire.junit5/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit5/bundle.test/pom.xml
@@ -10,7 +10,7 @@
     <repository>
       <id>oxygen</id>
       <layout>p2</layout>
-      <url>${oxygen-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
   

--- a/tycho-its/projects/surefire.junit54/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit54/bundle.test/pom.xml
@@ -10,7 +10,7 @@
     <repository>
       <id>eclipse201903</id>
       <layout>p2</layout>
-      <url>${repo-2019-03}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
   

--- a/tycho-its/projects/surefire.junit56/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit56/bundle.test/pom.xml
@@ -10,7 +10,7 @@
     <repository>
       <id>eclipse202003</id>
       <layout>p2</layout>
-      <url>${repo-2020-03}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
   

--- a/tycho-its/projects/surefire.junit59/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit59/bundle.test/pom.xml
@@ -10,7 +10,7 @@
     <repository>
       <id>eclipse202003</id>
       <layout>p2</layout>
-      <url>${repo-2020-03}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
   

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit5Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit5Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 SAP SE and others.
+ * Copyright (c) 2018, 2023 SAP SE and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,18 +17,16 @@ import static org.eclipse.tycho.test.util.SurefireUtil.assertTestMethodWasSucces
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
 import org.junit.Test;
 
 public class JUnit5Test extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testJUnit5Runner() throws Exception {
-		Verifier verifier = getVerifier("/surefire.junit5/bundle.test", false);
-		verifier.addCliOption("-Doxygen-repo=" + P2Repositories.ECLIPSE_OXYGEN.toString());
+		final Verifier verifier = getVerifier("/surefire.junit5/bundle.test");
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
-		String projectBasedir = verifier.getBasedir();
+		final String projectBasedir = verifier.getBasedir();
 		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit5Test", "My 1st JUnit 5 test!");
 		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit5Test",
 				"parameterizedJUnit5Test(String)[1] one");
@@ -47,11 +45,10 @@ public class JUnit5Test extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testJUnit4and54Runner() throws Exception {
-		Verifier verifier = getVerifier("/surefire.junit4and54/bundle.test", false);
-		verifier.addCliOption("-Drepo-2019-03=" + P2Repositories.ECLIPSE_LATEST.toString());
+		final Verifier verifier = getVerifier("/surefire.junit4and54/bundle.test");
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
-		String projectBasedir = verifier.getBasedir();
+		final String projectBasedir = verifier.getBasedir();
 		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit4Test", "testWithJUnit4");
 		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit54Test", "My 1st JUnit 5.4 test!");
 		// make sure test tagged as 'slow' was skipped
@@ -60,11 +57,10 @@ public class JUnit5Test extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testJUnit54Runner() throws Exception {
-		Verifier verifier = getVerifier("/surefire.junit54/bundle.test", false);
-		verifier.addCliOption("-Drepo-2019-03=" + P2Repositories.ECLIPSE_LATEST.toString());
+		final Verifier verifier = getVerifier("/surefire.junit54/bundle.test");
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
-		String projectBasedir = verifier.getBasedir();
+		final String projectBasedir = verifier.getBasedir();
 		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit54Test", "My 1st JUnit 5.4 test!");
 		// make sure test tagged as 'slow' was skipped
 		assertNumberOfSuccessfulTests(projectBasedir, "bundle.test.JUnit54Test", 1);
@@ -72,11 +68,10 @@ public class JUnit5Test extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testJUnit56Runner() throws Exception {
-		Verifier verifier = getVerifier("/surefire.junit56/bundle.test", false);
-		verifier.addCliOption("-Drepo-2020-03=" + P2Repositories.ECLIPSE_LATEST.toString());
+		final Verifier verifier = getVerifier("/surefire.junit56/bundle.test");
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
-		String projectBasedir = verifier.getBasedir();
+		final String projectBasedir = verifier.getBasedir();
 		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit56Test", "My 1st JUnit 5.6 test!");
 		// make sure test tagged as 'slow' was skipped
 		assertNumberOfSuccessfulTests(projectBasedir, "bundle.test.JUnit56Test", 1);
@@ -84,11 +79,10 @@ public class JUnit5Test extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testJUnit59Runner() throws Exception {
-		Verifier verifier = getVerifier("/surefire.junit59/bundle.test", false);
-		verifier.addCliOption("-Drepo-2020-03=" + P2Repositories.ECLIPSE_LATEST.toString());
+		final Verifier verifier = getVerifier("/surefire.junit59/bundle.test");
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
-		String projectBasedir = verifier.getBasedir();
+		final String projectBasedir = verifier.getBasedir();
 		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit59Test", "My 1st JUnit 5.9 test!");
 		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit59Test",
 				"parameterizedJUnit59TestWithMethodSource(int, int, int)[1] 0, 5, 5");


### PR DESCRIPTION
Changed the target-platform parameters to be the standard one so these settings could happen automatically.