### PR TITLE
Resolve API baseline with all matching environments

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/TargetEnvironment.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/TargetEnvironment.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.expression.IMatchExpression;
+import org.osgi.framework.Filter;
 
 public final class TargetEnvironment {
     private static final Properties EMPTY_PROPERTIES = new Properties();
@@ -68,6 +69,13 @@ public final class TargetEnvironment {
         return (os == null || os.equals(this.os)) && //
                 (ws == null || ws.equals(this.ws)) && //
                 (arch == null || arch.equals(this.arch));
+    }
+
+    public boolean match(Filter filter) {
+        if (filter != null) {
+            return filter.matches(toFilterProperties());
+        }
+        return true;
     }
 
     /**

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiApplicationResolver.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiApplicationResolver.java
@@ -28,6 +28,7 @@ import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.IllegalArtifactReferenceException;
 import org.eclipse.tycho.MavenRepositoryLocation;
+import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult.Entry;
@@ -59,8 +60,9 @@ public class ApiApplicationResolver {
 	private EclipseApplicationManager applicationManager;
 
 	public Collection<Path> getApiBaselineBundles(Collection<MavenRepositoryLocation> baselineRepoLocations,
-			ArtifactKey artifactKey) throws IllegalArtifactReferenceException {
-		P2Resolver resolver = applicationFactory.createResolver();
+			ArtifactKey artifactKey, Collection<TargetEnvironment> environment)
+			throws IllegalArtifactReferenceException {
+		P2Resolver resolver = applicationFactory.createResolver(environment);
 		resolver.addDependency(ArtifactType.TYPE_INSTALLABLE_UNIT, artifactKey.getId(), "0.0.0");
 		List<Path> resolvedBundles = new ArrayList<>();
 		TargetPlatform targetPlatform = applicationFactory.createTargetPlatform(baselineRepoLocations);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
@@ -62,6 +62,7 @@ import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
 import org.eclipse.tycho.helper.PluginRealmHelper;
 import org.eclipse.tycho.model.project.EclipseProject;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
+import org.osgi.framework.Filter;
 
 import aQute.bnd.osgi.Processor;
 
@@ -174,6 +175,16 @@ public class TychoProjectManager {
     public TargetPlatformConfiguration getTargetPlatformConfiguration(ReactorProject project) {
 
         return getTargetPlatformConfiguration(project.adapt(MavenProject.class));
+    }
+
+    public Collection<TargetEnvironment> getTargetEnvironments(MavenProject project) {
+        TychoProject tychoProject = projectTypes.get(project.getPackaging());
+        if (tychoProject != null) {
+            Filter environmentFilter = tychoProject.getTargetEnvironmentFilter(project);
+            return getTargetPlatformConfiguration(project).getEnvironments().stream()
+                    .filter(te -> te.match(environmentFilter)).toList();
+        }
+        return List.of(TargetEnvironment.getRunningEnvironment());
     }
 
     public Optional<TychoProject> getTychoProject(MavenProject project) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -375,10 +375,10 @@ public class DefaultTargetPlatformConfigurationReader {
                 List<TargetEnvironment> skipped = new ArrayList<>();
                 for (Xpp3Dom environmentDom : environmentsDom.getChildren("environment")) {
                     TargetEnvironment environment = newTargetEnvironment(environmentDom);
-                    if (!matchFilter(environment, filter)) {
-                        skipped.add(environment);
-                    } else {
+                    if (environment.match(filter)) {
                         result.addEnvironment(environment);
+                    } else {
+                        skipped.add(environment);
                     }
                 }
                 if (!skipped.isEmpty()) {
@@ -392,13 +392,6 @@ public class DefaultTargetPlatformConfigurationReader {
         } catch (TargetPlatformConfigurationException e) {
             throw new RuntimeException("target-platform-configuration error in project " + project.getId(), e);
         }
-    }
-
-    private static boolean matchFilter(TargetEnvironment environment, Filter filter) {
-        if (filter != null) {
-            return filter.matches(environment.toFilterProperties());
-        }
-        return true;
     }
 
     private static Filter getTargetEnvironmentFilter(TychoProject tychoProject, MavenProject project) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/framework/EclipseApplicationFactory.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/framework/EclipseApplicationFactory.java
@@ -13,7 +13,6 @@
 package org.eclipse.tycho.osgi.framework;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -97,8 +96,11 @@ public class EclipseApplicationFactory {
     }
 
     public P2Resolver createResolver() {
-        P2Resolver resolver = resolverFactory
-                .createResolver(Collections.singletonList(TargetEnvironment.getRunningEnvironment()));
+        return createResolver(List.of(TargetEnvironment.getRunningEnvironment()));
+    }
+
+    public P2Resolver createResolver(Collection<TargetEnvironment> environments) {
+        P2Resolver resolver = resolverFactory.createResolver(environments);
         return resolver;
     }
 


### PR DESCRIPTION
Currently the baseline is only resolved against the running target environment, but this does not work when multiple ones are matching or there is a platform filter.

This resolves the API baseline against all matching target environments.