### PR TITLE
Do not use helper for create memory composite

### DIFF
--- a/tools/.classpath
+++ b/tools/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/tools/.project
+++ b/tools/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>tools</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/tools/.settings/org.eclipse.jdt.core.prefs
+++ b/tools/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,10 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -179,23 +179,23 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
         final TychoMirrorApplication mirrorApp = createMirrorApplication(sources, destination, agent);
 
         // mirror scope: seed units...
-        mirrorApp
-                .setSourceIUs(toInstallableUnitList(projectSeeds, mirrorApp.getCompositeMetadataRepository(), sources));
-        mirrorApp.setIncludeSources(includeAllSource, sources.getTargetPlatform());
-        mirrorApp.setIncludeRequiredBundles(includeRequiredBundles);
-        mirrorApp.setIncludeRequiredFeatures(includeRequiredFeatures);
-        mirrorApp.setFilterProvided(filterProvided);
-        mirrorApp.setAddOnlyProvidingRepoReferences(addOnlyProvidingRepoReferences);
-        mirrorApp.setEnvironments(context.getEnvironments());
-        SlicingOptions options = new SlicingOptions();
-        options.considerStrictDependencyOnly(!includeAllDependencies);
-        Map<String, String> filter = options.getFilter();
-        addFilterForFeatureJARs(filter);
-        if (filterProperties != null) {
-            filter.putAll(filterProperties);
-        }
-        mirrorApp.setSlicingOptions(options);
         try {
+            mirrorApp.setSourceIUs(
+                    toInstallableUnitList(projectSeeds, mirrorApp.getCompositeMetadataRepository(), sources));
+            mirrorApp.setIncludeSources(includeAllSource, sources.getTargetPlatform());
+            mirrorApp.setIncludeRequiredBundles(includeRequiredBundles);
+            mirrorApp.setIncludeRequiredFeatures(includeRequiredFeatures);
+            mirrorApp.setFilterProvided(filterProvided);
+            mirrorApp.setAddOnlyProvidingRepoReferences(addOnlyProvidingRepoReferences);
+            mirrorApp.setEnvironments(context.getEnvironments());
+            SlicingOptions options = new SlicingOptions();
+            options.considerStrictDependencyOnly(!includeAllDependencies);
+            Map<String, String> filter = options.getFilter();
+            addFilterForFeatureJARs(filter);
+            if (filterProperties != null) {
+                filter.putAll(filterProperties);
+            }
+            mirrorApp.setSlicingOptions(options);
             LogListener logListener = new LogListener(logger);
             mirrorApp.setLog(logListener);
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/TychoMirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/TychoMirrorApplication.java
@@ -97,7 +97,7 @@ public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfrom
     }
 
     @Override
-    public IArtifactRepository getCompositeArtifactRepository() {
+    public IArtifactRepository getCompositeArtifactRepository() throws ProvisionException {
         IArtifactRepository repository = super.getCompositeArtifactRepository();
         if (targetPlatform != null) {
             return new ListCompositeArtifactRepository(List.of(repository, targetPlatform.getArtifactRepository()),
@@ -107,7 +107,7 @@ public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfrom
     }
 
     @Override
-    protected Slicer createSlicer(SlicingOptions options) {
+    protected Slicer createSlicer(SlicingOptions options) throws ProvisionException {
         List<Map<String, String>> filters = getContextFilters();
         List<IInstallableUnit> selectionContexts = filters.stream().map(InstallableUnit::contextIU).toList();
         boolean includeOptionalDependencies = options.includeOptionalDependencies();

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
@@ -475,7 +475,7 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
         return slice;
     }
 
-    protected Slicer createSlicer(SlicingOptions options) {
+    protected Slicer createSlicer(SlicingOptions options) throws ProvisionException {
         PermissiveSlicer slicer = new PermissiveSlicer(getCompositeMetadataRepository(), options.getFilter(),
                 options.includeOptionalDependencies(), options.isEverythingGreedy(), options.forceFilterTo(),
                 options.considerStrictDependencyOnly(), options.followOnlyFilteredRequirements());


### PR DESCRIPTION
Instead of going through the managers to create a composite repos, just do it directly and get better error reporting and less disturbing.

As seen in this run where it fails to choose a random URI:
- https://github.com/eclipse-tycho/tycho/runs/20870914146

So lets see if this makes anything worse...