### PR TITLE
Manage org.eclipse.equinox.p2.publisher.eclipse in parent pom

### DIFF
--- a/p2-maven-plugin/pom.xml
+++ b/p2-maven-plugin/pom.xml
@@ -66,7 +66,6 @@
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.equinox.p2.publisher.eclipse</artifactId>
-			<version>1.5.200</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.platform</groupId>
+				<artifactId>org.eclipse.equinox.p2.publisher.eclipse</artifactId>
+				<version>1.5.200</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.platform</groupId>
 				<artifactId>org.eclipse.equinox.simpleconfigurator.manipulator</artifactId>
 				<version>2.3.0</version>
 			</dependency>

--- a/tycho-build/pom.xml
+++ b/tycho-build/pom.xml
@@ -95,7 +95,6 @@
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.equinox.p2.publisher.eclipse</artifactId>
-			<version>1.5.200</version>
 		</dependency>
 
 


### PR DESCRIPTION
So one can for example specify https://github.com/eclipse-equinox/p2/pull/446 as a dependency more easily.