### PR TITLE
Add support for mirroring the projects target platform

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ### backports:
 
+- new `mirror-target-platform` mojo
 - new director mojo
 - support for PDE Api Tools Annotations
 - api tools fixes

--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,8 @@
 					<configuration>
 						<source>${min.jdk.version}</source>
 						<target>${min.jdk.version}</target>
+						<!-- Workaround for https://issues.apache.org/jira/browse/MCOMPILER-567 -->
+						<useIncrementalCompilation>false</useIncrementalCompilation>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/MirrorTargetPlatformMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/MirrorTargetPlatformMojo.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.target;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+import org.eclipse.tycho.ReactorProject;
+import org.eclipse.tycho.TargetPlatform;
+import org.eclipse.tycho.TargetPlatformService;
+import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
+import org.eclipse.tycho.p2.repository.ListCompositeMetadataRepository;
+import org.eclipse.tycho.p2.repository.PublishingRepository;
+import org.eclipse.tycho.p2.tools.FacadeException;
+import org.eclipse.tycho.p2.tools.mirroring.facade.MirrorApplicationService;
+import org.eclipse.tycho.p2maven.ListCompositeArtifactRepository;
+import org.eclipse.tycho.repository.registry.facade.ReactorRepositoryManager;
+
+/**
+ * Supports mirroring the computed target platform of the current project, this behaves similar to
+ * what PDE offers with its export deployable feature / plug-in and assembles an update site that
+ * contains everything this particular project depends on.
+ */
+@Mojo(name = "mirror-target-platform", threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
+public class MirrorTargetPlatformMojo extends AbstractMojo {
+
+    @Parameter(property = "project", readonly = true)
+    private MavenProject project;
+
+    @Parameter(defaultValue = "${project.build.directory}/target-platform-repository")
+    private File destination;
+
+    @Parameter(defaultValue = "${project.id}")
+    private String name;
+
+    @Component
+    private TargetPlatformService platformService;
+
+    @Component
+    private MirrorApplicationService mirrorService;
+
+    @Component
+    private ReactorRepositoryManager repositoryManager;
+
+    @Component
+    private IProvisioningAgent agent;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        ReactorProject reactorProject = DefaultReactorProject.adapt(project);
+        TargetPlatform targetPlatform = platformService.getTargetPlatform(reactorProject).orElse(null);
+        if (targetPlatform == null) {
+            getLog().info("Project has no target platform, skip execution.");
+            return;
+        }
+        IArtifactRepository sourceArtifactRepository = targetPlatform.getArtifactRepository();
+        IMetadataRepository sourceMetadataRepository = targetPlatform.getMetadataRepository();
+        PublishingRepository publishingRepository = repositoryManager.getPublishingRepository(reactorProject);
+        getLog().info("Mirroring target platform, this can take a while ...");
+        try {
+            IArtifactRepository artifactRepository = new ListCompositeArtifactRepository(
+                    List.of(sourceArtifactRepository, publishingRepository.getArtifactRepository()), agent);
+            IMetadataRepository metadataRepository = new ListCompositeMetadataRepository(
+                    List.of(sourceMetadataRepository, publishingRepository.getMetadataRepository()), agent);
+            mirrorService.mirrorDirect(artifactRepository, metadataRepository, destination, name);
+        } catch (FacadeException e) {
+            throw new MojoFailureException(e.getMessage(), e.getCause());
+        }
+    }
+
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
@@ -17,6 +17,8 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.tycho.BuildDirectory;
 import org.eclipse.tycho.DependencySeed;
 import org.eclipse.tycho.p2.tools.BuildContext;
@@ -106,6 +108,22 @@ public interface MirrorApplicationService {
     void mirrorStandalone(RepositoryReferences sources, DestinationRepositoryDescriptor destination,
             Collection<IUDescription> seedUnits, MirrorOptions mirrorOptions, BuildDirectory tempDirectory)
             throws FacadeException;
+
+    /**
+     * Mirrors the given sources to the destination, if the destination exits it will be delete
+     * beforehand.
+     * 
+     * @param sourceArtifactRepository
+     *            the source artifact repository
+     * @param sourceMetadataRepository
+     *            the source metadata repository
+     * @param repositoryDestination
+     *            the destination
+     * @param repositoryName
+     *            the name of the new repository
+     */
+    void mirrorDirect(IArtifactRepository sourceArtifactRepository, IMetadataRepository sourceMetadataRepository,
+            File repositoryDestination, String repositoryName) throws FacadeException;
 
     /**
      * Modifies the artifact repository to add mapping rules to download Maven released artifacts

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/InstallableUnitResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/InstallableUnitResolver.java
@@ -75,7 +75,8 @@ public class InstallableUnitResolver {
         this.logger = logger;
     }
 
-    public void addLocation(InstallableUnitLocation iuLocationDefinition, IQueryable<IInstallableUnit> localUnits) {
+    public Collection<IInstallableUnit> addLocation(InstallableUnitLocation iuLocationDefinition,
+            IQueryable<IInstallableUnit> localUnits) {
         //update (and validate) desired global state
         setIncludeMode(iuLocationDefinition.getIncludeMode());
         setIncludeAllEnvironments(iuLocationDefinition.includeAllEnvironments());
@@ -85,7 +86,9 @@ public class InstallableUnitResolver {
         default -> iuLocationDefinition.includeSource();
         });
         //resolve root units and add them
-        rootUnits.add(new RootUnits(getRootIUs(iuLocationDefinition.getUnits(), localUnits), localUnits));
+        Collection<IInstallableUnit> rootIUs = getRootIUs(iuLocationDefinition.getUnits(), localUnits);
+        rootUnits.add(new RootUnits(rootIUs, localUnits));
+        return rootIUs;
     }
 
     private void setIncludeMode(IncludeMode newValue) throws TargetDefinitionResolutionException {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PreliminaryTargetPlatformImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PreliminaryTargetPlatformImpl.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
@@ -61,7 +62,8 @@ public class PreliminaryTargetPlatformImpl extends TargetPlatformBaseImpl {
             Collection<IInstallableUnit> externalIUs, ExecutionEnvironmentResolutionHints executionEnvironment,
             TargetPlatformFilterEvaluator filter, LocalMetadataRepository localMetadataRepository,
             IRawArtifactFileProvider externalArtifacts, LocalArtifactRepository localArtifactRepository,
-            boolean includeLocalRepo, MavenLogger logger, Set<IInstallableUnit> shadowed) {
+            boolean includeLocalRepo, MavenLogger logger, Set<IInstallableUnit> shadowed,
+            IProvisioningAgent remoteAgent) {
         super(collectAllInstallableUnits(reactorProjectIUs, externalIUs, executionEnvironment), executionEnvironment,
                 externalArtifacts, localArtifactRepository, reactorProjectIUs, new HashMap<>(), shadowed);
         this.externalIUs = externalIUs;
@@ -69,7 +71,8 @@ public class PreliminaryTargetPlatformImpl extends TargetPlatformBaseImpl {
         this.localMetadataRepository = localMetadataRepository;
         this.includeLocalRepo = includeLocalRepo;
         this.logger = logger;
-        this.artifactRepository = new ProviderOnlyArtifactRepository(artifacts, null, URI.create("preliminary:/"));
+        this.artifactRepository = new ProviderOnlyArtifactRepository(artifacts, remoteAgent,
+                URI.create("preliminary:/"));
     }
 
     public static LinkedHashSet<IInstallableUnit> collectAllInstallableUnits(

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryImpl.java
@@ -294,7 +294,7 @@ public class TargetPlatformFactoryImpl implements TargetPlatformFactory {
                 externalArtifactFileProvider, //
                 localArtifactRepository, //
                 includeLocalMavenRepo, //
-                logger, shadowed);
+                logger, shadowed, remoteAgent);
         eeResolutionHandler.readFullSpecification(targetPlatform.getInstallableUnits());
 
         return targetPlatform;

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeSourceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeSourceTest.java
@@ -21,7 +21,11 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.equinox.p2.query.QueryUtil;
@@ -83,7 +87,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
 
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
-        assertEquals(2, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
+        assertEquals(2, getResultSet(content).size());
     }
 
     @Test
@@ -96,7 +100,12 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
 
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
-        assertEquals(2, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
+        assertEquals(2, getResultSet(content).size());
+    }
+
+    private Set<IInstallableUnit> getResultSet(TargetDefinitionContent content) {
+        return content.query(QueryUtil.ALL_UNITS, null).stream()
+                .filter(iu -> !iu.getId().startsWith("generated.target.category.")).collect(Collectors.toSet());
     }
 
     @Test
@@ -108,7 +117,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
                 lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(content), not(hasItem(SOURCE_BUNDLE)));
-        assertEquals(1, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
+        assertEquals(1, getResultSet(content).size());
     }
 
     @Test
@@ -120,7 +129,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
                 lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(content), not(hasItem(SOURCE_BUNDLE)));
-        assertEquals(1, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
+        assertEquals(1, getResultSet(content).size());
     }
 
     @Test
@@ -134,7 +143,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
         assertThat(versionedIdsOf(content), hasItem(NOSOURCE_BUNDLE));
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
-        assertEquals(3, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
+        assertEquals(3, getResultSet(content).size());
     }
 
     @Test
@@ -148,7 +157,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
         assertThat(versionedIdsOf(content), hasItem(NOSOURCE_BUNDLE));
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
-        assertEquals(3, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
+        assertEquals(3, getResultSet(content).size());
     }
 
     static class WithSourceLocationStub extends LocationStub {

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverTest.java
@@ -253,7 +253,11 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
     static Collection<IVersionedId> versionedIdsOf(TargetDefinitionContent content) {
         Collection<IVersionedId> result = new ArrayList<>();
         for (IInstallableUnit unit : content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet()) {
-            result.add(new VersionedId(unit.getId(), unit.getVersion()));
+            String id = unit.getId();
+            if (id.startsWith("generated.target.category.")) {
+                continue;
+            }
+            result.add(new VersionedId(id, unit.getVersion()));
         }
         return result;
     }

--- a/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinition.java
+++ b/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinition.java
@@ -115,6 +115,8 @@ public interface TargetDefinition {
 
 		Element getFeatureTemplate();
 
+		String getLabel();
+
 		@Override
 		public default String getTypeDescription() {
 			return TYPE;


### PR DESCRIPTION
This adds support for converting the projects computed target platform into a deployable p2 repository. This can be used to create a mirror of a target-file, or to have a repository that can be used to install one specific bundle or feature with all its dependencies.