### PR TITLE
Select best matching target environment for p2install

### DIFF
--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -639,17 +639,11 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
             File workingDir = new File(project.getBuild().getDirectory(), "p2temp");
             workingDir.mkdirs();
             installationBuilder.setWorkingDir(workingDir);
-            TargetEnvironment runningEnvironment = TargetEnvironment.getRunningEnvironment();
-            if (PlatformPropertiesUtils.OS_MACOSX.equals(runningEnvironment.getOs())) {
-                if (work.getName().endsWith(".app")) {
-                    installationBuilder.setDestination(work);
-                } else {
-                    installationBuilder.setDestination(new File(work, "Eclipse.app/Contents/Eclipse/"));
-                }
-            } else {
-                installationBuilder.setDestination(work);
-            }
-            return installationBuilder.install();
+            installationBuilder.setDestination(work);
+            List<TargetEnvironment> list = getTestTargetEnvironments();
+            TargetEnvironment env = list.get(0);
+            getLog().info("Provisioning with environment " + env + "...");
+            return installationBuilder.install(env);
         } catch (Exception ex) {
             throw new MojoExecutionException(ex.getMessage(), ex);
         }
@@ -1054,7 +1048,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         addProgramArgs(cli, "-data", osgiDataDirectory.getAbsolutePath(), //
                 "-install", testRuntime.getLocation().getAbsolutePath(), //
                 "-configuration", testRuntime.getConfigurationLocation().getAbsolutePath(), //
-                "-application", getTestApplication(testRuntime.getInstallationDescription()), //
+                "-application", getTestApplication(), //
                 "-testproperties", surefireProperties.getAbsolutePath());
         if (application != null) {
             cli.addProgramArguments("-testApplication", application);
@@ -1122,7 +1116,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         }
     }
 
-    private String getTestApplication(EquinoxInstallationDescription testRuntime) {
+    private String getTestApplication() {
         if (useUIHarness) {
             return "org.eclipse.tycho.surefire.osgibooter.uitest";
         } else {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provisioning/ProvisionedEquinoxInstallation.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provisioning/ProvisionedEquinoxInstallation.java
@@ -17,7 +17,6 @@ import java.io.File;
 import org.eclipse.sisu.equinox.launching.EquinoxInstallation;
 import org.eclipse.sisu.equinox.launching.EquinoxInstallationDescription;
 import org.eclipse.sisu.equinox.launching.internal.EquinoxInstallationLaunchConfiguration;
-import org.eclipse.tycho.core.osgitools.BundleReader;
 
 /**
  * This class provides an implementation of an {@link EquinoxInstallation} which represents an RCP
@@ -32,9 +31,9 @@ public class ProvisionedEquinoxInstallation implements EquinoxInstallation {
     private File configurationLocation;
     private EquinoxInstallationDescription description;
 
-    public ProvisionedEquinoxInstallation(File location, BundleReader bundleReader) {
+    public ProvisionedEquinoxInstallation(File location) {
         this.location = location;
-        description = new ProvisionedInstallationDescription(location, bundleReader);
+        description = new ProvisionedInstallationDescription(location, null);
     }
 
     @Override

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilderFactory.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilderFactory.java
@@ -15,14 +15,10 @@ package org.eclipse.tycho.surefire.provisioning;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
-import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.p2.tools.director.shared.DirectorRuntime;
 
 @Component(role = ProvisionedInstallationBuilderFactory.class)
 public class ProvisionedInstallationBuilderFactory {
-
-    @Requirement
-    private BundleReader bundleReader;
 
     @Requirement
     private DirectorRuntime directorRuntime;
@@ -31,7 +27,7 @@ public class ProvisionedInstallationBuilderFactory {
     private Logger logger;
 
     public ProvisionedInstallationBuilder createInstallationBuilder() {
-        return new ProvisionedInstallationBuilder(bundleReader, directorRuntime, logger);
+        return new ProvisionedInstallationBuilder(directorRuntime, logger);
     }
 
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilderTest.java
@@ -27,7 +27,7 @@ public class ProvisionedInstallationBuilderTest {
 
     @Test
     public void setDestination_LayoutNormal() throws Exception {
-        ProvisionedInstallationBuilder builder = new ProvisionedInstallationBuilder(null, null, null);
+        ProvisionedInstallationBuilder builder = new ProvisionedInstallationBuilder(null, null);
 
         File work = tempDir.newFolder("work");
         builder.setDestination(work);
@@ -36,7 +36,7 @@ public class ProvisionedInstallationBuilderTest {
 
     @Test
     public void setDestination_LayoutMacOS() throws Exception {
-        ProvisionedInstallationBuilder builder = new ProvisionedInstallationBuilder(null, null, null);
+        ProvisionedInstallationBuilder builder = new ProvisionedInstallationBuilder(null, null);
 
         File work = tempDir.newFolder("work.app");
         builder.setDestination(work);


### PR DESCRIPTION
Currently a p2 provisioned install always use the running target to provision what is also the best option most of the time. In case where there is no matching one this can lead to failing installs.

This now allows to specify the environments and shows a warning if the running one does not has any match.