### PR TITLE
[backport] Add support to specify target locations in the pom configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ### backports:
 
+- support for embedded target locations
 - using javac as the compiler for Tycho
 - new `mirror-target-platform` mojo
 - new director mojo

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetParameterObject.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetParameterObject.java
@@ -12,6 +12,7 @@ package org.eclipse.tycho.target;
 import java.io.File;
 import java.net.URI;
 
+import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.eclipse.tycho.p2.repository.GAV;
 
 /**
@@ -23,4 +24,5 @@ public class TargetParameterObject {
     public GAV target;
     public File file;
     public URI uri;
+    public PlexusConfiguration location;
 }

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
@@ -89,6 +89,7 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
      * <li><code>&lt;file></code> to define a file local to the build</li>
      * <li><code>&lt;uri></code> to define a (remote) URI that specifies a target, currently only
      * URIs that can be converted to URLs are supported (e.g. file:/.... http://..., )</li>
+     * <li>{@code <locations>} to define target locations inline</li>
      * </ul>
      */
     @Parameter(name = DefaultTargetPlatformConfigurationReader.TARGET)

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -17,7 +17,9 @@ package org.eclipse.tycho.core;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.OptionalResolutionAction;
@@ -121,6 +124,8 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     private ReferencedRepositoryMode referencedRepositoryMode = ReferencedRepositoryMode.ignore;
 
+    private List<Xpp3Dom> xmlFragments = new ArrayList<>();
+
     /**
      * Returns the list of configured target environments, or the running environment if no
      * environments have been specified explicitly.
@@ -140,6 +145,18 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
             Supplier<File> supplier = iterator.next();
             targets.add(supplier.get().toURI());
             iterator.remove();
+        }
+        if (!xmlFragments.isEmpty()) {
+            Xpp3Dom target = new Xpp3Dom("target");
+            Xpp3Dom locations = new Xpp3Dom(TargetDefinitionFile.ELEMENT_LOCATIONS);
+            target.addChild(locations);
+            for (Xpp3Dom location : xmlFragments) {
+                locations.addChild(new Xpp3Dom(location));
+            }
+            String collect = target.toString();
+            targets.add(URI.create("data:" + TargetDefinitionFile.APPLICATION_TARGET + ";base64,"
+                    + Base64.getEncoder().encodeToString(collect.getBytes(StandardCharsets.UTF_8))));
+            xmlFragments.clear();
         }
         return targets.stream().map(TargetDefinitionFile::read).toList();
     }
@@ -317,6 +334,10 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     public void setReferencedRepositoryMode(ReferencedRepositoryMode referencedRepositoryMode) {
         this.referencedRepositoryMode = referencedRepositoryMode;
+    }
+
+    public void addTargetLocation(Xpp3Dom locationDom) {
+        xmlFragments.add(locationDom);
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -331,10 +331,10 @@ public class DefaultTargetPlatformConfigurationReader {
 
     /**
      * Take the constraints of the configured execution environment into account when resolving
-     * dependencies or target definitions. These constraints include the list of system packages and the
-     * <tt>Bundle-RequiredExecutionEnvironment</tt> header. When set to <code>true</code>, the
-     * dependency resolution verifies that the bundle and all required bundles can be used in an OSGi
-     * container with the configured execution environment.
+     * dependencies or target definitions. These constraints include the list of system packages and
+     * the <tt>Bundle-RequiredExecutionEnvironment</tt> header. When set to <code>true</code>, the
+     * dependency resolution verifies that the bundle and all required bundles can be used in an
+     * OSGi container with the configured execution environment.
      */
     private void setResolveWithEEContraints(TargetPlatformConfiguration result, Xpp3Dom resolverDom) {
         String value = getStringValue(resolverDom.getChild(RESOLVE_WITH_EXECUTION_ENVIRONMENT_CONSTRAINTS));
@@ -462,6 +462,13 @@ public class DefaultTargetPlatformConfigurationReader {
                 }
             }
         }
+        Xpp3Dom[] locationsArray = targetDom.getChildren("location");
+        if (locationsArray != null && locationsArray.length > 0) {
+            for (Xpp3Dom locationDom : locationsArray) {
+                result.addTargetLocation(locationDom);
+            }
+        }
+
     }
 
     protected void addTargetArtifact(TargetPlatformConfiguration result, MavenSession session, MavenProject project,
@@ -592,9 +599,9 @@ public class DefaultTargetPlatformConfigurationReader {
      * 
      * @param project
      * @param targetFile
-     *                             the target file to check
+     *            the target file to check
      * @param otherTargetFiles
-     *                             other target files to take into account
+     *            other target files to take into account
      * @return <code>true</code> if the target file is the primary artifact, <code>false</code>
      *         otherwise
      */


### PR DESCRIPTION
Currently one can either define a target reference as a file or artefact this now adds support to also add locations directly to the pom xml configuration.