### PR TITLE
[backport] Support javac as a compiler for Tycho

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ### backports:
 
+- using javac as the compiler for Tycho
 - new `mirror-target-platform` mojo
 - new director mojo
 - support for PDE Api Tools Annotations

--- a/tycho-compiler-plugin/pom.xml
+++ b/tycho-compiler-plugin/pom.xml
@@ -86,6 +86,11 @@
 			<artifactId>bcel</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>org.codehaus.plexus</groupId>
+		    <artifactId>plexus-compiler-javac</artifactId>
+		    <version>2.14.2</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/tycho-compiler-plugin/src/main/java/copied/org/apache/maven/plugin/AbstractCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/copied/org/apache/maven/plugin/AbstractCompilerMojo.java
@@ -57,6 +57,8 @@ import org.codehaus.plexus.util.StringUtils;
  */
 public abstract class AbstractCompilerMojo extends AbstractMojo {
 
+    protected static final String JDT_COMPILER_ID = "jdt";
+
     public static final String DEFAULT_SOURCE_VERSION = "11";
 
     public static final String DEFAULT_TARGET_VERSION = "11";
@@ -144,8 +146,8 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
     /**
      * The compiler id of the compiler to use.
      */
-    @Parameter(property = "maven.compiler.compilerId", defaultValue = "jdt")
-    private String compilerId;
+    @Parameter(property = "maven.compiler.compilerId", defaultValue = JDT_COMPILER_ID)
+    protected String compilerId;
 
     /**
      * Version of the compiler to use, ex. "1.3", "1.5", if fork is set to true

--- a/tycho-its/projects/tycho-compiler-plugin/javac/pom.xml
+++ b/tycho-its/projects/tycho-compiler-plugin/javac/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.tycho.it</groupId>
+	<artifactId>javac.parent</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<properties>
+		<tycho-version>5.0.0-SNAPSHOT</tycho-version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-compiler-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<compilerId>javac</compilerId>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<modules>
+		<module>simple</module>
+	</modules>
+</project>

--- a/tycho-its/projects/tycho-compiler-plugin/javac/simple/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-compiler-plugin/javac/simple/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: simple
+Bundle-Version: 1.0.0.qualifier

--- a/tycho-its/projects/tycho-compiler-plugin/javac/simple/build.properties
+++ b/tycho-its/projects/tycho-compiler-plugin/javac/simple/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/tycho-compiler-plugin/javac/simple/pom.xml
+++ b/tycho-its/projects/tycho-compiler-plugin/javac/simple/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tycho.it</groupId>
+		<artifactId>javac.parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>simple</artifactId>
+
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/tycho-its/projects/tycho-compiler-plugin/javac/simple/src/Test.java
+++ b/tycho-its/projects/tycho-compiler-plugin/javac/simple/src/Test.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2012 SAP AG and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP AG - initial API and implementation
+ *******************************************************************************/
+
+public class Test
+{
+    public static void main(String[] args) {
+        int a = 0;
+    }
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/CompilerPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/CompilerPluginTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test;
+
+import org.apache.maven.it.Verifier;
+import org.junit.Test;
+
+/**
+ * Test for the tycho-compiler-plugin
+ */
+public class CompilerPluginTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testJavac() throws Exception {
+		Verifier verifier = getVerifier("tycho-compiler-plugin/javac", true, true);
+		verifier.executeGoal("compile");
+		verifier.verifyErrorFreeLog();
+	}
+
+}


### PR DESCRIPTION
Currently Tycho is strictly using ecj as a compiler but in general it might be there are situations one wants to use javac for compilation even though it might not has full features supported (e.g. package restrictions).

This is an attempt to make it possible to use javac at a very basic level.