### PR TITLE
Only use ci-friendly version if there is such property defined

### DIFF
--- a/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
@@ -84,7 +84,7 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 				if (properties.getProperty(TychoCiFriendlyVersions.PROPERTY_BUILDQUALIFIER_FORMAT) != null
 						|| properties.getProperty(TychoCiFriendlyVersions.PROPERTY_FORCE_QUALIFIER) != null
 						|| properties.getProperty(TychoCiFriendlyVersions.BUILD_QUALIFIER) != null) {
-					tychoMapping.setSnapshotFormat("${" + TychoCiFriendlyVersions.BUILD_QUALIFIER + "}");
+					tychoMapping.setSnapshotProperty(TychoCiFriendlyVersions.BUILD_QUALIFIER);
 				}
 			}
 		}

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndWorkspaceMapping.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndWorkspaceMapping.java
@@ -23,11 +23,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import org.apache.maven.model.Model;
-import org.apache.maven.model.Parent;
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.pomless.AbstractTychoMapping;
 import org.eclipse.tycho.pomless.NoParentPomFound;
+import org.eclipse.tycho.pomless.ParentModel;
 import org.sonatype.maven.polyglot.mapping.Mapping;
 
 import aQute.bnd.build.Project;
@@ -123,12 +123,12 @@ public class BndWorkspaceMapping extends AbstractTychoMapping {
 	}
 
 	@Override
-	protected Parent findParent(Path projectRoot, Map<String, ?> projectOptions) throws IOException {
+	protected ParentModel findParent(Path projectRoot, Map<String, ?> projectOptions) throws IOException {
 		try {
 			return super.findParent(projectRoot, projectOptions);
 		} catch (NoParentPomFound e) {
 			// this can happen in 100% pomless mode!
-			return null;
+			return new ParentModel(null, null);
 		}
 	}
 }

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/ParentModel.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/ParentModel.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.pomless;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+
+public record ParentModel(Parent parentReference, Model parentModel) {
+
+}

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoBundleMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoBundleMapping.java
@@ -95,7 +95,7 @@ public class TychoBundleMapping extends AbstractTychoMapping {
         // groupId is inherited from parent pom
         model.setArtifactId(bundleSymbolicName);
         String bundleVersion = getRequiredHeaderValue("Bundle-Version", manifestHeaders, manifestFile);
-        model.setVersion(getPomVersion(bundleVersion));
+        model.setVersion(getPomVersion(bundleVersion, model, artifactFile));
         String prefix;
         if (isTestBundle(bundleSymbolicName, bundleRoot)) {
             model.setPackaging(PACKAGING_TEST);

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoFeatureMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoFeatureMapping.java
@@ -47,7 +47,7 @@ public class TychoFeatureMapping extends AbstractXMLTychoMapping {
     @Override
     protected void initModelFromXML(Model model, Element xml, Path artifactFile) throws IOException {
         model.setArtifactId(getRequiredXMLAttributeValue(xml, "id"));
-        model.setVersion(getPomVersion(getRequiredXMLAttributeValue(xml, "version")));
+        model.setVersion(getPomVersion(getRequiredXMLAttributeValue(xml, "version"), model, artifactFile));
 
         Path featureProperties = artifactFile.getParent().resolve("feature.properties");
         Supplier<Properties> properties = getPropertiesSupplier(featureProperties);

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoRepositoryMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoRepositoryMapping.java
@@ -99,7 +99,7 @@ public class TychoRepositoryMapping extends AbstractXMLTychoMapping {
             model.setArtifactId(getRequiredXMLAttributeValue(xml, PRODUCT_UID_ATTRIBUTE));
             String version = getXMLAttributeValue(xml, PRODUCT_VERSION_ATTRIBUTE);
             if (version != null) {
-                model.setVersion(getPomVersion(version));
+                model.setVersion(getPomVersion(version, model, artifactFile));
             }
             String name = getXMLAttributeValue(xml, PRODUCT_NAME_ATTRIBUTE);
             model.setName(PRODUCT_NAME_PREFIX + (name != null ? name : model.getArtifactId()));


### PR DESCRIPTION
Currently it can happen that one uses one of the "trigger properties" that enable Tycho pomless feature to assume that a cifriendly version is to be used even though ci-friendly versions are actually not used at all.

This tries to differentiate the two cases by checking if there is actually a property defined that could be used in a ci-friendly way.