### PR TITLE
make "include" the default for referencedRepositoryMode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -83,9 +83,10 @@ to your project and make sure it has the `org.eclipse.pde.api.tools.apiAnalysisN
 
 Tycho now contains a new `tycho-repository-plugin` that can be used to package OSGi repositories.
 
-### new option to include referenced repositories when resolving the target platform
+### referenced repositories are considered by default when resolving the target platform
 
-Repositories can contain references to other repositories (e.g. to find additional dependencies), from now on there is a new option to also consider these references:
+The option `referencedRepositoryMode`, introduced in Tycho 4.0.2, now defaults to `include`: referenced repositories are considered by default when resolving the target platform, as PDE already does.
+To restore the old behavior of Tycho 4.0.2, you need to explicitly set the option to `ignore`:
 
 ```xml
 <plugin>
@@ -94,7 +95,7 @@ Repositories can contain references to other repositories (e.g. to find addition
 	<version>${tycho-version}</version>
 	<configuration>
 		... other configuration options ...
-		<referencedRepositoryMode>include</referencedRepositoryMode>
+		<referencedRepositoryMode>ignore</referencedRepositoryMode>
 	</configuration>
 </plugin>
 	
@@ -155,7 +156,21 @@ If `addOnlyProviding` is `true` repositories that don't provide any filtered uni
 ```
 
 ## 4.0.2
-- new option to include referenced repositories when resolving the target platform
+- new option to include referenced repositories when resolving the target platform:
+Repositories can contain references to other repositories (e.g. to find additional dependencies), from now on there is a new option, `referencedRepositoryMode`, to also consider these references. By default, it is set to `ignore`; to enable referenced repositories in target platform resolution, set it to `include`:
+
+```xml
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>target-platform-configuration</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		... other configuration options ...
+		<referencedRepositoryMode>include</referencedRepositoryMode>
+	</configuration>
+</plugin>
+```
+
 - Add dummy parameter to prevent warnings with jgit as timestamp provider
 
 ## 4.0.1

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -119,7 +119,7 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     private InjectP2MavenMetadataHandling p2MavenMetadataHandling;
 
-    private ReferencedRepositoryMode referencedRepositoryMode = ReferencedRepositoryMode.ignore;
+    private ReferencedRepositoryMode referencedRepositoryMode = ReferencedRepositoryMode.include;
 
     /**
      * Returns the list of configured target environments, or the running environment if no

--- a/tycho-its/projects/compiler.exclude/pom.xml
+++ b/tycho-its/projects/compiler.exclude/pom.xml
@@ -28,6 +28,18 @@
 				<version>${tycho-version}</version>
 				<extensions>true</extensions>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!-- The default is now include, and this would lead to
+						failures of the shape
+						Failed to load p2 repository from location http://download.eclipse.org/dsdp/dd/updates:
+						No repository found at http://download.eclipse.org/dsdp/dd/updates -->
+					<referencedRepositoryMode>ignore</referencedRepositoryMode>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/tycho-its/projects/p2Repository.repositoryRef.targetresolution.ignore/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2Repository.repositoryRef.targetresolution.ignore/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: p2Repository.repositoryRef.target;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.epsilon.picto
+Bundle-Name: p2Repository.repositoryRef.target

--- a/tycho-its/projects/p2Repository.repositoryRef.targetresolution.ignore/build.properties
+++ b/tycho-its/projects/p2Repository.repositoryRef.targetresolution.ignore/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/p2Repository.repositoryRef.targetresolution.ignore/pom.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.targetresolution.ignore/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project.p2Repository.repositoryRef.targetresolution</groupId>
+	<artifactId>p2Repository.repositoryRef.target</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>
+							${project.basedir}/test-target.target
+						</file>
+					</target>
+					<referencedRepositoryMode>ignore</referencedRepositoryMode>
+					<!--
+					The project requires a bundle from Epsilon and Eclipse.
+					The target platform only uses the Epsilon update site.
+					Epsilon update site uses referenced repositories so using its update site alone
+					should be enough to resolve the transitive dependencies.
+					However, we explicitly ignore referenced sites, so this should lead to
+					a resolution failure -->
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2Repository.repositoryRef.targetresolution.ignore/test-target.target
+++ b/tycho-its/projects/p2Repository.repositoryRef.targetresolution.ignore/test-target.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="test-target.target" sequenceNumber="1">
+	<locations>
+		<!-- Epsilon update site uses referenced repositories so using its update site alone
+			should be enough to resolve the transitive dependencies -->
+		<location includeAllPlatforms="false" includeConfigurePhase="true"
+			includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.epsilon.picto"
+				version="0.0.0" />
+			<repository
+				location="https://download.eclipse.org/epsilon/updates/2.4/" />
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/p2Repository.repositoryRef.targetresolution.include/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2Repository.repositoryRef.targetresolution.include/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: p2Repository.repositoryRef.target;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.epsilon.picto
+Bundle-Name: p2Repository.repositoryRef.target

--- a/tycho-its/projects/p2Repository.repositoryRef.targetresolution.include/build.properties
+++ b/tycho-its/projects/p2Repository.repositoryRef.targetresolution.include/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/p2Repository.repositoryRef.targetresolution.include/pom.xml
+++ b/tycho-its/projects/p2Repository.repositoryRef.targetresolution.include/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project.p2Repository.repositoryRef.targetresolution</groupId>
+	<artifactId>p2Repository.repositoryRef.target</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>
+							${project.basedir}/test-target.target
+						</file>
+					</target>
+					<!-- The default is
+					<referencedRepositoryMode>include</referencedRepositoryMode>
+					The project requires a bundle from Epsilon and Eclipse.
+					The target platform only uses the Epsilon update site.
+					Epsilon update site uses referenced repositories so using its update site alone
+					should be enough to resolve the transitive dependencies-->
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2Repository.repositoryRef.targetresolution.include/test-target.target
+++ b/tycho-its/projects/p2Repository.repositoryRef.targetresolution.include/test-target.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="test-target.target" sequenceNumber="1">
+	<locations>
+		<!-- Epsilon update site uses referenced repositories so using its update site alone
+			should be enough to resolve the transitive dependencies -->
+		<location includeAllPlatforms="false" includeConfigurePhase="true"
+			includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.epsilon.picto"
+				version="0.0.0" />
+			<repository
+				location="https://download.eclipse.org/epsilon/updates/2.4/" />
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/sourcePlugin/basic/pom.xml
+++ b/tycho-its/projects/sourcePlugin/basic/pom.xml
@@ -61,6 +61,19 @@
 					<forceContextQualifier>123abc</forceContextQualifier>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!-- The default is now include, and this would lead to
+						failures of the shape
+						Failed to load p2 repository from location http://download.eclipse.org/dsdp/dd/updates:
+						No repository found at http://download.eclipse.org/dsdp/dd/updates -->
+					<referencedRepositoryMode>ignore</referencedRepositoryMode>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/tycho-its/projects/sourcePlugin/extra-source-bundles/pom.xml
+++ b/tycho-its/projects/sourcePlugin/extra-source-bundles/pom.xml
@@ -44,6 +44,19 @@
 					<forceContextQualifier>123abc</forceContextQualifier>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!-- The default is now include, and this would lead to
+						failures of the shape
+						Failed to load p2 repository from location http://download.eclipse.org/dsdp/dd/updates:
+						No repository found at http://download.eclipse.org/dsdp/dd/updates -->
+					<referencedRepositoryMode>ignore</referencedRepositoryMode>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/tycho-its/projects/sourcePlugin/remote-source-bundles/pom.xml
+++ b/tycho-its/projects/sourcePlugin/remote-source-bundles/pom.xml
@@ -57,6 +57,19 @@
 					<forceContextQualifier>123abc</forceContextQualifier>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!-- The default is now include, and this would lead to
+						failures of the shape
+						Failed to load p2 repository from location http://download.eclipse.org/dsdp/dd/updates:
+						No repository found at http://download.eclipse.org/dsdp/dd/updates -->
+					<referencedRepositoryMode>ignore</referencedRepositoryMode>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepoRefLocationP2RepositoryIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepoRefLocationP2RepositoryIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.equinox.p2.repository.IRepository.TYPE_METADATA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.List;
@@ -82,6 +83,25 @@ public class RepoRefLocationP2RepositoryIntegrationTest extends AbstractTychoInt
 				new RepositoryReference("https://download.eclipse.org/eclipse/updates/4.29", TYPE_METADATA, ENABLED),
 				new RepositoryReference("https://download.eclipse.org/cbi/updates/license", TYPE_ARTIFACT, ENABLED),
 				new RepositoryReference("https://download.eclipse.org/cbi/updates/license", TYPE_METADATA, ENABLED)));
+	}
+
+	@Test
+	public void testTargetResolutionWithReferencedRepositoryInclude() throws Exception {
+		// <referencedRepositoryMode>include</referencedRepositoryMode> is the default
+		Verifier verifier = getVerifier("/p2Repository.repositoryRef.targetresolution.include", false);
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	@Test
+	public void testTargetResolutionWithReferencedRepositoryIgnore() throws Exception {
+		Verifier verifier = getVerifier("/p2Repository.repositoryRef.targetresolution.ignore", false);
+		try {
+			verifier.executeGoal("package");
+			fail("Build should fail due to missing transitive dependency dependency");
+		} catch (VerificationException e) {
+			verifier.verifyTextInLog("requires 'osgi.bundle; org.eclipse.emf.ecore 0.0.0' but it could not be found");
+		}
 	}
 
 	private List<RepositoryReference> buildAndGetRepositoryReferences(String buildRoot, Consumer<Verifier> setup)


### PR DESCRIPTION
Closes #3231 

I added `ignore` in a few existing IT that now would fail https://github.com/eclipse-tycho/tycho/commit/27d4db5dbf2b268ca3538776e3a6cf4c2105712e

I added 2 new ITs to test the default behavior, and when `ignore` is passed https://github.com/eclipse-tycho/tycho/commit/1e4f477bdfb06a67fd9642b842a78cf1b7382f9c. For these 2 new ITs, I relied on the Epsilon update site that I know has referenced repositories. I hope that's fine. I added the corresponding test methods into https://github.com/eclipse-tycho/tycho/commit/1e4f477bdfb06a67fd9642b842a78cf1b7382f9c#diff-d6720b06bef8b3e5409e7044e315c4952389dfb8f160ff2ff965002fe333c98d. I don't know if that's the right place, but it looked like so.

Finally, I updated the release notes accordingly https://github.com/eclipse-tycho/tycho/commit/6d72e7b6f6dbf49a716da9a6d910cd99f945eeea. I took the chance to document that option in 4.0.2 where it was added (or backported?).