### PR TITLE
Disable P2 mirrors by default

### DIFF
--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryPropertiesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryPropertiesTest.java
@@ -78,4 +78,10 @@ public class P2RepositoryPropertiesTest extends AbstractTychoIntegrationTest {
 		assertTrue(properties.containsKey(TychoConstants.PROP_PGP_SIGNATURES)
 				&& !properties.get(TychoConstants.PROP_PGP_SIGNATURES).isBlank());
 	}
+
+	@Override
+	protected boolean isDisableMirrors() {
+		// we want to test mirror properties...
+		return false;
+	}
 }

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/AbstractTychoIntegrationTest.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/AbstractTychoIntegrationTest.java
@@ -90,6 +90,9 @@ public abstract class AbstractTychoIntegrationTest {
 
         Verifier verifier = new Verifier(testDir.getAbsolutePath());
         verifier.setForkJvm(isForked());
+        if (isDisableMirrors()) {
+            verifier.setSystemProperty("tycho.disableP2Mirrors", "true");
+        }
         String debug = System.getProperty("tycho.mvnDebug");
         if (debug != null) {
             System.out.println("Preparing to execute Maven in debug mode");
@@ -144,6 +147,14 @@ public abstract class AbstractTychoIntegrationTest {
 
         return verifier;
 
+    }
+
+    /**
+     * can be overridden by subclass to explicitly enable mirrors, by default they are disabled.
+     * 
+     */
+    protected boolean isDisableMirrors() {
+        return true;
     }
 
     protected boolean isForked() {


### PR DESCRIPTION
Having p2 mirrors enabled has some drawbacks as it can lead to instabilities see https://github.com/eclipse-equinox/p2/pull/414 also test can fail because a mirror can't be reached or is slow.

Because of this we should disable mirrors all together and only selectively enable them for tests where this is required.