### PR TITLE
Add build timestamp to the manifest and enable deep aggregate inspection

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -60,6 +60,10 @@ public interface TychoConstants {
 
     public static final String BUILD_TIMESTAMP = CTX_BASENAME + "/buildTimestamp";
 
+    String HEADER_TYCHO_BUILD_TIMESTAMP = "Tycho-Build-Timestamp";
+
+    String HEADER_BND_LAST_MODIFIED = "Bnd-LastModified";
+
     public String JAR_EXTENSION = "jar";
 
     String PROP_GROUP_ID = "maven-groupId";

--- a/tycho-artifactcomparator/pom.xml
+++ b/tycho-artifactcomparator/pom.xml
@@ -82,6 +82,11 @@
 		    <artifactId>jfiveparse</artifactId>
 		    <version>1.0.2</version>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>tycho-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ManifestComparator.java
+++ b/tycho-artifactcomparator/src/main/java/org/eclipse/tycho/zipcomparator/internal/ManifestComparator.java
@@ -25,6 +25,7 @@ import java.util.jar.Attributes.Name;
 import java.util.jar.Manifest;
 
 import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 import org.eclipse.tycho.artifactcomparator.ComparatorInputStream;
@@ -51,13 +52,14 @@ public class ManifestComparator implements ContentsComparator {
             new Name("Build-Jdk"), //
             new Name("Built-By"), //
             new Name("Build-Jdk-Spec"),
+            //added by Tycho itself
+            new Name(TychoConstants.HEADER_TYCHO_BUILD_TIMESTAMP), //
             // lets be friendly to bnd/maven-bundle-plugin
-            new Name("Bnd-LastModified"), //
+            new Name(TychoConstants.HEADER_BND_LAST_MODIFIED), //
             new Name("Bundle-Developers"), //
             new Name("Tool"),
             // this is common attribute not supported by Tycho yet
             new Name("Eclipse-SourceReferences"));
-    // TODO make it possible to disable default ignores and add custom ignore
 
     @Override
     public ArtifactDelta getDelta(ComparatorInputStream baseline, ComparatorInputStream reactor, ComparisonData data)

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
@@ -151,7 +151,7 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
 		project.getProperties().put(UNQUALIFIED_VERSION, projectVersion.unqualifiedVersion);
 		project.getProperties().put(QUALIFIED_VERSION, projectVersion.getOSGiVersion());
 		getLog().info("The project's OSGi version is " + projectVersion.getOSGiVersion());
-		DefaultReactorProject.adapt(project).setContextValue(TychoConstants.BUILD_TIMESTAMP, projectVersion);
+		DefaultReactorProject.adapt(project).setContextValue(TychoConstants.BUILD_TIMESTAMP, timestamp);
     }
 
 	private TychoProjectVersion calculateQualifiedVersion(Date timestamp)

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
@@ -50,66 +50,75 @@ import org.eclipse.tycho.model.Feature;
 
 @Mojo(name = "package-feature", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
-    private static final Object LOCK = new Object();
+	private static final Object LOCK = new Object();
 
-    private static final String FEATURE_PROPERTIES = "feature.properties";
+	private static final String FEATURE_PROPERTIES = "feature.properties";
 
-    /**
-     * The <a href="https://maven.apache.org/shared/maven-archiver/">maven archiver</a> to use. One
-     * of the archiver properties is the <code>addMavenDescriptor</code> flag, which indicates
-     * whether the generated archive will contain the pom.xml and pom.properties file. If no archive
-     * configuration is specified, the default value is <code>false</code>. If the maven descriptor
-     * should be added to the artifact, use the following configuration:
-     * 
-     * <pre>
-     * &lt;plugin&gt;
-     *   &lt;groupId&gt;org.eclipse.tycho&lt;/groupId&gt;
-     *   &lt;artifactId&gt;tycho-packaging-plugin&lt;/artifactId&gt;
-     *   &lt;version&gt;${tycho-version}&lt;/version&gt;
-     *   &lt;configuration&gt;
-     *     &lt;archive&gt;
-     *       &lt;addMavenDescriptor&gt;true&lt;/addMavenDescriptor&gt;
-     *     &lt;/archive&gt;
-     *   &lt;/configuration&gt;
-     * &lt;/plugin&gt;
-     * </pre>
-     */
-    @Parameter
-    private MavenArchiveConfiguration archive;
+	/**
+	 * The <a href="https://maven.apache.org/shared/maven-archiver/">maven
+	 * archiver</a> to use. One of the archiver properties is the
+	 * <code>addMavenDescriptor</code> flag, which indicates whether the generated
+	 * archive will contain the pom.xml and pom.properties file. If no archive
+	 * configuration is specified, the default value is <code>false</code>. If the
+	 * maven descriptor should be added to the artifact, use the following
+	 * configuration:
+	 * 
+	 * <pre>
+	 * &lt;plugin&gt;
+	 *   &lt;groupId&gt;org.eclipse.tycho&lt;/groupId&gt;
+	 *   &lt;artifactId&gt;tycho-packaging-plugin&lt;/artifactId&gt;
+	 *   &lt;version&gt;${tycho-version}&lt;/version&gt;
+	 *   &lt;configuration&gt;
+	 *     &lt;archive&gt;
+	 *       &lt;addMavenDescriptor&gt;true&lt;/addMavenDescriptor&gt;
+	 *     &lt;/archive&gt;
+	 *   &lt;/configuration&gt;
+	 * &lt;/plugin&gt;
+	 * </pre>
+	 */
+	@Parameter
+	private MavenArchiveConfiguration archive;
 
-    /**
-     * The output directory of the jar file
-     * 
-     * By default this is the Maven <tt>target/</tt> directory.
-     */
-    @Parameter(property = "project.build.directory")
-    private File outputDirectory;
+	/**
+	 * The output directory of the jar file
+	 * 
+	 * By default this is the Maven <tt>target/</tt> directory.
+	 */
+	@Parameter(property = "project.build.directory")
+	private File outputDirectory;
 
-    @Parameter(property = "project.basedir")
-    private File basedir;
+	@Parameter(property = "project.basedir")
+	private File basedir;
 
-    /**
-     * The path to the <code>feature.xml</code> file.
-     * <p>
-     * Defaults to the <code>feature.xml</code> under the project's base directory.
-     */
-    @Parameter(defaultValue = "${project.basedir}/" + FEATURE_XML)
-    private File featureFile;
+	/**
+	 * The path to the <code>feature.xml</code> file.
+	 * <p>
+	 * Defaults to the <code>feature.xml</code> under the project's base directory.
+	 */
+	@Parameter(defaultValue = "${project.basedir}/" + FEATURE_XML)
+	private File featureFile;
 
-    /**
-     * Name of the generated JAR.
-     */
-    @Parameter(property = "project.build.finalName", alias = "jarName", required = true)
-    private String finalName;
+	/**
+	 * Name of the generated JAR.
+	 */
+	@Parameter(property = "project.build.finalName", alias = "jarName", required = true)
+	private String finalName;
 
-    @Parameter(defaultValue = "${project.build.directory}/site")
-    private File target;
+	@Parameter(defaultValue = "${project.build.directory}/site")
+	private File target;
 
-    @Component
-    private FeatureXmlTransformer featureXmlTransformer;
+	/**
+	 * Include the build timestamp in the manifest to track changes in the
+	 * <code>build-qualifier-aggregator</code> mojo
+	 */
+	@Parameter(defaultValue = "true")
+	private boolean includeBuildTimestamp;
 
-    @Component
-    private LicenseFeatureHelper licenseFeatureHelper;
+	@Component
+	private FeatureXmlTransformer featureXmlTransformer;
+
+	@Component
+	private LicenseFeatureHelper licenseFeatureHelper;
 
 	@Component
 	private TargetPlatformService platformService;
@@ -117,174 +126,175 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
 	@Component
 	private BuildPropertiesParser buildPropertiesParser;
 
-    @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
-        synchronized (LOCK) {
-            outputDirectory.mkdirs();
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		synchronized (LOCK) {
+			outputDirectory.mkdirs();
 
-            if (!featureFile.isFile()) {
-                throw new MojoExecutionException("The featureFile parameter must represent a valid file");
-            }
+			if (!featureFile.isFile()) {
+				throw new MojoExecutionException("The featureFile parameter must represent a valid file");
+			}
 
-            Feature feature;
+			Feature feature;
 
-            try {
-                feature = Feature.read(featureFile);
-            } catch (final IOException e) {
-                throw new MojoExecutionException("Error reading " + featureFile, e);
-            }
+			try {
+				feature = Feature.read(featureFile);
+			} catch (final IOException e) {
+				throw new MojoExecutionException("Error reading " + featureFile, e);
+			}
 
-            File licenseFeature = licenseFeatureHelper.getLicenseFeature(feature, project);
+			File licenseFeature = licenseFeatureHelper.getLicenseFeature(feature, project);
 
-            updateLicenseProperties(feature, licenseFeature);
+			updateLicenseProperties(feature, licenseFeature);
 
-            File featureXml = new File(outputDirectory, FEATURE_XML);
-            try {
-                expandVersionQualifiers(feature);
-                Feature.write(feature, featureXml);
-            } catch (IOException e) {
-                throw new MojoExecutionException("Error updating feature.xml", e);
-            }
+			File featureXml = new File(outputDirectory, FEATURE_XML);
+			try {
+				expandVersionQualifiers(feature);
+				Feature.write(feature, featureXml);
+			} catch (IOException e) {
+				throw new MojoExecutionException("Error updating feature.xml", e);
+			}
 
 			BuildProperties buildProperties = buildPropertiesParser.parse(DefaultReactorProject.adapt(project));
-            checkBinIncludesExist(buildProperties);
+			checkBinIncludesExist(buildProperties);
 
-            File featureProperties = getFeatureProperties(licenseFeature, buildProperties);
+			File featureProperties = getFeatureProperties(licenseFeature, buildProperties);
 
-            File outputJar = new File(outputDirectory, finalName + ".jar");
-            outputJar.getParentFile().mkdirs();
+			File outputJar = new File(outputDirectory, finalName + ".jar");
+			outputJar.getParentFile().mkdirs();
 
-            MavenArchiver archiver = new MavenArchiver();
-            JarArchiver jarArchiver = getJarArchiver();
-            archiver.setArchiver(jarArchiver);
-            archiver.setOutputFile(outputJar);
-            jarArchiver.setDestFile(outputJar);
+			MavenArchiver archiver = createMavenArchiver(includeBuildTimestamp);
+			JarArchiver jarArchiver = getJarArchiver();
+			archiver.setArchiver(jarArchiver);
+			archiver.setOutputFile(outputJar);
+			jarArchiver.setDestFile(outputJar);
 
-            try {
-                // Additional file sets win over bin.includes ones, so we add them first
-                if (additionalFileSets != null) {
-                    for (final var fileSet : additionalFileSets) {
-                        final var directory = fileSet.getDirectory();
+			try {
+				// Additional file sets win over bin.includes ones, so we add them first
+				if (additionalFileSets != null) {
+					for (final var fileSet : additionalFileSets) {
+						final var directory = fileSet.getDirectory();
 
-                        // noinspection ConstantConditions
-                        if (directory != null && directory.isDirectory()) {
-                            archiver.getArchiver().addFileSet(fileSet);
-                        }
-                    }
-                }
+						// noinspection ConstantConditions
+						if (directory != null && directory.isDirectory()) {
+							archiver.getArchiver().addFileSet(fileSet);
+						}
+					}
+				}
 
-                archiver.getArchiver().addFileSet(getManuallyIncludedFiles(buildProperties));
-                if (licenseFeature != null) {
-                    archiver.getArchiver()
-                            .addArchivedFileSet(licenseFeatureHelper.getLicenseFeatureFileSet(licenseFeature));
-                }
-                archiver.getArchiver().addFile(featureXml, FEATURE_XML);
-                if (featureProperties != null) {
-                    archiver.getArchiver().addFile(featureProperties, FEATURE_PROPERTIES);
-                }
-                if (archive == null) {
-                    archive = new MavenArchiveConfiguration();
-                    archive.setAddMavenDescriptor(false);
-                }
+				archiver.getArchiver().addFileSet(getManuallyIncludedFiles(buildProperties));
+				if (licenseFeature != null) {
+					archiver.getArchiver()
+							.addArchivedFileSet(licenseFeatureHelper.getLicenseFeatureFileSet(licenseFeature));
+				}
+				archiver.getArchiver().addFile(featureXml, FEATURE_XML);
+				if (featureProperties != null) {
+					archiver.getArchiver().addFile(featureProperties, FEATURE_PROPERTIES);
+				}
+				if (archive == null) {
+					archive = new MavenArchiveConfiguration();
+					archive.setAddMavenDescriptor(false);
+				}
 				MavenProject mavenProject = project;
 				archiver.createArchive(session, mavenProject, archive);
-            } catch (Exception e) {
-                throw new MojoExecutionException("Error creating feature package", e);
-            }
+			} catch (Exception e) {
+				throw new MojoExecutionException("Error creating feature package", e);
+			}
 
-            project.getArtifact().setFile(outputJar);
-        }
-    }
+			project.getArtifact().setFile(outputJar);
+		}
+	}
 
