### PR TITLE
Add a javadoc dependency injector

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -41,11 +40,8 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.io.ModelWriter;
 import org.apache.maven.project.MavenProject;
@@ -158,28 +154,13 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
                             //do not inject additional dependencies for non Tycho managed projects!
                             continue;
                         }
-                        Model model = project.getModel();
-                        Set<String> existingDependencies = model.getDependencies().stream()
-                                .map(TychoMavenLifecycleParticipant::getKey)
-                                .collect(Collectors.toCollection(HashSet::new));
                         Collection<MavenProject> dependencyProjects = closure.getDependencyProjects(project);
-                        for (MavenProject dependencyProject : dependencyProjects) {
-                            Dependency dependency = new Dependency();
-                            dependency.setArtifactId(dependencyProject.getArtifactId());
-                            dependency.setGroupId(dependencyProject.getGroupId());
-                            dependency.setVersion(dependencyProject.getVersion());
-                            String packaging = dependencyProject.getPackaging();
-                            dependency.setType(packaging);
-                            dependency.setScope(Artifact.SCOPE_COMPILE);
-                            dependency.setOptional(false);
-                            if (existingDependencies.add(getKey(dependency))) {
-                                model.addDependency(dependency);
-                            }
-                        }
+                        MavenDependencyInjector.injectMavenProjectDependencies(project, dependencyProjects);
                         if (DUMP_DATA) {
                             try {
                                 Set<MavenProject> visited = new HashSet<>();
-                                modelWriter.write(new File(project.getBasedir(), "pom-model.xml"), Map.of(), model);
+                                modelWriter.write(new File(project.getBasedir(), "pom-model.xml"), Map.of(),
+                                        project.getModel());
                                 try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
                                         new FileOutputStream(new File(project.getBasedir(), "requirements.txt"))))) {
                                     writer.write(project.getId() + ":\r\n");
@@ -221,13 +202,6 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
                         visited);
             }
         }
-    }
-
-    private static String getKey(Dependency dependency) {
-
-        return dependency.getGroupId() + ":" + dependency.getArtifactId() + ":"
-                + Objects.requireNonNullElse(dependency.getType(), "jar") + ":" + dependency.getVersion() + ":"
-                + Objects.requireNonNullElse(dependency.getClassifier(), "");
     }
 
     @Override

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/ConfigureMojo.java
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/ConfigureMojo.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.extras.docbundle;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * This mojo is only there
+ */
+@Mojo(name = "configure-document-bundle-plugin", defaultPhase = LifecyclePhase.INITIALIZE, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true)
+public class ConfigureMojo extends AbstractMojo {
+
+	/**
+	 * name of the parameter to inject javadoc source dependencies
+	 */
+	public static final String PARAM_INJECT_JAVADOC_DEPENDENCIES = "injectJavadocDependencies";
+	@Parameter(name = PARAM_INJECT_JAVADOC_DEPENDENCIES)
+	private boolean dummyBoolean;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		throw new MojoFailureException("This mojo is not intended to be ever called");
+	}
+
+}

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocBuildListener.java
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocBuildListener.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.extras.docbundle;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.tycho.build.BuildListener;
+import org.eclipse.tycho.core.maven.MavenDependencyInjector;
+import org.eclipse.tycho.helper.PluginConfigurationHelper;
+import org.eclipse.tycho.helper.PluginConfigurationHelper.Configuration;
+import org.eclipse.tycho.helper.ProjectHelper;
+
+@Component(role = BuildListener.class, hint = "javadoc")
+public class JavadocBuildListener implements BuildListener {
+
+	private static final String JAVADOC_GOAL = "javadoc";
+	private static final String ARTIFACT_ID = "maven-javadoc-plugin";
+	private static final String GROUP_ID = "org.apache.maven.plugins";
+
+	@Requirement
+	private ProjectHelper projectHelper;
+
+	@Requirement
+	private PluginConfigurationHelper configurationHelper;
+
+	@Override
+	public void buildStarted(MavenSession session) {
+		List<MavenProject> projects = session.getProjects();
+		for (MavenProject project : projects) {
+			if (isJavadocProject(project, session)) {
+				Configuration configuration = configurationHelper.getConfiguration(GROUP_ID, ARTIFACT_ID, JAVADOC_GOAL,
+						project, session);
+				List<MavenProject> additionalProjects = configuration.getString("sourcepath").stream()
+						.flatMap(sourcepath -> {
+							return Arrays.stream(sourcepath.split(";|:"));
+						}).map(s -> s.strip()).map(s -> new File(project.getBasedir(), s).toPath().normalize())
+						.map(sourcePath -> getProject(sourcePath, projects)).filter(Objects::nonNull).distinct()
+						.toList();
+				MavenDependencyInjector.injectMavenProjectDependencies(project, additionalProjects);
+			}
+		}
+
+	}
+
+	private MavenProject getProject(Path sourcePath, List<MavenProject> projects) {
+		MavenProject match = null;
+		int matchNameCount = -1;
+		for (MavenProject mavenProject : projects) {
+			Path basePath = mavenProject.getBasedir().toPath();
+			if (sourcePath.startsWith(basePath)) {
+				int nameCount = basePath.getNameCount();
+				if (match == null || nameCount > matchNameCount) {
+					match = mavenProject;
+					matchNameCount = nameCount;
+				}
+			}
+		}
+		return match;
+	}
+
+	private boolean isJavadocProject(MavenProject project, MavenSession mavenSession) {
+		if (projectHelper.hasPluginExecution(GROUP_ID, ARTIFACT_ID, JAVADOC_GOAL, project, mavenSession)) {
+			Configuration configuration = configurationHelper.getConfiguration(ConfigureMojo.class, project,
+					mavenSession);
+			return configuration.getBoolean(ConfigureMojo.PARAM_INJECT_JAVADOC_DEPENDENCIES).orElse(false);
+		}
+		return false;
+	}
+
+	@Override
+	public void buildEnded(MavenSession session) {
+		// nothing to do...
+	}
+
+}

