### PR TITLE
Set the output folder of the imported project to the maven location

### DIFF
--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisMojo.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisMojo.java
@@ -172,9 +172,11 @@ public class ApiAnalysisMojo extends AbstractMojo {
 			}
 			ApiAnalysisResult analysisResult;
 			try {
-				analysisResult = eclipseFramework.execute(new ApiAnalysis(baselineBundles, dependencyBundles,
+				ApiAnalysis analysis = new ApiAnalysis(baselineBundles, dependencyBundles,
 						project.getName(), fileToPath(apiFilter), fileToPath(apiPreferences),
-						fileToPath(project.getBasedir()), debug, fileToPath(project.getArtifact().getFile())));
+						fileToPath(project.getBasedir()), debug, fileToPath(project.getArtifact().getFile()),
+						stringToPath(project.getBuild().getOutputDirectory()));
+				analysisResult = eclipseFramework.execute(analysis);
 			} catch (Exception e) {
 				throw new MojoExecutionException("Execute ApiApplication failed", e);
 			} finally {
@@ -348,6 +350,13 @@ public class ApiAnalysisMojo extends AbstractMojo {
 			return Objects.equals(key, other.key);
 		}
 
+	}
+
+	private static Path stringToPath(String file) {
+		if (file == null) {
+			return null;
+		}
+		return Path.of(file);
 	}
 
 	private static Path fileToPath(File file) {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/apitools/ApiToolsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/apitools/ApiToolsTest.java
@@ -60,25 +60,31 @@ public class ApiToolsTest extends AbstractTychoIntegrationTest {
 			}
 		});
 		// check summary output
-		verifier.verifyTextInLog("4 API ERRORS");
+		verifier.verifyTextInLog("7 API ERRORS");
 		verifier.verifyTextInLog("0 API warnings");
 		// check error output has source references and lines
+		verifier.verifyTextInLog("File ClassA.java at line 5: The method bundle.ClassA.getString() has been removed");
 		verifier.verifyTextInLog(
-				"File ApiInterface.java at line 2: The type bundle.ApiInterface has been removed from api-bundle");
-		verifier.verifyTextInLog("File ClassA.java at line 5: The type bundle.ClassA has been removed from api-bundle");
+				"File ClassA.java at line 5: The method bundle.ClassA.getCollection() has been removed");
 		verifier.verifyTextInLog(
 				"File MANIFEST.MF at line 0: The type bundle.InterfaceA has been removed from api-bundle");
+		verifier.verifyTextInLog("File ClassA.java at line 7: Missing @since tag on getGreetings()");
+		verifier.verifyTextInLog("File ClassA.java at line 11: Missing @since tag on getCollection()");
+		verifier.verifyTextInLog("File InterfaceB.java at line 2: Missing @since tag on bundle.InterfaceB");
 		verifier.verifyTextInLog(
 				"File MANIFEST.MF at line 5: The major version should be incremented in version 0.0.1, since API breakage occurred since version 0.0.1");
 		// now check for the build error output
 		verifier.verifyTextInLog("on project api-bundle-1: There are API errors:");
+		verifier.verifyTextInLog("src/bundle/ClassA.java:5 The method bundle.ClassA.getString() has been removed");
+		verifier.verifyTextInLog("src/bundle/ClassA.java:5 The method bundle.ClassA.getCollection() has been removed");
 		verifier.verifyTextInLog(
-				"src/bundle/ApiInterface.java:2 The type bundle.ApiInterface has been removed from api-bundle");
-		verifier.verifyTextInLog(
-				"src/bundle/ClassA.java:5 The type bundle.ClassA has been removed from api-bundle-1_0.0.1");
-		verifier.verifyTextInLog("META-INF/MANIFEST.MF:0 The type bundle.InterfaceA has been removed from api-bundle");
+				"META-INF/MANIFEST.MF:0 The type bundle.InterfaceA has been removed from api-bundle-1_0.0.1");
+		verifier.verifyTextInLog("src/bundle/ClassA.java:7 Missing @since tag on getGreetings()");
+		verifier.verifyTextInLog("src/bundle/ClassA.java:11 Missing @since tag on getCollection()");
+		verifier.verifyTextInLog("src/bundle/InterfaceB.java:2 Missing @since tag on bundle.InterfaceB");
 		verifier.verifyTextInLog(
 				"META-INF/MANIFEST.MF:5 The major version should be incremented in version 0.0.1, since API breakage occurred since version 0.0.1");
+
 		// TODO: check with api-filter
 		// TODO: check with second plugin with BREE?
 	}


### PR DESCRIPTION
Currently there could be a mismatch between what eclipse assumes as outputfolder where the class files are located and maven.

This ensures that the project info is always updated with the correct location and parts of the code operating on the output location do find the classes (or folders).

See https://github.com/eclipse-pde/eclipse.pde/issues/782#issuecomment-1762550912