### PR TITLE
Print registered extensions in framework debug

### DIFF
--- a/sisu-osgi/sisu-osgi-connect/pom.xml
+++ b/sisu-osgi/sisu-osgi-connect/pom.xml
@@ -1,14 +1,16 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.eclipse.tycho</groupId>
-    <artifactId>sisu-osgi</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
-  </parent>
-  <artifactId>sisu-osgi-connect</artifactId>
-  <name>Sisu Implementation of the OSGi R8 Framework Connect Specification</name>
-  
-  <dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>sisu-osgi</artifactId>
+		<version>5.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>sisu-osgi-connect</artifactId>
+	<name>Sisu Implementation of the OSGi R8 Framework Connect Specification</name>
+
+	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>sisu-osgi-api</artifactId>
@@ -19,13 +21,18 @@
 			<artifactId>org.eclipse.osgi</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>org.osgi</groupId>
-		    <artifactId>org.osgi.service.component</artifactId>
-		    <version>1.5.1</version>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.service.component</artifactId>
+			<version>1.5.1</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.eclipse.sisu</groupId>
-		    <artifactId>org.eclipse.sisu.plexus</artifactId>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.registry</artifactId>
+			<version>3.11.300</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.sisu</groupId>
+			<artifactId>org.eclipse.sisu.plexus</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
@@ -35,9 +42,9 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
-  </dependencies>
-  
-  <build>
+	</dependencies>
+
+	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Currently we print services and components but extensions are useful as well.