### PR TITLE
Fixed demos for testing by using a released non-snapshot tycho version.

### DIFF
--- a/demo/testing/bnd/pom.xml
+++ b/demo/testing/bnd/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.0.0</version>
 	<properties>
 		<target-platform>https://download.eclipse.org/releases/2022-12/</target-platform>
-		<tycho-version>4.0.0-SNAPSHOT</tycho-version>
+		<tycho-version>4.0.4</tycho-version>
 		<bnd-version>6.4.0</bnd-version>
 	</properties>
 	<repositories>

--- a/demo/testing/surefire/pom.xml
+++ b/demo/testing/surefire/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.0.0</version>
 	<properties>
 		<target-platform>https://download.eclipse.org/releases/2022-12/</target-platform>
-		<tycho-version>4.0.0-SNAPSHOT</tycho-version>
+		<tycho-version>4.0.4</tycho-version>
 		<surefire-plugin-version>3.0.0-M7</surefire-plugin-version>
 	</properties>
 	<repositories>

--- a/demo/testing/tycho/pom.xml
+++ b/demo/testing/tycho/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.0.0</version>
 	<properties>
 		<target-platform>https://download.eclipse.org/releases/2022-12/</target-platform>
-		<tycho-version>4.0.0-SNAPSHOT</tycho-version>
+		<tycho-version>4.0.4</tycho-version>
 	</properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
Fixed demos for testing by using a released non-snapshot tycho version -> latest released, which is 4.0.4.