-    private void updateLicenseProperties(Feature feature, File licenseFeatureFile) {
-        // remove license feature id and version from feature.xml
-        feature.setLicenseFeature(null);
-        feature.setLicenseFeatureVersion(null);
-        // copy the license text and URL from the license feature
-        if (licenseFeatureFile != null) {
-            Feature licenseFeature = Feature.loadFeature(licenseFeatureFile);
-            if (licenseFeature.getLicenseURL() != null) {
-                feature.setLicenseURL(licenseFeature.getLicenseURL());
-            }
-            if (licenseFeature.getLicense() != null) {
-                feature.setLicense(licenseFeature.getLicense());
-            }
-        }
-    }
+	private void updateLicenseProperties(Feature feature, File licenseFeatureFile) {
+		// remove license feature id and version from feature.xml
+		feature.setLicenseFeature(null);
+		feature.setLicenseFeatureVersion(null);
+		// copy the license text and URL from the license feature
+		if (licenseFeatureFile != null) {
+			Feature licenseFeature = Feature.loadFeature(licenseFeatureFile);
+			if (licenseFeature.getLicenseURL() != null) {
+				feature.setLicenseURL(licenseFeature.getLicenseURL());
+			}
+			if (licenseFeature.getLicense() != null) {
+				feature.setLicense(licenseFeature.getLicense());
+			}
+		}
+	}
 
