### PR TITLE
Remove readonly from parameter to prevent maven warning

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/AbstractP2Mojo.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/AbstractP2Mojo.java
@@ -36,7 +36,7 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
     @Parameter(property = "project", readonly = true)
     private MavenProject project;
 
-    @Parameter(property = "buildQualifier", readonly = true)
+    @Parameter(property = "buildQualifier")
     private String qualifier;
 
     @Component

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -118,7 +118,7 @@ public class CompareWithBaselineMojo extends AbstractMojo {
      * The hint of an available {@link ArtifactComparator} component to use for comparison of
      * artifacts with same version.
      */
-    @Parameter(defaultValue = BytesArtifactComparator.HINT, readonly = true)
+    @Parameter(defaultValue = BytesArtifactComparator.HINT)
     private String comparator;
     @Component(role = ArtifactComparator.class)
     protected Map<String, ArtifactComparator> artifactComparators;

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
@@ -122,7 +122,7 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
      *
      * @since 2.1
      */
-    @Parameter(defaultValue = "${project.build.outputDirectory}/META-INF/MANIFEST.MF", required = true, readonly = true)
+    @Parameter(defaultValue = "${project.build.outputDirectory}/META-INF/MANIFEST.MF", required = true)
     private File defaultManifestFile;
 
     /**


### PR DESCRIPTION
I have not found any reason why these should be parameters + read only especially if there is a user property so simply not mark them as read only.

Fix https://github.com/eclipse-tycho/tycho/issues/2644