### PR TITLE
Support access rules defined from the classpath

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -92,8 +92,11 @@ import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.core.osgitools.project.EclipsePluginProject;
 import org.eclipse.tycho.core.resolver.shared.PomDependencies;
 import org.eclipse.tycho.helper.PluginRealmHelper;
+import org.eclipse.tycho.model.classpath.ClasspathContainerEntry;
+import org.eclipse.tycho.model.classpath.ContainerAccessRule;
 import org.eclipse.tycho.model.classpath.JREClasspathEntry;
 import org.eclipse.tycho.model.classpath.M2ClasspathVariable;
+import org.eclipse.tycho.model.classpath.PluginDependenciesClasspathContainer;
 import org.eclipse.tycho.model.classpath.ProjectClasspathEntry;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
@@ -570,10 +573,19 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
 
     @Override
     public List<String> getClasspathElements() throws MojoExecutionException {
+        Collection<ProjectClasspathEntry> classpathEntries = getEclipsePluginProject().getClasspathEntries();
         final List<String> classpath = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         Set<String> includedPathes = new HashSet<>();
         boolean useAccessRules = JDT_COMPILER_ID.equals(compilerId);
+        List<ContainerAccessRule> globalRules;
+        if (useAccessRules) {
+            globalRules = classpathEntries.stream().filter(PluginDependenciesClasspathContainer.class::isInstance)
+                    .map(PluginDependenciesClasspathContainer.class::cast).map(ClasspathContainerEntry::getAccessRules)
+                    .findFirst().orElse(List.of());
+        } else {
+            globalRules = List.of();
+        }
         for (ClasspathEntry cpe : getClasspath()) {
             Stream<File> classpathLocations = Stream
                     .concat(cpe.getLocations().stream(),
@@ -582,7 +594,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
                     .filter(AbstractOsgiCompilerMojo::isValidLocation).distinct();
             classpathLocations.forEach(location -> {
                 String path = location.getAbsolutePath();
-                String entry = path + toString(cpe.getAccessRules(), useAccessRules);
+                String entry = path + toString(cpe.getAccessRules(), globalRules, useAccessRules);
                 if (seen.add(entry)) {
                     includedPathes.add(path);
                     classpath.add(entry);
@@ -593,7 +605,6 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
             ArtifactRepository repository = session.getLocalRepository();
             if (repository != null) {
                 String basedir = repository.getBasedir();
-                Collection<ProjectClasspathEntry> classpathEntries = getEclipsePluginProject().getClasspathEntries();
                 for (ProjectClasspathEntry cpe : classpathEntries) {
                     if (cpe instanceof M2ClasspathVariable cpv) {
                         String entry = new File(basedir, cpv.getRepositoryPath()).getAbsolutePath();
@@ -647,17 +658,33 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
         return (BundleProject) projectType;
     }
 
-    private String toString(Collection<AccessRule> rules, boolean useAccessRules) {
+    private String toString(Collection<AccessRule> entryRules, List<ContainerAccessRule> containerRules,
+            boolean useAccessRules) {
         if (useAccessRules) {
             StringJoiner result = new StringJoiner(RULE_SEPARATOR, "[", "]"); // include all
-            if (rules != null) {
-                for (AccessRule rule : rules) {
-                    result.add((rule.isDiscouraged() ? "~" : "+") + rule.getPattern());
+            if (entryRules != null) {
+                for (ContainerAccessRule rule : containerRules) {
+                    switch (rule.getKind()) {
+                    case ACCESSIBLE:
+                        result.add("+" + rule.getPattern());
+                        break;
+                    case DISCOURAGED:
+                        result.add("~" + rule.getPattern());
+                        break;
+                    case NON_ACCESSIBLE:
+                        result.add("-" + rule.getPattern());
+                        break;
+                    default:
+                        break;
+                    }
+                }
+                if (entryRules != null) {
+                    for (AccessRule rule : entryRules) {
+                        result.add((rule.isDiscouraged() ? "~" : "+") + rule.getPattern());
+                    }
                 }
                 result.add(RULE_EXCLUDE_ALL);
             } else {
-                // include everything, not strictly necessary, but lets make this obvious
-                //result.append("[+**/*]");
                 return "";
             }
             return result.toString();
@@ -734,9 +761,9 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
             compilerConfiguration.setReleaseVersion(releaseLevel);
         }
         configureJavaHome(compilerConfiguration);
-        configureBootclasspathAccessRules(compilerConfiguration);
-        configureCompilerLog(compilerConfiguration);
         Collection<ProjectClasspathEntry> classpathEntries = getEclipsePluginProject().getClasspathEntries();
+        configureBootclasspathAccessRules(compilerConfiguration, classpathEntries);
+        configureCompilerLog(compilerConfiguration);
         for (ProjectClasspathEntry cpe : classpathEntries) {
             if (cpe instanceof JREClasspathEntry jreClasspathEntry) {
                 if (jreClasspathEntry.isModule()) {
@@ -789,8 +816,8 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
         addCompilerCustomArgument(compilerConfiguration, "-log", logPath);
     }
 
-    private void configureBootclasspathAccessRules(CompilerConfiguration compilerConfiguration)
-            throws MojoExecutionException {
+    private void configureBootclasspathAccessRules(CompilerConfiguration compilerConfiguration,
+            Collection<ProjectClasspathEntry> classpathEntries) throws MojoExecutionException {
         List<AccessRule> accessRules = new ArrayList<>();
 
         if (requireJREPackageImports != null) {
@@ -815,8 +842,11 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
                     .addAll(getBundleProject().getBootClasspathExtraAccessRules(DefaultReactorProject.adapt(project)));
         }
         if (!accessRules.isEmpty()) {
+            List<ContainerAccessRule> globalRules = classpathEntries.stream()
+                    .filter(JREClasspathEntry.class::isInstance).map(JREClasspathEntry.class::cast)
+                    .map(ClasspathContainerEntry::getAccessRules).findFirst().orElse(List.of());
             addCompilerCustomArgument(compilerConfiguration, "org.osgi.framework.system.packages",
-                    toString(accessRules, true));
+                    toString(accessRules, globalRules, true));
         }
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultClasspathEntry.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultClasspathEntry.java
@@ -66,6 +66,9 @@ public class DefaultClasspathEntry implements ClasspathEntry {
 
         @Override
         public String toString() {
+            if (isDiscouraged()) {
+                return getPattern() + " (discouraged)";
+            }
             return getPattern();
         }
 

--- a/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/classpath/ClasspathContainerEntry.java
+++ b/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/classpath/ClasspathContainerEntry.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.model.classpath;
 
+import java.util.List;
+
 /**
  * represents a container classpath entry, this could be for example:
  * 
@@ -32,5 +34,11 @@ public interface ClasspathContainerEntry extends ProjectClasspathEntry {
      * @return the path for this container
      */
     String getContainerPath();
+
+    /**
+     * 
+     * @return the {@link ContainerAccessRule}s defined for this classpathcontainer
+     */
+    List<ContainerAccessRule> getAccessRules();
 
 }

--- a/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/classpath/ContainerAccessRule.java
+++ b/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/classpath/ContainerAccessRule.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich  - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.model.classpath;
+
+import java.util.Objects;
+
+public interface ContainerAccessRule {
+
+    public enum Kind {
+        ACCESSIBLE("accessible"), NON_ACCESSIBLE("nonaccessible"), DISCOURAGED("discouraged"), UNKNOWN("");
+
+        private String attribute;
+
+        Kind(String attribute) {
+            this.attribute = attribute;
+        }
+
+        static Kind parse(String value) {
+            for (Kind kind : values()) {
+                if (Objects.equals(kind.attribute, value)) {
+                    return kind;
+                }
+            }
+            return Kind.UNKNOWN;
+        }
+
+    }
+
+    Kind getKind();
+
+    String getPattern();
+}

--- a/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/classpath/JREClasspathEntry.java
+++ b/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/classpath/JREClasspathEntry.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.model.classpath;
 
 import java.util.Collection;
 
-public interface JREClasspathEntry extends ProjectClasspathEntry {
+public interface JREClasspathEntry extends ClasspathContainerEntry {
 
     static final String JRE_CONTAINER_PATH = "org.eclipse.jdt.launching.JRE_CONTAINER";
 

--- a/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/classpath/PluginDependenciesClasspathContainer.java
+++ b/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/classpath/PluginDependenciesClasspathContainer.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich  - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.model.classpath;
+
+public interface PluginDependenciesClasspathContainer extends ClasspathContainerEntry {
+    static final String PATH = "org.eclipse.pde.core.requiredPlugins";
+}


### PR DESCRIPTION
In JDT one can define access rules from a classpath container, these are currently ignored and lead to warnings (or even errors) or duplicate configuration.

This now adds support for parsing these rules and use them for the required plugins and the jre container.