### PR TITLE
Add a category for mirrored feature / bundle project and filter IUs

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorApplicationService.java
@@ -17,8 +17,9 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.query.IQueryable;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
-import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.tycho.BuildDirectory;
 import org.eclipse.tycho.DependencySeed;
 import org.eclipse.tycho.p2.tools.BuildContext;
@@ -121,9 +122,11 @@ public interface MirrorApplicationService {
      *            the destination
      * @param repositoryName
      *            the name of the new repository
+     * @throws FacadeException
      */
-    void mirrorDirect(IArtifactRepository sourceArtifactRepository, IMetadataRepository sourceMetadataRepository,
-            File repositoryDestination, String repositoryName) throws FacadeException;
+    void mirrorDirect(IArtifactRepository sourceArtifactRepository,
+            IQueryable<IInstallableUnit> sourceMetadataRepository, File repositoryDestination, String repositoryName)
+            throws FacadeException;
 
     /**
      * Modifies the artifact repository to add mapping rules to download Maven released artifacts

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -62,6 +62,7 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.IQueryable;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.IRepositoryManager;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
@@ -459,8 +460,9 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
     }
 
     @Override
-    public void mirrorDirect(IArtifactRepository sourceArtifactRepository, IMetadataRepository sourceMetadataRepository,
-            File repositoryDestination, String repositoryName) throws FacadeException {
+    public void mirrorDirect(IArtifactRepository sourceArtifactRepository,
+            IQueryable<IInstallableUnit> sourceMetadataRepository, File repositoryDestination, String repositoryName)
+            throws FacadeException {
         if (repositoryDestination.exists()) {
             FileUtils.deleteQuietly(repositoryDestination);
         }

--- a/tycho-its/projects/TYCHO0383dotQualifierMatching/featureDotQualifier/pom.xml
+++ b/tycho-its/projects/TYCHO0383dotQualifierMatching/featureDotQualifier/pom.xml
@@ -32,11 +32,20 @@
 
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-packaging-plugin</artifactId>
+        <artifactId>target-platform-configuration</artifactId>
         <version>${tycho-version}</version>
-        <configuration>
-          <deployableFeature>true</deployableFeature>
-        </configuration>
+        <executions>
+			  <execution>
+				  <id>inject</id>
+				  <goals>
+					  <goal>mirror-target-platform</goal>
+				  </goals>
+			  </execution>
+		</executions>
+		<configuration>
+			<destination>${project.build.directory}/site</destination>
+			<includeCategories>false</includeCategories>
+		</configuration>
       </plugin>
 
       <plugin>

--- a/tycho-its/projects/TYCHO0439repositoryCategories/pom.xml
+++ b/tycho-its/projects/TYCHO0439repositoryCategories/pom.xml
@@ -31,11 +31,20 @@
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-packaging-plugin</artifactId>
+        <artifactId>target-platform-configuration</artifactId>
         <version>${tycho-version}</version>
-        <configuration>
-          <deployableFeature>true</deployableFeature>
-        </configuration>
+        <executions>
+			  <execution>
+				  <id>inject</id>
+				  <goals>
+					  <goal>mirror-target-platform</goal>
+				  </goals>
+			  </execution>
+		</executions>
+		<configuration>
+			<destination>${project.build.directory}/site</destination>
+			<includeCategories>false</includeCategories>
+		</configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>

--- a/tycho-its/projects/brokenp2data/pom.xml
+++ b/tycho-its/projects/brokenp2data/pom.xml
@@ -25,9 +25,6 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
 				<version>${tycho-version}</version>
-				<configuration>
-					<deployableFeature>true</deployableFeature>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-its/projects/custom-bundle-plugin/custom-bundle-parent/custom.bundle.feature/pom.xml
+++ b/tycho-its/projects/custom-bundle-plugin/custom-bundle-parent/custom.bundle.feature/pom.xml
@@ -15,11 +15,20 @@
     <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-packaging-plugin</artifactId>
+        <artifactId>target-platform-configuration</artifactId>
         <version>${tycho-version}</version>
-        <configuration>
-          <deployableFeature>true</deployableFeature>
-        </configuration>
+        <executions>
+			  <execution>
+				  <id>inject</id>
+				  <goals>
+					  <goal>mirror-target-platform</goal>
+				  </goals>
+			  </execution>
+		</executions>
+		<configuration>
+			<destination>${project.build.directory}/site</destination>
+			<includeCategories>false</includeCategories>
+		</configuration>
       </plugin>
     </plugins>
   </build>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0439repositoryCategories/RepositoryCategoriesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0439repositoryCategories/RepositoryCategoriesTest.java
@@ -28,41 +28,41 @@ import de.pdark.decentxml.XMLParser;
 
 public class RepositoryCategoriesTest extends AbstractTychoIntegrationTest {
 
-    @Test
-    public void testDeployableFeature() throws Exception {
-        Verifier v01 = getVerifier("TYCHO0439repositoryCategories");
-        v01.executeGoal("install");
-        v01.verifyErrorFreeLog();
+	@Test
+	public void testDeployableFeature() throws Exception {
+		Verifier v01 = getVerifier("TYCHO0439repositoryCategories");
+		v01.executeGoal("install");
+		v01.verifyErrorFreeLog();
 
-        File site = new File(v01.getBasedir(), "target/site");
-        Assert.assertTrue(site.isDirectory());
+		File site = new File(v01.getBasedir(), "target/site");
+		Assert.assertTrue(site.isDirectory());
 
-        File content = new File(site, "content.jar");
-        Assert.assertTrue(content.isFile());
+		File content = new File(site, "content.jar");
+		Assert.assertTrue(content.getAbsolutePath() + " is not a file!", content.isFile());
 
-        boolean found = false;
+		boolean found = false;
 
-        XMLParser parser = new XMLParser();
-        Document document = null;
-        ZipFile contentJar = new ZipFile(content);
-        try {
-            ZipEntry contentXmlEntry = contentJar.getEntry("content.xml");
-            document = parser.parse(new XMLIOSource(contentJar.getInputStream(contentXmlEntry)));
-        } finally {
-            contentJar.close();
-        }
-        Element repository = document.getRootElement();
-        all_units: for (Element unit : repository.getChild("units").getChildren("unit")) {
-            for (Element property : unit.getChild("properties").getChildren("property")) {
-                if ("org.eclipse.equinox.p2.type.category".equals(property.getAttributeValue("name"))
-                        && Boolean.parseBoolean(property.getAttributeValue("value"))) {
-                    found = true;
-                    break all_units;
-                }
-            }
-        }
+		XMLParser parser = new XMLParser();
+		Document document = null;
+		ZipFile contentJar = new ZipFile(content);
+		try {
+			ZipEntry contentXmlEntry = contentJar.getEntry("content.xml");
+			document = parser.parse(new XMLIOSource(contentJar.getInputStream(contentXmlEntry)));
+		} finally {
+			contentJar.close();
+		}
+		Element repository = document.getRootElement();
+		all_units: for (Element unit : repository.getChild("units").getChildren("unit")) {
+			for (Element property : unit.getChild("properties").getChildren("property")) {
+				if ("org.eclipse.equinox.p2.type.category".equals(property.getAttributeValue("name"))
+						&& Boolean.parseBoolean(property.getAttributeValue("value"))) {
+					found = true;
+					break all_units;
+				}
+			}
+		}
 
-        Assert.assertTrue("Custom category", found);
-    }
+		Assert.assertTrue("Custom category is missing: " + content.getAbsolutePath(), found);
+	}
 
 }

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
@@ -103,10 +103,13 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
     private String finalName;
 
     /**
-     * If set to <code>true</code>, standard eclipse update site directory with feature content will
-     * be created under target folder.
-     */
+	 * If set to <code>true</code>, standard eclipse update site directory with
+	 * feature content will be created under target folder.
+	 * 
+	 * @deprecated use the new <code>mirror-target-platform</code> instead.
+	 */
     @Parameter(defaultValue = "false")
+	@Deprecated
     private boolean deployableFeature = false;
 
     @Parameter(defaultValue = "${project.build.directory}/site")


### PR DESCRIPTION
Currently when mirroring the target platform of a bundle/feature it mirrors everything that is reachable. Also it creates an update-site that has not categories.

This now filters the IUs based on the project units, adds a category for it and allows to even filter categories completely if desired.

This also contains the migration of previous used deployableFeature in test to using this new way of creating an update-site, as part of this the deployableFeature option is also deprecated.