### PR TITLE
Calculate severity level based on the project not on the problem

### DIFF
--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisResult.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisResult.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.osgi.service.resolver.ResolverError;
 import org.eclipse.pde.api.tools.internal.provisional.problems.IApiProblem;
 
@@ -33,8 +34,8 @@ public class ApiAnalysisResult implements Serializable {
 		return resolveError.stream();
 	}
 
-	public void addProblem(IApiProblem problem) {
-		problems.add(new ApiProblemDTO(problem));
+	public void addProblem(IApiProblem problem, IProject project) {
+		problems.add(new ApiProblemDTO(problem, project));
 	}
 
 	public void addResolverError(ResolverError error) {

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiProblemDTO.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiProblemDTO.java
@@ -14,6 +14,9 @@ package org.eclipse.tycho.apitools;
 
 import java.io.Serializable;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.pde.api.tools.internal.problems.ApiProblemFactory;
+import org.eclipse.pde.api.tools.internal.provisional.ApiPlugin;
 import org.eclipse.pde.api.tools.internal.provisional.problems.IApiProblem;
 
 public class ApiProblemDTO implements IApiProblem, Serializable {
@@ -34,8 +37,8 @@ public class ApiProblemDTO implements IApiProblem, Serializable {
 	private final int flags;
 	private final String toString;
 
-	public ApiProblemDTO(IApiProblem problem) {
-		severity = problem.getSeverity();
+	public ApiProblemDTO(IApiProblem problem, IProject project) {
+		severity = ApiPlugin.getDefault().getSeverityLevel(ApiProblemFactory.getProblemSeverityId(problem), project);
 		elementKind = problem.getElementKind();
 		messageid = problem.getMessageid();
 		resourcePath = problem.getResourcePath();


### PR DESCRIPTION
ApiProblem.getSeverity() always returns the workspace defaults because it always passes null. Also the method is actually never used inside API Tools.

Instead we recalculate the real severity based on the currently processed project.