### PR TITLE
Fix and test cases for #2930

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultMavenRepositorySettings.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultMavenRepositorySettings.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
@@ -157,5 +158,10 @@ public class DefaultMavenRepositorySettings implements MavenRepositorySettings, 
 			settings = new Settings();
 			mirrors = Collections.emptyList();
 		}
+	}
+
+	@Override
+	public Stream<MavenRepositoryLocation> getMirrors() {
+		return mirrors.stream().map(m -> new MavenRepositoryLocation(m.getId(), URI.create(m.getUrl())));
 	}
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultRepositoryIdManager.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultRepositoryIdManager.java
@@ -118,9 +118,10 @@ public class DefaultRepositoryIdManager implements IRepositoryIdManager {
 
     @Override
 	public Stream<MavenRepositoryLocation> getKnownMavenRepositoryLocations() {
-        return knownMavenRepositoryIds.entrySet().stream()
-                .map(e -> new MavenRepositoryLocation(e.getValue(), e.getKey()));
-    }
+		// Returns both repository and mirror locations
+		return Stream.concat(knownMavenRepositoryIds.entrySet().stream()
+				.map(e -> new MavenRepositoryLocation(e.getValue(), e.getKey())), settings.getMirrors());
+	}
 
 	@Override
 	public MavenRepositorySettings getSettings() {

--- a/tycho-api/src/main/java/org/eclipse/tycho/MavenRepositorySettings.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/MavenRepositorySettings.java
@@ -14,6 +14,7 @@
 package org.eclipse.tycho;
 
 import java.net.URI;
+import java.util.stream.Stream;
 
 /**
  * Provides the mirror configuration and credentials from the Maven settings for loading remote p2
@@ -59,5 +60,10 @@ public interface MavenRepositorySettings {
      * Returns the configured credentials for the given repository, or <code>null</code>.
      */
     Credentials getCredentials(MavenRepositoryLocation location);
+
+    /**
+     * Returns all configured mirror locations.
+     */
+    Stream<MavenRepositoryLocation> getMirrors();
 
 }

--- a/tycho-its/projects/target.httpAuthentication/settings-auth-mirror.xml
+++ b/tycho-its/projects/target.httpAuthentication/settings-auth-mirror.xml
@@ -1,0 +1,18 @@
+<settings>
+  <servers>
+    <server>
+      <id>test-auth-mirror</id>
+      <username>mirror-user</username>
+      <password>mirror-password</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>test-auth-mirror</id>      
+      <url>${p2.authMirror}</url>
+      <mirrorOf>test-server</mirrorOf>
+      <layout>p2</layout>
+      <mirrorOfLayouts>p2</mirrorOfLayouts>
+	</mirror>	  
+  </mirrors>
+</settings>

--- a/tycho-its/projects/target.httpAuthentication/settings-mirror.xml
+++ b/tycho-its/projects/target.httpAuthentication/settings-mirror.xml
@@ -1,0 +1,11 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>test-mirror</id>      
+      <url>${p2.mirror}</url>	
+      <mirrorOf>test-server</mirrorOf>
+      <layout>p2</layout>
+      <mirrorOfLayouts>p2</mirrorOfLayouts>
+	</mirror>	  
+  </mirrors>
+</settings>


### PR DESCRIPTION
Two test cases added to class _PasswordProtectedP2RepositoryTest_ for trying to reproduce the bug:

- _testMirror_: the test server is accessed over a mirror without authentication.
- _testAuthMirror_: the test server is accessed over a mirror with authentication. This the one that should fail.

 As things stand, they both pass, so they need improving.