### PR TITLE
Clean resources from previous build's volatiles (#2946)

### DIFF
--- a/tycho-compiler-plugin/pom.xml
+++ b/tycho-compiler-plugin/pom.xml
@@ -10,7 +10,8 @@
  -    Sonatype Inc. - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -87,5 +88,24 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<configuration>
+					<failOnError>false</failOnError>
+					<filesets>
+						<fileset>
+							<directory>${project.basedir}/src/test/resources/projects</directory>
+							<includes>
+								<include>**/bin/**</include>
+							</includes>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>


### PR DESCRIPTION
Fixes #2946

When test projects for `tycho-compiler-plugin` are built, their directories are polluted with build
results. This makes tests using those project unreliable. In particular Eclipse build puts compiled classes in bin directory of test projects, causing #2946.

This change removes some of the pollution to stabilize subsequent tests. 