### PR TITLE
Using Status.error in TychoRepositoryTransport

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransport.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransport.java
@@ -87,8 +87,7 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 	@Override
 	public IStatus download(URI toDownload, OutputStream target, long startPos, IProgressMonitor monitor) {
 		if (startPos > 0) {
-			return new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"range downloads are not implemented");
+			return Status.error("range downloads are not implemented");
 		}
 		return download(toDownload, target, monitor);
 	}
@@ -111,11 +110,9 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 			}
 			return reportStatus(downloadStatus, target);
 		} catch (AuthenticationFailedException e) {
-			return new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"authentication failed for " + toDownload, e);
+			return Status.error("authentication failed for " + toDownload, e);
 		} catch (IOException e) {
-			return reportStatus(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"download from " + toDownload + " failed", e), target);
+			return reportStatus(Status.error("download from " + toDownload + " failed", e), target);
 		} catch (CoreException e) {
 			return reportStatus(e.getStatus(), target);
 		}
@@ -162,8 +159,7 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 			if (DEBUG_REQUESTS) {
 				logger.debug(" --> generic error: " + e);
 			}
-			throw new CoreException(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"download from " + toDownload + " failed", e));
+			throw new CoreException(Status.error("download from " + toDownload + " failed", e));
 		} finally {
 			if (DEBUG_REQUESTS) {
 				logger.debug("Total number of requests: " + requests.longValue() + " (" + indexRequests.longValue()
@@ -199,8 +195,7 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 		} catch (FileNotFoundException e) {
 			throw e;
 		} catch (IOException e) {
-			throw new CoreException(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"download from " + toDownload + " failed", e));
+			throw new CoreException(Status.error("download from " + toDownload + " failed", e));
 		}
 	}
 


### PR DESCRIPTION
Status.error could be used in TychoRepositoryTransport instead of the older and longer API. As errors are not the normal case, the overhead of the StackWalker should not affect regular builds.