### PR TITLE
Speedup repository assembly

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/ImmutableInMemoryMetadataRepository.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/ImmutableInMemoryMetadataRepository.java
@@ -24,28 +24,18 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.p2.core.IPool;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-import org.eclipse.equinox.p2.query.IQuery;
-import org.eclipse.equinox.p2.query.IQueryResult;
-import org.eclipse.equinox.p2.query.IQueryable;
 import org.eclipse.equinox.p2.repository.IRepositoryReference;
 import org.eclipse.equinox.p2.repository.IRunnableWithProgress;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+import org.eclipse.tycho.p2tools.copiedfromp2.QueryableArray;
 
-public class ImmutableInMemoryMetadataRepository implements IMetadataRepository {
+public class ImmutableInMemoryMetadataRepository extends QueryableArray implements IMetadataRepository {
 
-    private final IQueryable<IInstallableUnit> units;
-
-    public ImmutableInMemoryMetadataRepository(Set<IInstallableUnit> units) {
-        this.units = new QueryableArray(units);
-    }
-
-    @Override
-    public IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
-        return units.query(query, monitor);
+    public ImmutableInMemoryMetadataRepository(Set<IInstallableUnit> units, boolean copy) {
+        super(units, copy);
     }
 
     @Override

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/AbstractSlicerResolutionStrategy.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/AbstractSlicerResolutionStrategy.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.MultiStatus;
-import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.internal.p2.metadata.IRequiredCapability;
 import org.eclipse.equinox.internal.p2.metadata.RequiredCapability;
 import org.eclipse.equinox.internal.p2.metadata.RequiredPropertiesMatch;
@@ -47,6 +46,7 @@ import org.eclipse.equinox.p2.query.IQueryable;
 import org.eclipse.tycho.core.shared.MavenLogger;
 import org.eclipse.tycho.core.shared.StatusTool;
 import org.eclipse.tycho.p2.resolver.ResolverException;
+import org.eclipse.tycho.p2tools.copiedfromp2.QueryableArray;
 import org.eclipse.tycho.p2tools.copiedfromp2.Slicer;
 
 abstract class AbstractSlicerResolutionStrategy extends AbstractResolutionStrategy {
@@ -94,9 +94,9 @@ abstract class AbstractSlicerResolutionStrategy extends AbstractResolutionStrate
             seedIUs.add(createUnitRequiring("tycho-ee", null, data.getEEResolutionHints().getMandatoryRequires()));
         }
 
-        IQueryable<IInstallableUnit> baseIUCollection = new QueryableArray(availableIUs);
+        IQueryable<IInstallableUnit> baseIUCollection = new QueryableArray(availableIUs, false);
         Slicer slicer = newSlicer((query, monitor1) -> {
-
+//
             IQueryResult<IInstallableUnit> queryResult = baseIUCollection.query(query, monitor1);
             if (queryResult.isEmpty()) {
                 IQueryable<IInstallableUnit> additionalUnitStore = data.getAdditionalUnitStore();

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/DependencyCollector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/DependencyCollector.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.internal.p2.metadata.RequiredCapability;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
@@ -31,6 +30,7 @@ import org.eclipse.equinox.p2.query.IQueryable;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.tycho.core.shared.MavenLogger;
 import org.eclipse.tycho.p2.publisher.FeatureDependenciesAction;
+import org.eclipse.tycho.p2tools.copiedfromp2.QueryableArray;
 
 public class DependencyCollector extends AbstractResolutionStrategy {
 
@@ -51,7 +51,7 @@ public class DependencyCollector extends AbstractResolutionStrategy {
 
         result.addAll(data.getRootIUs());
 
-        IQueryable<IInstallableUnit> availableUIsQueryable = new QueryableArray(data.getAvailableIUs());
+        IQueryable<IInstallableUnit> availableUIsQueryable = new QueryableArray(data.getAvailableIUs(), false);
         for (IInstallableUnit iu : data.getRootIUs()) {
             collectIncludedIUs(availableUIsQueryable, result, errors, iu, true, monitor);
         }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/FinalTargetPlatformImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/FinalTargetPlatformImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.tycho.p2.repository.LocalArtifactRepository;
 public class FinalTargetPlatformImpl extends TargetPlatformBaseImpl {
 
     private IArtifactRepository artifactRepository;
+    private IMetadataRepository metadataRepository;
 
     public FinalTargetPlatformImpl(LinkedHashSet<IInstallableUnit> installableUnits,
             ExecutionEnvironmentResolutionHints executionEnvironment, IRawArtifactFileProvider jointArtifacts,
@@ -39,6 +40,7 @@ public class FinalTargetPlatformImpl extends TargetPlatformBaseImpl {
         super(installableUnits, executionEnvironment, jointArtifacts, localArtifactRepository, reactorProjectLookup,
                 mavenArtifactLookup, shadowed);
         this.artifactRepository = artifactRepository;
+        this.metadataRepository = new ImmutableInMemoryMetadataRepository(installableUnits, false);
     }
 
     @Override
@@ -48,7 +50,7 @@ public class FinalTargetPlatformImpl extends TargetPlatformBaseImpl {
 
     @Override
     public IMetadataRepository getMetadataRepository() {
-        return new ImmutableInMemoryMetadataRepository(installableUnits);
+        return metadataRepository;
     }
 
     @Override

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
@@ -34,7 +34,6 @@ import java.util.function.Consumer;
 
 import org.apache.felix.resolver.util.CopyOnWriteSet;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IProvidedCapability;
@@ -75,6 +74,7 @@ import org.eclipse.tycho.p2.publisher.AuthoredIUAction;
 import org.eclipse.tycho.p2.resolver.ResolverException;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformFactory;
+import org.eclipse.tycho.p2tools.copiedfromp2.QueryableArray;
 import org.eclipse.tycho.p2tools.copiedfromp2.Slicer;
 import org.eclipse.tycho.targetplatform.P2TargetPlatform;
 
@@ -329,7 +329,7 @@ public class P2ResolverImpl implements P2Resolver {
     public P2ResolutionResult resolveInstallableUnit(TargetPlatform context, String id, String versionRange) {
 
         P2TargetPlatform targetPlatform = getTargetFromContext(context);
-        IQueryable<IInstallableUnit> queriable = new QueryableArray(targetPlatform.getInstallableUnits());
+        IQueryable<IInstallableUnit> queriable = new QueryableArray(targetPlatform.getInstallableUnits(), false);
 
         VersionRange range = new VersionRange(versionRange);
         IRequirement requirement = MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, id, range, null,

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomInstallableUnitStore.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomInstallableUnitStore.java
@@ -31,7 +31,6 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.publisher.IPublisherInfo;
 import org.eclipse.equinox.p2.publisher.PublisherInfo;
@@ -49,6 +48,7 @@ import org.eclipse.tycho.p2.metadata.ReactorProjectFacade;
 import org.eclipse.tycho.p2.repository.RepositoryLayoutHelper;
 import org.eclipse.tycho.p2.resolver.WrappedArtifact;
 import org.eclipse.tycho.p2maven.InstallableUnitGenerator;
+import org.eclipse.tycho.p2tools.copiedfromp2.QueryableArray;
 
 class PomInstallableUnitStore implements IQueryable<IInstallableUnit> {
 
@@ -200,7 +200,7 @@ class PomInstallableUnitStore implements IQueryable<IInstallableUnit> {
                     }
                 });
             }
-            collection = new QueryableArray(installableUnitLookUp.keySet());
+            collection = new QueryableArray(installableUnitLookUp.keySet(), false);
         }
         return collection;
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ProjectorResolutionStrategy.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/ProjectorResolutionStrategy.java
@@ -27,7 +27,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.internal.p2.director.Explanation;
-import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.internal.p2.director.SimplePlanner;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IRequirement;
@@ -39,6 +38,7 @@ import org.eclipse.tycho.core.shared.MavenLogger;
 import org.eclipse.tycho.core.shared.StatusTool;
 import org.eclipse.tycho.p2.resolver.ResolverException;
 import org.eclipse.tycho.p2tools.copiedfromp2.Projector;
+import org.eclipse.tycho.p2tools.copiedfromp2.QueryableArray;
 import org.eclipse.tycho.p2tools.copiedfromp2.Slicer;
 
 public class ProjectorResolutionStrategy extends AbstractSlicerResolutionStrategy {
@@ -109,7 +109,7 @@ public class ProjectorResolutionStrategy extends AbstractSlicerResolutionStrateg
         };
         projector.encode(createUnitRequiring("tycho", seedUnits, seedRequires),
                 EMPTY_IU_ARRAY /* alreadyExistingRoots */,
-                new QueryableArray(List.of()) /* installedIUs */, seedUnits /* newRoots */, monitor);
+                new QueryableArray(List.of(), false) /* installedIUs */, seedUnits /* newRoots */, monitor);
         IStatus s = projector.invokeSolver(monitor);
         if (s.getSeverity() == IStatus.ERROR) {
             Set<Explanation> explanation = getExplanation(projector); // suppress "Cannot complete the request.  Generating details."

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryImpl.java
@@ -44,7 +44,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.URIUtil;
-import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
@@ -114,6 +113,7 @@ import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformFactory;
 import org.eclipse.tycho.p2maven.ListCompositeArtifactRepository;
 import org.eclipse.tycho.p2maven.advices.MavenPropertiesAdvice;
+import org.eclipse.tycho.p2tools.copiedfromp2.QueryableArray;
 import org.eclipse.tycho.targetplatform.P2TargetPlatform;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
 import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
@@ -334,7 +334,7 @@ public class TargetPlatformFactoryImpl implements TargetPlatformFactory {
                         Collection<ProjectClasspathEntry> entries = eclipseProject.getClasspathEntries();
                         for (ProjectClasspathEntry entry : entries) {
                             if (entry instanceof JUnitClasspathContainerEntry junit) {
-                                IQueryable<IInstallableUnit> queriable = new QueryableArray(externalUIs);
+                                IQueryable<IInstallableUnit> queriable = new QueryableArray(externalUIs, false);
                                 Collection<JUnitBundle> artifacts = junit.getArtifacts();
                                 for (JUnitBundle bundle : artifacts) {
                                     MavenArtifactKey maven = ClasspathReader.toMaven(bundle);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -53,7 +53,6 @@ import org.eclipse.equinox.p2.internal.repository.mirroring.IArtifactMirrorLog;
 import org.eclipse.equinox.p2.internal.repository.mirroring.Mirroring;
 import org.eclipse.equinox.p2.internal.repository.tools.Activator;
 import org.eclipse.equinox.p2.internal.repository.tools.Messages;
-import org.eclipse.equinox.p2.internal.repository.tools.RecreateRepositoryApplication;
 import org.eclipse.equinox.p2.internal.repository.tools.RepositoryDescriptor;
 import org.eclipse.equinox.p2.internal.repository.tools.SlicingOptions;
 import org.eclipse.equinox.p2.internal.repository.tools.XZCompressor;
@@ -82,6 +81,7 @@ import org.eclipse.tycho.p2.tools.RepositoryReferences;
 import org.eclipse.tycho.p2.tools.mirroring.facade.IUDescription;
 import org.eclipse.tycho.p2.tools.mirroring.facade.MirrorApplicationService;
 import org.eclipse.tycho.p2.tools.mirroring.facade.MirrorOptions;
+import org.eclipse.tycho.p2tools.copiedfromp2.RecreateRepositoryApplication;
 
 @Component(role = MirrorApplicationService.class)
 public class MirrorApplicationServiceImpl implements MirrorApplicationService {
@@ -239,10 +239,7 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
             artifactsXz.delete();
         }
         descriptor.setLocation(location.toURI());
-        //TODO this is to trigger loading of the osgi services and we can not pass the agent directly see 
-        // https://github.com/eclipse-equinox/p2/issues/151
-        agent.getService(IArtifactRepositoryManager.class);
-        RecreateRepositoryApplication application = new RecreateRepositoryApplication();
+        RecreateRepositoryApplication application = new RecreateRepositoryApplication(agent);
         application.setArtifactRepository(descriptor.getRepoLocation());
         try {
             application.run(new NullProgressMonitor());

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/QueryableArray.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/QueryableArray.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Cloudsmith Inc. - query indexes
+ *******************************************************************************/
+package org.eclipse.tycho.p2tools.copiedfromp2;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.equinox.internal.p2.core.helpers.CollectionUtils;
+import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
+import org.eclipse.equinox.internal.p2.metadata.TranslationSupport;
+import org.eclipse.equinox.internal.p2.metadata.index.CapabilityIndex;
+import org.eclipse.equinox.internal.p2.metadata.index.IdIndex;
+import org.eclipse.equinox.internal.p2.metadata.index.IndexProvider;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.KeyWithLocale;
+import org.eclipse.equinox.p2.metadata.index.IIndex;
+
+public class QueryableArray extends IndexProvider<IInstallableUnit> {
+    private final List<IInstallableUnit> dataSet;
+    private IIndex<IInstallableUnit> capabilityIndex;
+    private IIndex<IInstallableUnit> idIndex;
+    private TranslationSupport translationSupport;
+
+    public QueryableArray(IInstallableUnit[] ius) {
+        dataSet = CollectionUtils.unmodifiableList(ius);
+    }
+
+    public QueryableArray(Collection<IInstallableUnit> ius) {
+        dataSet = List.copyOf(ius);
+    }
+
+    @Override
+    public Iterator<IInstallableUnit> everything() {
+        return dataSet.iterator();
+    }
+
+    @Override
+    public boolean contains(IInstallableUnit element) {
+        return dataSet.contains(element);
+    }
+
+    @Override
+    public synchronized IIndex<IInstallableUnit> getIndex(String memberName) {
+        if (InstallableUnit.MEMBER_PROVIDED_CAPABILITIES.equals(memberName)) {
+            if (capabilityIndex == null)
+                capabilityIndex = new CapabilityIndex(dataSet.iterator());
+            return capabilityIndex;
+        }
+        if (InstallableUnit.MEMBER_ID.equals(memberName)) {
+            if (idIndex == null)
+                idIndex = new IdIndex(dataSet.iterator());
+            return idIndex;
+        }
+        return null;
+    }
+
+    @Override
+    public synchronized Object getManagedProperty(Object client, String memberName, Object key) {
+        if (!(client instanceof IInstallableUnit))
+            return null;
+        IInstallableUnit iu = (IInstallableUnit) client;
+        if (InstallableUnit.MEMBER_TRANSLATED_PROPERTIES.equals(memberName)) {
+            if (translationSupport == null)
+                translationSupport = new TranslationSupport(this);
+            return key instanceof KeyWithLocale ? translationSupport.getIUProperty(iu, (KeyWithLocale) key)
+                    : translationSupport.getIUProperty(iu, key.toString());
+        }
+        return null;
+    }
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/QueryableArray.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/QueryableArray.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.eclipse.equinox.internal.p2.core.helpers.CollectionUtils;
 import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
 import org.eclipse.equinox.internal.p2.metadata.TranslationSupport;
 import org.eclipse.equinox.internal.p2.metadata.index.CapabilityIndex;
@@ -29,17 +28,21 @@ import org.eclipse.equinox.p2.metadata.KeyWithLocale;
 import org.eclipse.equinox.p2.metadata.index.IIndex;
 
 public class QueryableArray extends IndexProvider<IInstallableUnit> {
-    private final List<IInstallableUnit> dataSet;
+    private final Collection<IInstallableUnit> dataSet;
     private IIndex<IInstallableUnit> capabilityIndex;
     private IIndex<IInstallableUnit> idIndex;
     private TranslationSupport translationSupport;
 
     public QueryableArray(IInstallableUnit[] ius) {
-        dataSet = CollectionUtils.unmodifiableList(ius);
+        this(List.of(ius), false);
     }
 
     public QueryableArray(Collection<IInstallableUnit> ius) {
-        dataSet = List.copyOf(ius);
+        this(ius, true);
+    }
+
+    public QueryableArray(Collection<IInstallableUnit> ius, boolean copy) {
+        dataSet = copy ? List.copyOf(ius) : ius;
     }
 
     @Override

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/RecreateRepositoryApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/RecreateRepositoryApplication.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Sonatype Inc - ongoing development
+ *     Mykola Nikishov - multiple artifact checksums
+ *******************************************************************************/
+
+package org.eclipse.tycho.p2tools.copiedfromp2;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.equinox.internal.p2.artifact.processors.checksum.ChecksumUtilities;
+import org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository;
+import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.internal.repository.tools.Messages;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.repository.IRepository;
+import org.eclipse.equinox.p2.repository.IRepositoryManager;
+import org.eclipse.equinox.p2.repository.artifact.ArtifactKeyQuery;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
+import org.eclipse.equinox.p2.repository.artifact.IFileArtifactRepository;
+import org.eclipse.equinox.p2.repository.artifact.spi.ArtifactDescriptor;
+import org.eclipse.osgi.util.NLS;
+
+public class RecreateRepositoryApplication extends AbstractApplication {
+    private URI repoLocation;
+    private String repoName = null;
+    boolean removeArtifactRepo = true;
+    private Map<String, String> repoProperties = null;
+    private Map<IArtifactKey, IArtifactDescriptor[]> repoMap = null;
+
+    public RecreateRepositoryApplication(IProvisioningAgent agent) {
+        super(agent);
+    }
+
+    @Override
+    public IStatus run(IProgressMonitor monitor) throws ProvisionException {
+        try {
+            IArtifactRepository repository = initialize(monitor);
+            removeRepository(repository, monitor);
+            recreateRepository(monitor);
+        } finally {
+            if (removeArtifactRepo) {
+                IArtifactRepositoryManager repositoryManager = getArtifactRepositoryManager();
+                repositoryManager.removeRepository(repoLocation);
+            }
+        }
+
+        return Status.OK_STATUS;
+    }
+
+    public void setArtifactRepository(URI repository) {
+        this.repoLocation = repository;
+    }
+
+    private IArtifactRepository initialize(IProgressMonitor monitor) throws ProvisionException {
+        IArtifactRepositoryManager repositoryManager = getArtifactRepositoryManager();
+        removeArtifactRepo = !repositoryManager.contains(repoLocation);
+
+        IArtifactRepository repository = repositoryManager.loadRepository(repoLocation,
+                IRepositoryManager.REPOSITORY_HINT_MODIFIABLE, monitor);
+
+        if (repository == null || !repository.isModifiable())
+            throw new ProvisionException(
+                    NLS.bind(Messages.exception_destinationNotModifiable, repository.getLocation()));
+        if (!(repository instanceof IFileArtifactRepository))
+            throw new ProvisionException(NLS.bind(Messages.exception_notLocalFileRepo, repository.getLocation()));
+
+        repoName = repository.getName();
+        repoProperties = repository.getProperties();
+
+        repoMap = new HashMap<>();
+        IQueryResult<IArtifactKey> keys = repository.query(ArtifactKeyQuery.ALL_KEYS, null);
+        for (IArtifactKey key : keys) {
+            IArtifactDescriptor[] descriptors = repository.getArtifactDescriptors(key);
+            repoMap.put(key, descriptors);
+        }
+
+        return repository;
+    }
+
+    private void removeRepository(IArtifactRepository repository, IProgressMonitor monitor) throws ProvisionException {
+        IArtifactRepositoryManager manager = getArtifactRepositoryManager();
+        manager.removeRepository(repository.getLocation());
+
+        boolean compressed = Boolean.parseBoolean(repoProperties.get(IRepository.PROP_COMPRESSED));
+        URI realLocation = SimpleArtifactRepository.getActualLocation(repository.getLocation(), compressed);
+        File realFile = URIUtil.toFile(realLocation);
+        if (!realFile.exists() || !realFile.delete())
+            throw new ProvisionException(NLS.bind(Messages.exception_unableToRemoveRepo, realFile.toString()));
+    }
+
+    private void recreateRepository(IProgressMonitor monitor) throws ProvisionException {
+        IArtifactRepositoryManager manager = getArtifactRepositoryManager();
+
+        IArtifactRepository repository = manager.createRepository(repoLocation, repoName,
+                IArtifactRepositoryManager.TYPE_SIMPLE_REPOSITORY, repoProperties);
+        if (!(repository instanceof IFileArtifactRepository))
+            throw new ProvisionException(NLS.bind(Messages.exception_notLocalFileRepo, repository.getLocation()));
+
+        IFileArtifactRepository simple = (IFileArtifactRepository) repository;
+        for (IArtifactKey key : repoMap.keySet()) {
+            IArtifactDescriptor[] descriptors = repoMap.get(key);
+
+            Set<File> files = new HashSet<>();
+            for (IArtifactDescriptor descriptor : descriptors) {
+                File artifactFile = simple.getArtifactFile(descriptor);
+                files.add(artifactFile);
+
+                String size = Long.toString(artifactFile.length());
+
+                ArtifactDescriptor newDescriptor = new ArtifactDescriptor(descriptor);
+                newDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_SIZE, size);
+                newDescriptor.setProperty(IArtifactDescriptor.DOWNLOAD_SIZE, size);
+
+                Map<String, String> checksums = new HashMap<>();
+                List<String> checksumsToSkip = Collections.emptyList();
+                IStatus status = ChecksumUtilities.calculateChecksums(artifactFile, checksums, checksumsToSkip);
+                if (!status.isOK())
+                    // TODO handle errors in some way
+                    LogHelper.log(status);
+
+                Map<String, String> checksumsToProperties = ChecksumUtilities
+                        .checksumsToProperties(IArtifactDescriptor.DOWNLOAD_CHECKSUM, checksums);
+                newDescriptor.addProperties(checksumsToProperties);
+
+                repository.addDescriptor(newDescriptor, null);
+            }
+        }
+    }
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/Slicer.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/Slicer.java
@@ -35,7 +35,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
 import org.eclipse.equinox.internal.p2.core.helpers.Tracing;
 import org.eclipse.equinox.internal.p2.director.Messages;
-import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
 import org.eclipse.equinox.internal.p2.metadata.InstallableUnitPatch;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
@@ -105,11 +104,11 @@ public class Slicer {
         if (result.getSeverity() == IStatus.ERROR) {
             return null;
         }
-        return new QueryableArray(considered);
+        return new QueryableArray(considered, false);
     }
 
     private void computeNonGreedyIUs() {
-        IQueryable<IInstallableUnit> queryable = new QueryableArray(considered);
+        IQueryable<IInstallableUnit> queryable = new QueryableArray(considered, false);
         for (IInstallableUnit iu : queryable.query(QueryUtil.ALL_UNITS, new NullProgressMonitor())) {
             iu = iu.unresolved();
             Collection<IRequirement> reqs = getRequirements(iu);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/Slicer.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/Slicer.java
@@ -205,24 +205,28 @@ public class Slicer {
         return aggregatedRequirements;
     }
 
+    private Set<IRequirement> consideredRequirements = new HashSet<>();
+
     private void expandRequirement(IInstallableUnit iu, IRequirement req) {
         if (req.getMax() == 0) {
             return;
         }
-        List<IInstallableUnit> selected = selectIUsForRequirement(possibilites, req).toList();
-        for (IInstallableUnit match : selected) {
-            Map<Version, IInstallableUnit> iuSlice = slice.get(match.getId());
-            if ((iuSlice == null || !iuSlice.containsKey(match.getVersion())) && considered.add(match)) {
-                toProcess.add(match);
-            }
-        }
-        if (selected.isEmpty()) {
-            if (req.getMin() == 0) {
-                if (DEBUG) {
-                    System.out.println("No IU found to satisfy optional dependency of " + iu + " on req " + req); //$NON-NLS-1$//$NON-NLS-2$
+        if (consideredRequirements.add(req)) {
+            List<IInstallableUnit> selected = selectIUsForRequirement(possibilites, req).toList();
+            for (IInstallableUnit match : selected) {
+                Map<Version, IInstallableUnit> iuSlice = slice.get(match.getId());
+                if ((iuSlice == null || !iuSlice.containsKey(match.getVersion())) && considered.add(match)) {
+                    toProcess.add(match);
                 }
-            } else {
-                result.add(Status.warning(NLS.bind(Messages.Planner_Unsatisfied_dependency, iu, req)));
+            }
+            if (selected.isEmpty()) {
+                if (req.getMin() == 0) {
+                    if (DEBUG) {
+                        System.out.println("No IU found to satisfy optional dependency of " + iu + " on req " + req); //$NON-NLS-1$//$NON-NLS-2$
+                    }
+                } else {
+                    result.add(Status.warning(NLS.bind(Messages.Planner_Unsatisfied_dependency, iu, req)));
+                }
             }
         }
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublisherServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublisherServiceTest.java
@@ -69,7 +69,7 @@ public class PublisherServiceTest extends TychoPlexusTestCase {
 
         LinkedHashSet<IInstallableUnit> installableUnits = new LinkedHashSet<>();
         installableUnits.add(InstallableUnitUtil.createFeatureIU("org.eclipse.example.original_feature", "1.0.0"));
-        IMetadataRepository context = new ImmutableInMemoryMetadataRepository(installableUnits);
+        IMetadataRepository context = new ImmutableInMemoryMetadataRepository(installableUnits, true);
 
         // TODO these publishers don't produce artifacts, so we could run without file system
         outputRepository = new PublishingRepositoryImpl(lookup(IProvisioningAgent.class),


### PR DESCRIPTION
Main improvement is that `FinalTargetPlatformImpl#getMetadataRepository()` previously copied on each call the whole target and also the index for it got rebuild on each call, what can have a impact if called very often.

In the bad case it can take > 1 minute to build a repository where now it is down to just 10 seconds.