### PR TITLE
Consider the max occurrence of a requirement

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/TargetEnvironment.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/TargetEnvironment.java
@@ -13,7 +13,6 @@
 package org.eclipse.tycho;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -88,7 +87,7 @@ public final class TargetEnvironment {
      * Returns the target environment as map. The keys are "osgi.ws", "osgi.os", and "osgi.arch".
      * This format is used by the p2 slicer to filter installable units by environments.
      * 
-     * @return a new instance of {@link HashMap} with the target environment set
+     * @return a new instance of {@link LinkedHashMap} with the target environment set
      */
     public Map<String, String> toFilterProperties() {
         //for nicer debug output, use an ordered map here

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
@@ -36,6 +36,8 @@ import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ClasspathEntry;
@@ -43,6 +45,7 @@ import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.ResolvedArtifactKey;
+import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.TargetPlatformService;
 import org.eclipse.tycho.TychoConstants;
@@ -141,6 +144,25 @@ public class TychoProjectManager {
             sink.setProfileConfiguration(configuredDefaultProfile,
                     "target-platform-configuration <executionEnvironmentDefault>");
         }
+    }
+
+    public List<IInstallableUnit> getContextIUs(MavenProject project) {
+        TargetPlatformConfiguration configuration = getTargetPlatformConfiguration(project);
+        return configuration.getEnvironments().stream().map(env -> getProfileProperties(env, configuration))
+                .map(InstallableUnit::contextIU).toList();
+    }
+
+    public Map<String, String> getProfileProperties(MavenProject project, TargetEnvironment environment) {
+        TargetPlatformConfiguration configuration = getTargetPlatformConfiguration(project);
+        return getProfileProperties(environment, configuration);
+    }
+
+    private Map<String, String> getProfileProperties(TargetEnvironment environment,
+            TargetPlatformConfiguration configuration) {
+        Map<String, String> properties = environment.toFilterProperties();
+        properties.put("org.eclipse.update.install.features", "true");
+        properties.putAll(configuration.getProfileProperties());
+        return properties;
     }
 
     public TargetPlatformConfiguration getTargetPlatformConfiguration(MavenProject project) {


### PR DESCRIPTION
Currently all matching units are considered even if there are only a lower number to use.

This adds a filtering after the initial collection phase to limit the dependencies to the max of the requirement and also adds the infrastructure to support filtering based on the profile properties.

relates to https://github.com/eclipse-tycho/tycho/issues/3197

FYI @merks this will fix the issue seen with:
- https://github.com/eclipse-tycho/tycho/pull/3198

but will conflict with your change to `InstallableUnitSlicer.java`, can you probably remove that from your PR so we have a test-case only change?