-    private File getFeatureProperties(File licenseFeature, BuildProperties buildProperties)
-            throws MojoExecutionException {
-        try {
-            File localFeatureProperties = new File(basedir, FEATURE_PROPERTIES);
-            File targetFeatureProperties = new File(outputDirectory, FEATURE_PROPERTIES);
-            if (targetFeatureProperties.exists() && !targetFeatureProperties.delete()) {
-                throw new MojoExecutionException("Could not delete file " + targetFeatureProperties.getAbsolutePath());
-            }
-            // copy the feature.properties from the current feature to the target directory
-            if (buildProperties.getBinIncludes().contains(FEATURE_PROPERTIES) && localFeatureProperties.canRead()) {
-                Files.copy(localFeatureProperties.toPath(), targetFeatureProperties.toPath());
-            }
-            // if there is a license feature, append to the existing feature.properties or create
-            // a new one containing the license features's feature.properties content
-            if (licenseFeature != null) {
-                appendToOrAddFeatureProperties(targetFeatureProperties, licenseFeature);
-            }
-            if (targetFeatureProperties.exists()) {
-                return targetFeatureProperties;
-            }
-            return null;
-        } catch (IOException e) {
-            throw new MojoExecutionException("Could not create feature.properties file for project " + project, e);
-        }
-    }
+	private File getFeatureProperties(File licenseFeature, BuildProperties buildProperties)
+			throws MojoExecutionException {
+		try {
+			File localFeatureProperties = new File(basedir, FEATURE_PROPERTIES);
+			File targetFeatureProperties = new File(outputDirectory, FEATURE_PROPERTIES);
+			if (targetFeatureProperties.exists() && !targetFeatureProperties.delete()) {
+				throw new MojoExecutionException("Could not delete file " + targetFeatureProperties.getAbsolutePath());
+			}
+			// copy the feature.properties from the current feature to the target directory
+			if (buildProperties.getBinIncludes().contains(FEATURE_PROPERTIES) && localFeatureProperties.canRead()) {
+				Files.copy(localFeatureProperties.toPath(), targetFeatureProperties.toPath());
+			}
+			// if there is a license feature, append to the existing feature.properties or
+			// create
+			// a new one containing the license features's feature.properties content
+			if (licenseFeature != null) {
+				appendToOrAddFeatureProperties(targetFeatureProperties, licenseFeature);
+			}
+			if (targetFeatureProperties.exists()) {
+				return targetFeatureProperties;
+			}
+			return null;
+		} catch (IOException e) {
+			throw new MojoExecutionException("Could not create feature.properties file for project " + project, e);
+		}
+	}
 
