### PR TITLE
Add support to specify target locations in the pom configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,40 @@ If you are reading this in the browser, then you can quickly jump to specific ve
 
 ## 5.0.0 (under development)
 
+### support for embedded target locations
+
+You can already define target definition files in various ways, e.g. as maven artifact or file reference, 
+now it is also possible to define them as an embedded part of the target platform configuration, 
+all locations are handled as if they are part of a single target file:
+
+```xml
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>target-platform-configuration</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		<target>
+			<!-- one or more location elements like in a target file -->
+			<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+				<dependencies>
+					<dependency>
+						...
+					</dependency>
+				</dependencies>
+			</location>
+		    <location includeAllPlatforms="true" includeMode="slicer" type="InstallableUnit">
+		      <unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+		      ...
+		      <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210"/>
+		    </location>
+		    ...
+		</target>
+	</configuration>
+</plugin>
+```
+
+this is especially useful if you need some content only for the build but not in the IDE.
+
 ### using javac as the compiler for Tycho
 
 You can now use `javac` as the compiler backend for Tycho by adding the following configuration:
@@ -19,7 +53,7 @@ You can now use `javac` as the compiler backend for Tycho by adding the followin
 		<compilerId>javac</compilerId>
 	</configuration>
 </plugin>
- ```
+```
 
 
 ### new `mirror-target-platform`
@@ -39,7 +73,7 @@ There is a new `mirror-target-platform` that allows to mirror the current target
 	  </execution>
   </executions>
 </plugin>
- ```
+```
 
 the most usual use-case for this is to transform an existing target-file into a standalone repository.
 
@@ -68,7 +102,7 @@ This mojo can be used in two ways:
        </execution>
     </executions>
  </plugin>
- ```
+```
 
 
 ### new `tycho-eclipse-plugin`

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetParameterObject.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetParameterObject.java
@@ -12,6 +12,7 @@ package org.eclipse.tycho.target;
 import java.io.File;
 import java.net.URI;
 
+import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.eclipse.tycho.p2.repository.GAV;
 
 /**
@@ -23,4 +24,5 @@ public class TargetParameterObject {
     public GAV target;
     public File file;
     public URI uri;
+    public PlexusConfiguration location;
 }

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
@@ -89,6 +89,7 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
      * <li><code>&lt;file></code> to define a file local to the build</li>
      * <li><code>&lt;uri></code> to define a (remote) URI that specifies a target, currently only
      * URIs that can be converted to URLs are supported (e.g. file:/.... http://..., )</li>
+     * <li>{@code <locations>} to define target locations inline</li>
      * </ul>
      */
     @Parameter(name = DefaultTargetPlatformConfigurationReader.TARGET)

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -331,10 +331,10 @@ public class DefaultTargetPlatformConfigurationReader {
 
     /**
      * Take the constraints of the configured execution environment into account when resolving
-     * dependencies or target definitions. These constraints include the list of system packages and the
-     * <tt>Bundle-RequiredExecutionEnvironment</tt> header. When set to <code>true</code>, the
-     * dependency resolution verifies that the bundle and all required bundles can be used in an OSGi
-     * container with the configured execution environment.
+     * dependencies or target definitions. These constraints include the list of system packages and
+     * the <tt>Bundle-RequiredExecutionEnvironment</tt> header. When set to <code>true</code>, the
+     * dependency resolution verifies that the bundle and all required bundles can be used in an
+     * OSGi container with the configured execution environment.
      */
     private void setResolveWithEEContraints(TargetPlatformConfiguration result, Xpp3Dom resolverDom) {
         String value = getStringValue(resolverDom.getChild(RESOLVE_WITH_EXECUTION_ENVIRONMENT_CONSTRAINTS));
@@ -462,6 +462,13 @@ public class DefaultTargetPlatformConfigurationReader {
                 }
             }
         }
+        Xpp3Dom[] locationsArray = targetDom.getChildren("location");
+        if (locationsArray != null && locationsArray.length > 0) {
+            for (Xpp3Dom locationDom : locationsArray) {
+                result.addTargetLocation(locationDom);
+            }
+        }
+
     }
 
     protected void addTargetArtifact(TargetPlatformConfiguration result, MavenSession session, MavenProject project,
@@ -592,9 +599,9 @@ public class DefaultTargetPlatformConfigurationReader {
      * 
      * @param project
      * @param targetFile
-     *                             the target file to check
+     *            the target file to check
      * @param otherTargetFiles
-     *                             other target files to take into account
+     *            other target files to take into account
      * @return <code>true</code> if the target file is the primary artifact, <code>false</code>
      *         otherwise
      */


### PR DESCRIPTION
Currently one can either define a target reference as a file or artefact this now adds support to also add locations directly to the pom xml configuration.

FYI @akurtakov @mickaelistria 