### PR TITLE
Make Tycho work behind https proxy

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/helper/ProxyHelper.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/helper/ProxyHelper.java
@@ -70,6 +70,9 @@ public class ProxyHelper implements Initializable {
 		if (org.eclipse.aether.repository.Proxy.TYPE_HTTP.equalsIgnoreCase(type)) {
 			return Type.HTTP;
 		}
+		if (org.eclipse.aether.repository.Proxy.TYPE_HTTPS.equalsIgnoreCase(type)) {
+			return Type.HTTP;
+		}
 		return Type.SOCKS;
 	}
 


### PR DESCRIPTION
If a proxy is specified with the https procotol in the settings.xml, Tycho fails downloading artifacts from any URL that uses that proxy, because it wrongly configures a SOCKS transport in such cases.

Fixes #1935, #2709, #2533.

This affects all 4.x versions and should probably be backported.

Fame belongs to @glatuske who had pointed me to that line some time earlier already...