### PR TITLE
Remove warning about unspecified environment

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -167,8 +167,6 @@ public class DefaultTargetPlatformConfigurationReader {
         }
 
         if (result.getEnvironments().isEmpty()) {
-            // applying defaults
-            logger.warn("No explicit target runtime environment configuration. Build is platform dependent.");
             result.addEnvironment(TargetEnvironment.getRunningEnvironment());
             result.setImplicitTargetEnvironment(true);
         } else {


### PR DESCRIPTION
Currently if not target platform environment is specified Tycho emits a warning "No explicit target runtime environment configuration. Build is platform dependent." beside from that nothing ever seems go wrong and actually Tycho builds *can* be environment agnostic. Also there is not really a way to tell Tycho that it is okay, so either the user has to use a specific one or configure many ones that make resolving slower.

This now removes this warning, if with modern Tycho there are any problems that arise from a missing environment configuration one should better give a specific error/hint at this place instead of warn "just in case".