-    private void appendToOrAddFeatureProperties(File targetFeatureProperties, File licenseFeature) throws IOException {
-        try (ZipFile zip = new ZipFile(licenseFeature)) {
-            ZipEntry entry = zip.getEntry(FEATURE_PROPERTIES);
-            if (entry != null) {
-                try (InputStream inputStream = zip.getInputStream(entry);
-                        FileWriter writer = new FileWriter(targetFeatureProperties.getAbsolutePath(), true)) {
-                    // if we append, first add a new line to be sure that we start 
-                    // in a new line of the existing file
-                    if (targetFeatureProperties.exists()) {
-                        IOUtil.copy("\n", writer);
-                    }
-                    IOUtil.copy(inputStream, writer);
-                }
-            }
-        }
-    }
+	private void appendToOrAddFeatureProperties(File targetFeatureProperties, File licenseFeature) throws IOException {
+		try (ZipFile zip = new ZipFile(licenseFeature)) {
+			ZipEntry entry = zip.getEntry(FEATURE_PROPERTIES);
+			if (entry != null) {
+				try (InputStream inputStream = zip.getInputStream(entry);
+						FileWriter writer = new FileWriter(targetFeatureProperties.getAbsolutePath(), true)) {
+					// if we append, first add a new line to be sure that we start
+					// in a new line of the existing file
+					if (targetFeatureProperties.exists()) {
+						IOUtil.copy("\n", writer);
+					}
+					IOUtil.copy(inputStream, writer);
+				}
+			}
+		}
+	}
 
