### PR TITLE
Improve error message in case resolve fails

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/ResolverException.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/ResolverException.java
@@ -13,7 +13,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.resolver;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.internal.p2.director.Explanation;
 import org.eclipse.tycho.core.shared.StatusTool;
 
 /**
@@ -25,11 +30,17 @@ public class ResolverException extends Exception {
     private static final long serialVersionUID = 1L;
     private final String details;
     private final String selectionContext;
+    private Collection<Explanation> explanation;
 
     public ResolverException(String msg, Throwable cause) {
         super(msg, cause);
         selectionContext = "N/A";
         details = "N/A";
+    }
+
+    public ResolverException(Collection<Explanation> explanation, String selectionContext, Throwable cause) {
+        this(explanation.stream().map(Object::toString).collect(Collectors.joining("\n")), selectionContext, cause);
+        this.explanation = explanation;
     }
 
     public ResolverException(String details, String selectionContext, Throwable cause) {
@@ -50,6 +61,10 @@ public class ResolverException extends Exception {
 
     public String getSelectionContext() {
         return selectionContext;
+    }
+
+    public Stream<Explanation> explanations() {
+        return explanation.stream();
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ProjectorResolutionStrategy.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ProjectorResolutionStrategy.java
@@ -91,8 +91,7 @@ public class ProjectorResolutionStrategy extends AbstractSlicerResolutionStrateg
             // log all transitive requirements which cannot be satisfied; this doesn't print the dependency chain from the seed to the units with missing requirements, so this is less useful than the "explanation"
             logger.debug(StatusTool.toLogMessage(s));
             explainProblems(explanation, MavenLogger::error);
-            throw new ResolverException(explanation.stream().map(Object::toString).collect(Collectors.joining("\n")),
-                    selectionContext.toString(), StatusTool.findException(s));
+            throw new ResolverException(explanation, selectionContext.toString(), StatusTool.findException(s));
         }
         if (s.getSeverity() == IStatus.WARNING) {
             logger.warn(StatusTool.toLogMessage(s));


### PR DESCRIPTION
Currently Tycho gives a rather vague message ('see log for details') if a resolve fails for a project what requires the user to search and match the actual error if the resolving of a project fails.

This now adds the errors directly to the exception what gives a much better info to the user in case of resolve failure.

