### PR TITLE
[backport] Support using a provisioned install for eclipse-run mojo

### DIFF
--- a/sisu-osgi/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/ProvisionedEquinoxInstallation.java
+++ b/sisu-osgi/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/ProvisionedEquinoxInstallation.java
@@ -10,12 +10,10 @@
  * Contributors:
  *    Mickael Istria (Red Hat Inc.) - 386988 Support for provisioned applications
  ******************************************************************************/
-package org.eclipse.tycho.surefire.provisioning;
+package org.eclipse.sisu.equinox.launching;
 
 import java.io.File;
 
-import org.eclipse.sisu.equinox.launching.EquinoxInstallation;
-import org.eclipse.sisu.equinox.launching.EquinoxInstallationDescription;
 import org.eclipse.sisu.equinox.launching.internal.EquinoxInstallationLaunchConfiguration;
 
 /**
@@ -33,7 +31,7 @@ public class ProvisionedEquinoxInstallation implements EquinoxInstallation {
 
     public ProvisionedEquinoxInstallation(File location) {
         this.location = location;
-        description = new ProvisionedInstallationDescription(location, null);
+        description = new ProvisionedInstallationDescription(location);
     }
 
     @Override

--- a/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
@@ -53,10 +53,10 @@ public class EclipseRunMojo extends org.eclipse.tycho.eclipserun.EclipseRunMojo 
 			List<String> applicationArgs, int forkedProcessTimeoutInSeconds, Map<String, String> environmentVariables,
 			EquinoxInstallationFactory installationFactory, EquinoxLauncher launcher,
 			ToolchainProvider toolchainProvider, P2ResolverFactory resolverFactory, Logger logger,
-			ToolchainManager toolchainManager, TargetPlatformFactory platformFactory) {
+			ToolchainManager toolchainManager, TargetPlatformFactory platformFactory, File installation) {
 		super(work, clearWorkspaceBeforeLaunch, project, dependencies, addDefaultDependencies, executionEnvironment,
 				repositories, session, jvmArgs, skip, applicationArgs, forkedProcessTimeoutInSeconds,
 				environmentVariables, installationFactory, launcher, toolchainProvider, resolverFactory, logger,
-				toolchainManager, platformFactory);
+				toolchainManager, platformFactory, installation);
 	}
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilder.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilder.java
@@ -22,6 +22,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.sisu.equinox.launching.EquinoxInstallation;
+import org.eclipse.sisu.equinox.launching.ProvisionedEquinoxInstallation;
 import org.eclipse.tycho.PlatformPropertiesUtils;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.p2.tools.director.shared.DirectorCommandException;


### PR DESCRIPTION
Currently Tycho always assembles the eclipse installation used by the eclipse run mojo but in some cases it is more useful to run an existing application.

This now adds support to use an already assembled eclipse installation.