### PR TITLE
Strip down ReactorRepositoryManager

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/TargetPlatform.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/TargetPlatform.java
@@ -33,6 +33,7 @@ public interface TargetPlatform {
      * Key under which the final target platform is stored in the reactor project instances.
      */
     String FINAL_TARGET_PLATFORM_KEY = "org.eclipse.tycho.core.TychoConstants/targetPlatform";
+    String PRELIMINARY_TARGET_PLATFORM_KEY = "org.eclipse.tycho.core.TychoConstants/dependencyOnlyTargetPlatform";
 
     /**
      * Returns an artifact of the given type, id and matching version. The version reference string
@@ -77,12 +78,11 @@ public interface TargetPlatform {
 
     default ResolvedArtifactKey resolvePackage(String packageName, String versionRef)
             throws DependencyResolutionException, IllegalArtifactReferenceException {
-        ArtifactKey packageJar = resolveArtifact(PublisherHelper.CAPABILITY_NS_JAVA_PACKAGE, packageName,
-                versionRef);
-        File location = getArtifactLocation(new DefaultArtifactKey(ArtifactType.TYPE_ECLIPSE_PLUGIN,
-                packageJar.getId(), packageJar.getVersion()));
-        return ResolvedArtifactKey.of(ArtifactType.TYPE_ECLIPSE_PLUGIN, packageJar.getId(),
-                packageJar.getVersion(), location);
+        ArtifactKey packageJar = resolveArtifact(PublisherHelper.CAPABILITY_NS_JAVA_PACKAGE, packageName, versionRef);
+        File location = getArtifactLocation(
+                new DefaultArtifactKey(ArtifactType.TYPE_ECLIPSE_PLUGIN, packageJar.getId(), packageJar.getVersion()));
+        return ResolvedArtifactKey.of(ArtifactType.TYPE_ECLIPSE_PLUGIN, packageJar.getId(), packageJar.getVersion(),
+                location);
     }
 
     /**

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PublisherServiceFactoryImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PublisherServiceFactoryImpl.java
@@ -19,6 +19,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.tycho.Interpolator;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetEnvironment;
+import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.p2.repository.PublishingRepository;
 import org.eclipse.tycho.p2.tools.publisher.PublishProductToolImpl;
@@ -40,9 +41,9 @@ public class PublisherServiceFactoryImpl implements PublisherServiceFactory {
 
     @Override
     public PublisherService createPublisher(ReactorProject project, List<TargetEnvironment> environments) {
-        P2TargetPlatform targetPlatform = (P2TargetPlatform) reactorRepoManager.getFinalTargetPlatform(project);
+        P2TargetPlatform targetPlatform = (P2TargetPlatform) getFinalTargetPlatform(project);
         PublisherActionRunner publisherRunner = getPublisherRunnerForProject(targetPlatform, environments);
-        PublishingRepository publishingRepository = reactorRepoManager.getPublishingRepository(project.getIdentities());
+        PublishingRepository publishingRepository = reactorRepoManager.getPublishingRepository(project);
 
         return new PublisherServiceImpl(publisherRunner, project.getBuildQualifier(), publishingRepository);
     }
@@ -50,12 +51,24 @@ public class PublisherServiceFactoryImpl implements PublisherServiceFactory {
     @Override
     public PublishProductTool createProductPublisher(ReactorProject project, List<TargetEnvironment> environments,
             String buildQualifier, Interpolator interpolator) {
-        P2TargetPlatform targetPlatform = (P2TargetPlatform) reactorRepoManager.getFinalTargetPlatform(project);
+        P2TargetPlatform targetPlatform = (P2TargetPlatform) getFinalTargetPlatform(project);
         PublisherActionRunner publisherRunner = getPublisherRunnerForProject(targetPlatform, environments);
-        PublishingRepository publishingRepository = reactorRepoManager.getPublishingRepository(project.getIdentities());
+        PublishingRepository publishingRepository = reactorRepoManager.getPublishingRepository(project);
 
         return new PublishProductToolImpl(publisherRunner, publishingRepository, targetPlatform, buildQualifier,
                 interpolator, mavenContext.getLogger());
+    }
+
+    /**
+     * Returns the target platform with final p2 metadata for the given project.
+     */
+    private TargetPlatform getFinalTargetPlatform(ReactorProject project) {
+        TargetPlatform targetPlatform = (TargetPlatform) project
+                .getContextValue(TargetPlatform.FINAL_TARGET_PLATFORM_KEY);
+        if (targetPlatform == null) {
+            throw new IllegalStateException("Target platform is missing");
+        }
+        return targetPlatform;
     }
 
     private PublisherActionRunner getPublisherRunnerForProject(P2TargetPlatform targetPlatform,

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ReactorRepositoryManagerImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ReactorRepositoryManagerImpl.java
@@ -13,133 +13,23 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.LegacySupport;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
-import org.eclipse.tycho.ExecutionEnvironmentConfiguration;
-import org.eclipse.tycho.MavenArtifactRepositoryReference;
-import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.ReactorProjectIdentities;
-import org.eclipse.tycho.TargetPlatform;
-import org.eclipse.tycho.TychoConstants;
-import org.eclipse.tycho.core.DependencyResolver;
-import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
-import org.eclipse.tycho.core.resolver.P2ResolverFactory;
 import org.eclipse.tycho.p2.repository.PublishingRepository;
 import org.eclipse.tycho.p2.repository.module.PublishingRepositoryImpl;
-import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
-import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
-import org.eclipse.tycho.p2.target.facade.TargetPlatformFactory;
 import org.eclipse.tycho.repository.registry.facade.ReactorRepositoryManager;
-import org.eclipse.tycho.targetplatform.TargetDefinition.MavenGAVLocation;
 
 @Component(role = ReactorRepositoryManager.class)
 public class ReactorRepositoryManagerImpl implements ReactorRepositoryManager {
 
-    private static final String PRELIMINARY_TARGET_PLATFORM_KEY = ReactorRepositoryManagerImpl.class.getName()
-            + "/dependencyOnlyTargetPlatform";
-
     @Requirement
     IProvisioningAgent agent;
-    @Requirement
-    P2ResolverFactory p2ResolverFactory;
-
-    @Requirement(hint = P2DependencyResolver.ROLE_HINT)
-    DependencyResolver p2Resolver;
-
-    @Requirement
-    LegacySupport legacySupport;
-    private TargetPlatformFactory tpFactory;
 
     @Override
     public PublishingRepository getPublishingRepository(ReactorProjectIdentities project) {
         return new PublishingRepositoryImpl(agent, project);
-    }
-
-    @Override
-    public TargetPlatform computePreliminaryTargetPlatform(ReactorProject project,
-            TargetPlatformConfigurationStub tpConfiguration, ExecutionEnvironmentConfiguration eeConfiguration,
-            List<ReactorProject> reactorProjects) {
-        //
-        // at this point, there is only incomplete ("dependency-only") metadata for the reactor projects
-        TargetPlatform result = getTpFactory().createTargetPlatform(tpConfiguration, eeConfiguration, reactorProjects,
-                project);
-        project.setContextValue(PRELIMINARY_TARGET_PLATFORM_KEY, result);
-
-        List<MavenArtifactRepositoryReference> repositoryReferences = tpConfiguration.getTargetDefinitions().stream()
-                .flatMap(definition -> definition.getLocations().stream()).filter(MavenGAVLocation.class::isInstance)
-                .map(MavenGAVLocation.class::cast).flatMap(location -> location.getRepositoryReferences().stream())
-                .toList();
-        project.setContextValue(TychoConstants.CTX_REPOSITORY_REFERENCE, repositoryReferences);
-        return result;
-    }
-
-    @Override
-    public TargetPlatform computeFinalTargetPlatform(ReactorProject project,
-            List<? extends ReactorProjectIdentities> upstreamProjects, PomDependencyCollector pomDependencyCollector) {
-        synchronized (project) {
-            PreliminaryTargetPlatformImpl preliminaryTargetPlatform = getRegisteredPreliminaryTargetPlatform(project);
-            if (preliminaryTargetPlatform == null) {
-                MavenSession session = project.adapt(MavenSession.class);
-                if (session == null) {
-                    session = legacySupport.getSession();
-                    if (session == null) {
-                        return null;
-                    }
-                }
-                MavenProject mavenProject = project.adapt(MavenProject.class);
-                if (mavenProject == null) {
-                    return null;
-                }
-                preliminaryTargetPlatform = (PreliminaryTargetPlatformImpl) p2Resolver
-                        .computePreliminaryTargetPlatform(session, mavenProject, DefaultReactorProject.adapt(session));
-
-            }
-            List<PublishingRepository> upstreamProjectResults = getBuildResults(upstreamProjects);
-            TargetPlatform result = getTpFactory().createTargetPlatformWithUpdatedReactorContent(
-                    preliminaryTargetPlatform, upstreamProjectResults, pomDependencyCollector);
-
-            project.setContextValue(TargetPlatform.FINAL_TARGET_PLATFORM_KEY, result);
-            return result;
-        }
-    }
-
-    private PreliminaryTargetPlatformImpl getRegisteredPreliminaryTargetPlatform(ReactorProject project) {
-        return project.getContextValue(
-                PRELIMINARY_TARGET_PLATFORM_KEY) instanceof PreliminaryTargetPlatformImpl preliminaryTargetPlatformImpl
-                        ? preliminaryTargetPlatformImpl
-                        : null;
-    }
-
-    private List<PublishingRepository> getBuildResults(List<? extends ReactorProjectIdentities> projects) {
-        List<PublishingRepository> results = new ArrayList<>(projects.size());
-        for (ReactorProjectIdentities project : projects) {
-            results.add(getPublishingRepository(project));
-        }
-        return results;
-    }
-
-    @Override
-    public TargetPlatform getFinalTargetPlatform(ReactorProject project) {
-        TargetPlatform targetPlatform = (TargetPlatform) project
-                .getContextValue(TargetPlatform.FINAL_TARGET_PLATFORM_KEY);
-        if (targetPlatform == null) {
-            throw new IllegalStateException("Target platform is missing");
-        }
-        return targetPlatform;
-    }
-
-    public synchronized TargetPlatformFactory getTpFactory() {
-        if (tpFactory == null) {
-            tpFactory = p2ResolverFactory.getTargetPlatformFactory();
-        }
-        return tpFactory;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/repository/registry/facade/ReactorRepositoryManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/repository/registry/facade/ReactorRepositoryManager.java
@@ -13,15 +13,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.repository.registry.facade;
 
-import java.util.List;
-
-import org.eclipse.tycho.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.ReactorProjectIdentities;
-import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.p2.repository.PublishingRepository;
-import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
-import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
 
 /**
  * Manages the p2 repositories for the projects' build results ("publishing repository") and the p2
@@ -30,41 +24,16 @@ import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
 public interface ReactorRepositoryManager {
 
     /**
-     * Computes the target platform with dependency-only p2 metadata and attaches it to the given
-     * project.
-     * 
-     * @param project
-     *            the reactor project to compute the target platform for.
-     * @param resolvedEnvironment
-     */
-    TargetPlatform computePreliminaryTargetPlatform(ReactorProject project,
-            TargetPlatformConfigurationStub tpConfiguration, ExecutionEnvironmentConfiguration eeConfiguration,
-            List<ReactorProject> reactorProjects);
-
-    /**
-     * Computes the (immutable) target platform with final p2 metadata and attaches it to the given
-     * project.
-     * 
-     * @param project
-     *            the reactor project to compute the target platform for.
-     * @param upstreamProjects
-     *            Other projects in the reactor which have already been built and may be referenced
-     *            by the given project.
-     */
-    TargetPlatform computeFinalTargetPlatform(ReactorProject project,
-            List<? extends ReactorProjectIdentities> upstreamProjects, PomDependencyCollector pomDependencyCollector);
-
-    /**
-     * Returns the target platform with final p2 metadata for the given project.
-     */
-    TargetPlatform getFinalTargetPlatform(ReactorProject project);
-
-    /**
      * Returns the project's publishing repository.
      * 
      * @param project
      *            a reference to a project in the reactor.
+     * @return the {@link PublishingRepository} for the {@link ReactorProjectIdentities}
      */
     PublishingRepository getPublishingRepository(ReactorProjectIdentities project);
+
+    default PublishingRepository getPublishingRepository(ReactorProject project) {
+        return getPublishingRepository(project.getIdentities());
+    }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ReactorRepositoryManagerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ReactorRepositoryManagerTest.java
@@ -13,28 +13,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.eclipse.tycho.test.util.InstallableUnitMatchers.unitWithId;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Arrays;
-import java.util.Collection;
-
-import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-import org.eclipse.tycho.MavenRepositoryLocation;
-import org.eclipse.tycho.ReactorProject;
-import org.eclipse.tycho.ReactorProjectIdentities;
-import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfigurationStub;
-import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
-import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
 import org.eclipse.tycho.repository.registry.facade.ReactorRepositoryManager;
-import org.eclipse.tycho.targetplatform.P2TargetPlatform;
-import org.eclipse.tycho.test.util.ReactorProjectIdentitiesStub;
 import org.eclipse.tycho.test.util.ReactorProjectStub;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -65,36 +49,6 @@ public class ReactorRepositoryManagerTest extends MavenServiceStubbingTestBase {
         subject = lookup(ReactorRepositoryManager.class);
 
         assertNotNull(subject);
-    }
-
-    @Test
-    @Ignore("This test currently do no longer work with the mocked project...")
-    public void testTargetPlatformComputationInIntegration() throws Exception {
-        subject = lookup(ReactorRepositoryManager.class);
-        assertNotNull(subject);
-        ReactorProject currentProject = new ReactorProjectStub("reactor-artifact");
-
-        TargetPlatformConfigurationStub tpConfig = new TargetPlatformConfigurationStub();
-        tpConfig.addP2Repository(
-                new MavenRepositoryLocation(null, ResourceUtil.resourceFile("repositories/launchers").toURI()));
-        subject.computePreliminaryTargetPlatform(currentProject, tpConfig,
-                new ExecutionEnvironmentConfigurationStub("JavaSE-1.7"), null);
-
-        ReactorProjectIdentities upstreamProject = new ReactorProjectIdentitiesStub(
-                ResourceUtil.resourceFile("projectresult"));
-
-        subject.computeFinalTargetPlatform(currentProject, Arrays.asList(upstreamProject), pomDependencyCollector);
-
-        P2TargetPlatform finalTP = (P2TargetPlatform) currentProject
-                .getContextValue("org.eclipse.tycho.core.TychoConstants/targetPlatform");
-        Collection<IInstallableUnit> units = finalTP.getInstallableUnits();
-        // units from the p2 repository
-        assertThat(units, hasItem(unitWithId("org.eclipse.equinox.launcher")));
-        // units from the upstream project
-        assertThat(units, hasItem(unitWithId("bundle")));
-        assertThat(units, hasItem(unitWithId("bundle.source")));
-
-        // TODO get artifact
     }
 
 }

--- a/tycho-p2-publisher-plugin/src/main/java/org/eclipse/tycho/plugins/p2/publisher/PublishProductMojo.java
+++ b/tycho-p2-publisher-plugin/src/main/java/org/eclipse/tycho/plugins/p2/publisher/PublishProductMojo.java
@@ -137,7 +137,7 @@ public final class PublishProductMojo extends AbstractPublishMojo {
             File artifactsXml = new File(getProject().getBuild().getDirectory(), TychoConstants.FILE_NAME_P2_ARTIFACTS);
             if (artifactsXml.isFile()) {
                 PublishingRepository publishingRepository = reactorRepoManager
-                        .getPublishingRepository(getReactorProject().getIdentities());
+                        .getPublishingRepository(getReactorProject());
                 IFileArtifactRepository repository = publishingRepository.getArtifactRepository();
                 repository.descriptorQueryable().query(new IQuery<IArtifactDescriptor>() {
 


### PR DESCRIPTION
Currently ReactorRepositoryManager is also involved in computing target platforms that is actually called on other places with similar context and only referenced on single places.

This strip down ReactorRepositoryManager to providing the PublishingRepository and inline the computation of platforms to allow more local optimiziations.