### PR TITLE
Add a reproducer IT for issue #2977

### DIFF
--- a/tycho-its/projects/p2Inf.virtualUnit/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2Inf.virtualUnit/bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: pvu.bundle
+Bundle-SymbolicName: pvu.bundle;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: TEST
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/p2Inf.virtualUnit/bundle/META-INF/p2.inf
+++ b/tycho-its/projects/p2Inf.virtualUnit/bundle/META-INF/p2.inf
@@ -1,0 +1,11 @@
+# Create the virtual IU
+units.0.id=configure.pvu.bundle
+units.0.version=1.0.0
+units.0.provides.1.namespace=org.eclipse.equinox.p2.iu
+units.0.provides.1.name=configure.pvu.bundle
+units.0.provides.1.version=1.0.0
+
+# Require in this bundle the created virtual IU
+requires.0.namespace=org.eclipse.equinox.p2.iu
+requires.0.name=configure.pvu.bundle
+requires.0.range=0.0.0

--- a/tycho-its/projects/p2Inf.virtualUnit/bundle/build.properties
+++ b/tycho-its/projects/p2Inf.virtualUnit/bundle/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/p2Inf.virtualUnit/bundle/pom.xml
+++ b/tycho-its/projects/p2Inf.virtualUnit/bundle/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>tycho-its-project.p2Inf.virtualUnit</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pvu.bundle</artifactId>
+    <packaging>eclipse-plugin</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <pomDependencies>consider</pomDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tycho-its/projects/p2Inf.virtualUnit/pom.xml
+++ b/tycho-its/projects/p2Inf.virtualUnit/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>tycho-its-project.p2Inf.virtualUnit</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <tycho-version>4.0.3</tycho-version>
+    </properties>
+
+    <modules>
+        <module>bundle</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-maven-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/VirtualUnitTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/VirtualUnitTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Martin D'Aloia and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.test.p2Inf;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+import de.pdark.decentxml.Document;
+import de.pdark.decentxml.Element;
+import de.pdark.decentxml.XMLParser;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Test that a virtual IU created just with metadata in a p2.inf file can be required
+ * in the same p2.inf file.
+ * <p>
+ * It used to work until 3.0.5 (using <code><pomDependencies>consider</pomDependencies></code>)
+ * but since 4.0.0 failed with:
+ * <pre>
+ * Cannot resolve project dependencies:
+ *   Software being installed: pvu.bundle 1.0.0.qualifier
+ *   Missing requirement: pvu.bundle 1.0.0.qualifier requires 'org.eclipse.equinox.p2.iu; configure.pvu.bundle 0.0.0' but it could not be found
+ * </pre>
+ *
+ * See https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md#mixed-reactor-setups-require-the-new-resolver-now
+ * and https://github.com/eclipse-tycho/tycho/issues/2977
+ */
+public class VirtualUnitTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testVirtualUnitRequirementDoesNotFailBuild() throws Exception {
+		Verifier verifier = getVerifier("/p2Inf.virtualUnit", false);
+		verifier.executeGoals(asList("verify"));
+		verifier.verifyErrorFreeLog();
+
+		String hostUnitId = "pvu.bundle";
+		String configureUnitId = "configure.pvu.bundle";
+
+		File p2Content = new File(verifier.getBasedir(), "bundle/target/p2content.xml");
+		Document doc = XMLParser.parse(p2Content);
+
+		List<Element> units = doc.getChild("units").getChildren("unit");
+		Optional<Element> hostUnit = findUnit(units, hostUnitId);
+		Optional<Element> configureUnit = findUnit(units, configureUnitId);
+
+		Stream<Element> hostUnitRequirements = findRequirements(hostUnit);
+
+		assertTrue("Host IU " + hostUnitId + " not found", hostUnit.isPresent());
+		assertTrue("Configure IU " + configureUnitId + " not found", configureUnit.isPresent());
+		assertTrue("Requirement of IU " + configureUnitId + " not found in IU " + hostUnitId,
+				hostUnitRequirements.anyMatch(elem -> configureUnitId.equals(elem.getAttributeValue("name"))));
+	}
+
+	private static Optional<Element> findUnit(List<Element> units, String hostUnitId) {
+		return units.stream()
+				.filter(elem -> hostUnitId.equals(elem.getAttributeValue("id")))
+				.findFirst();
+	}
+
+	private static Stream<Element> findRequirements(Optional<Element> hostUnit) {
+		return hostUnit.stream().flatMap(elem -> elem.getChild("requires").getChildren("required").stream());
+	}
+
+}


### PR DESCRIPTION
Virtual configuration IU in p2.inf does not work in 4.0.3 (works in 3.0.5)

If we add this statement in the `VirtualUnitTest`:
```
verifier.addCliOption("-Dtycho-version=3.0.5");
```
the test works ok and does not fail.