-    /**
-     * @return A {@link FileSet} including files as configured by the <tt>bin.includes</tt> and
-     *         <tt>bin.excludes</tt> properties without the files that are always included
-     *         automatically.
-     */
-    private FileSet getManuallyIncludedFiles(BuildProperties buildProperties) {
-        List<String> binExcludes = new ArrayList<>(buildProperties.getBinExcludes());
-        binExcludes.add(FEATURE_XML); // we'll include updated feature.xml
-        binExcludes.add(FEATURE_PROPERTIES); // we'll include updated feature.properties
-        return getFileSet(basedir, buildProperties.getBinIncludes(), binExcludes);
-    }
+	/**
+	 * @return A {@link FileSet} including files as configured by the
+	 *         <tt>bin.includes</tt> and <tt>bin.excludes</tt> properties without
+	 *         the files that are always included automatically.
+	 */
+	private FileSet getManuallyIncludedFiles(BuildProperties buildProperties) {
+		List<String> binExcludes = new ArrayList<>(buildProperties.getBinExcludes());
+		binExcludes.add(FEATURE_XML); // we'll include updated feature.xml
+		binExcludes.add(FEATURE_PROPERTIES); // we'll include updated feature.properties
+		return getFileSet(basedir, buildProperties.getBinIncludes(), binExcludes);
+	}
 
