### PR TITLE
Add a reproducer to show that PR #2978 was a partial fix

### DIFF
--- a/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle1/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: pvumb.bundle1
+Bundle-SymbolicName: pvumb.bundle1;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: TEST
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle1/META-INF/p2.inf
+++ b/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle1/META-INF/p2.inf
@@ -1,0 +1,11 @@
+# Create the virtual IU
+units.0.id=configure.pvumb.bundle1
+units.0.version=1.0.0
+units.0.provides.1.namespace=org.eclipse.equinox.p2.iu
+units.0.provides.1.name=configure.pvumb.bundle1
+units.0.provides.1.version=1.0.0
+
+# Require in this bundle the created virtual IU
+requires.0.namespace=org.eclipse.equinox.p2.iu
+requires.0.name=configure.pvumb.bundle1
+requires.0.range=0.0.0

--- a/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle1/build.properties
+++ b/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle1/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle1/pom.xml
+++ b/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle1/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>tycho-its-project.p2Inf.virtualUnit.multiBundle</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pvumb.bundle1</artifactId>
+    <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle2/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: pvumb.bundle2
+Bundle-SymbolicName: pvumb.bundle2;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: TEST
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: pvumb.bundle1

--- a/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle2/build.properties
+++ b/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle2/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle2/pom.xml
+++ b/tycho-its/projects/p2Inf.virtualUnit.multiBundle/bundle2/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>tycho-its-project.p2Inf.virtualUnit.multiBundle</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pvumb.bundle2</artifactId>
+    <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/tycho-its/projects/p2Inf.virtualUnit.multiBundle/pom.xml
+++ b/tycho-its/projects/p2Inf.virtualUnit.multiBundle/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>tycho-its-project.p2Inf.virtualUnit.multiBundle</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <tycho-version>4.0.4</tycho-version>
+    </properties>
+
+    <modules>
+        <module>bundle1</module>
+        <module>bundle2</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-maven-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <pomDependencies>consider</pomDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
The fix of PR #2978 was a partial fix for issue #2977. It fixed the case of a single bundled but when the bundle providing/requiring the virtual IU is required by another bundle it fails with the same error as before even with Tycho 4.0.4:

```
[ERROR] Cannot resolve project dependencies:
[ERROR]   Software being installed: pvumb.bundle2 1.0.0.qualifier
[ERROR]   Missing requirement: pvumb.bundle1 1.0.0.qualifier requires 'org.eclipse.equinox.p2.iu; configure.pvumb.bundle1 0.0.0' but it could not be found
[ERROR]   Cannot satisfy dependency: pvumb.bundle2 1.0.0.qualifier depends on: osgi.bundle; pvumb.bundle1 0.0.0
```

A workaround is to use:

```
requires.0.optional=true
requires.0.greedy=true
```

This PR provides a new Integration Test case that shows this scenario. Previous one was refactored a little bit to avoid duplications.