--- a/tycho-spi/src/main/java/org/eclipse/tycho/helper/ProjectHelper.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/helper/ProjectHelper.java
@@ -86,7 +86,7 @@ public class ProjectHelper {
      * @param goal
      * @param project
      * @param mavenSession
-     * @return <code>true</code> if an execution was found or <code>false</code> otherwhise.
+     * @return <code>true</code> if an execution was found or <code>false</code> otherwise.
      */
     public boolean hasPluginExecution(String pluginGroupId, String pluginArtifactId, String goal, MavenProject project,
             MavenSession mavenSession) {
@@ -127,11 +127,14 @@ public class ProjectHelper {
                 if (goal == null) {
                     return getDom(plugin.getConfiguration());
                 }
+                //first check for goal specific configuration
                 for (PluginExecution execution : plugin.getExecutions()) {
                     if (execution.getGoals().contains(goal)) {
                         return getDom(execution.getConfiguration());
                     }
                 }
+                //get plugin config
+                return getDom(plugin.getConfiguration());
             }
         }
         return null;

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/VersionBumpBuildListener.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/VersionBumpBuildListener.java
@@ -32,7 +32,7 @@ import org.eclipse.tycho.versions.engine.VersionsEngine;
 import org.eclipse.tycho.versions.pom.PomFile;
 import org.osgi.framework.Version;
 
-@Component(role = BuildListener.class)
+@Component(role = BuildListener.class, hint = "version-bump")
 public class VersionBumpBuildListener implements BuildListener {
 
     @Requirement
@@ -79,10 +79,10 @@ public class VersionBumpBuildListener implements BuildListener {
                             String newVersion = suggestedVersion.map(String::valueOf)
                                     .orElseGet(() -> Versions.incrementVersion(currentVersion,
                                             VersionBumpMojo.getIncrement(session, project, projectHelper)));
-							boolean isSnapshot = currentVersion.endsWith(TychoConstants.SUFFIX_SNAPSHOT);
-							if (isSnapshot) {
-								newVersion += TychoConstants.SUFFIX_SNAPSHOT;
-							}
+                            boolean isSnapshot = currentVersion.endsWith(TychoConstants.SUFFIX_SNAPSHOT);
+                            if (isSnapshot) {
+                                newVersion += TychoConstants.SUFFIX_SNAPSHOT;
+                            }
                             logger.info(project.getId() + " requires a version bump from " + currentVersion + " => "
                                     + newVersion);
                             engine.setProjects(metadataReader.getProjects());


### PR DESCRIPTION
When using the javadoc goal to aggregate documentation using configured source directories there is the problem that also a reference to projects that are mentioned in the source directories is required.

This adds a new (configurable) injector that adds the projects mentioned as the source as dependencies of the project.