-    private void expandVersionQualifiers(Feature feature) throws MojoFailureException {
-        ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-        feature.setVersion(reactorProject.getExpandedVersion());
+	private void expandVersionQualifiers(Feature feature) throws MojoFailureException {
+		ReactorProject reactorProject = DefaultReactorProject.adapt(project);
+		feature.setVersion(reactorProject.getExpandedVersion());
 
 		TargetPlatform targetPlatform = platformService.getTargetPlatform(reactorProject).orElse(null);
 		if (targetPlatform == null) {
 			getLog().warn(
-                    "Skipping version reference expansion in eclipse-feature project using the deprecated -Dtycho.targetPlatform configuration");
+					"Skipping version reference expansion in eclipse-feature project using the deprecated -Dtycho.targetPlatform configuration");
 			return;
 		}
 		featureXmlTransformer.expandReferences(feature, targetPlatform);
-    }
+	}
 
-    private JarArchiver getJarArchiver() throws MojoExecutionException {
-        try {
+	private JarArchiver getJarArchiver() throws MojoExecutionException {
+		try {
 			return plexus.lookup(JarArchiver.class, "jar");
-        } catch (ComponentLookupException e) {
-            throw new MojoExecutionException("Unable to get JarArchiver", e);
-        }
-    }
+		} catch (ComponentLookupException e) {
+			throw new MojoExecutionException("Unable to get JarArchiver", e);
+		}
+	}
 }

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -155,6 +155,13 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 	@Parameter(defaultValue = "true")
 	private boolean deriveHeaderFromSource;
 
+	/**
+	 * Include the build timestamp in the manifest to track changes in the
+	 * <code>build-qualifier-aggregator</code> mojo
+	 */
+	@Parameter(defaultValue = "true")
+	private boolean includeBuildTimestamp;
+
 	@Component
 	private SourceReferenceComputer soureReferenceComputer;
 
@@ -224,7 +231,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 
 	private File createPluginJar() throws MojoExecutionException {
 		try {
-			MavenArchiver archiver = new MavenArchiver();
+			MavenArchiver archiver = createMavenArchiver(includeBuildTimestamp);
 			archiver.setArchiver(jarArchiver);
 
 			File pluginFile = new File(buildDirectory, finalName + ".jar");


### PR DESCRIPTION
Currently the build timestamp is only encoded in the file-name. This is then parsed back from the string into a date.

This has several drawbacks:
- it is sometimes unreliable and usually the user won't notice that e.g. when the dependency and the build are using different formating rules for qualifiers
- it does not work well for "standard" artifacts not build by Tycho that are probably not using qualifiers in the name

Because of this, the following changes are applied:
- the build timestamp is read from the reactor if possible
- the build timestamp is written to the manifest as part of the packaging
- if parsing is not successful the manifest is inspected if it contains some well known build time stamps from either Tycho or BND
- if thats not available the jar entry time is used as a last resort

both things can be configured but are enabled by default just in case it causes issues for the users and they rely on the old behavior.