### PR TITLE
Only set download/install-size attributes in features if they exist

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/WrappedArtifact.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/WrappedArtifact.java
@@ -76,7 +76,7 @@ public final class WrappedArtifact extends ArtifactFacadeProxy {
 
     public String getReferenceHint() {
         return "The artifact can be referenced in feature files with the following data: <plugin id=\"" + wrappedBsn
-                + "\" version=\"" + wrappedVersion + "\" download-size=\"0\" install-size=\"0\" unpack=\"false\"/>";
+                + "\" version=\"" + wrappedVersion + "\"/>";
     }
 
     public String getGeneratedManifest() {

--- a/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/PluginRef.java
+++ b/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/PluginRef.java
@@ -85,6 +85,12 @@ public class PluginRef {
         dom.setAttribute("arch", arch);
     }
 
+    @Deprecated
+    public boolean hasUnpack() {
+        String value = dom.getAttributeValue("unpack");
+        return value != null && !value.isBlank();
+    }
+
     /**
      * @deprecated The installation format (packed/unpacked) shall be specified through the bundle's
      *             Eclipse-BundleShape manifest header. The feature.xml's unpack attribute may not
@@ -105,12 +111,22 @@ public class PluginRef {
         dom.setAttribute("unpack", Boolean.toString(unpack));
     }
 
+    public boolean hasDownloadSize() {
+        String value = dom.getAttributeValue("download-size");
+        return value != null && !value.isBlank();
+    }
+
     public long getDownloadSize() {
         return Long.parseLong(dom.getAttributeValue("download-size"));
     }
 
     public void setDownloadSize(long size) {
         dom.setAttribute("download-size", Long.toString(size));
+    }
+
+    public boolean hasInstallSize() {
+        String value = dom.getAttributeValue("install-size");
+        return value != null && !value.isBlank();
     }
 
     public long getInstallSize() {

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
@@ -575,8 +575,9 @@ public class SourceFeatureMojo extends AbstractMojo {
         if (pluginRef.getArch() != null) {
             sourceRef.setArch(pluginRef.getArch());
         }
-        sourceRef.setUnpack(false);
-
+        if (pluginRef.hasUnpack()) {
+            sourceRef.setUnpack(false);
+        }
         sourceFeature.addPlugin(sourceRef);
     }
 


### PR DESCRIPTION
This allows the first step of the degradation of the unused feature attributes 'install/download-size', 'unpack' and 'fragment'.

In the context of https://github.com/eclipse-pde/eclipse.pde/issues/730