### PR TITLE
set-version should update a micro version range properly

### DIFF
--- a/tycho-its/projects/tycho-version-plugin/set-version/version_ranges/consumer.micro/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-version-plugin/set-version/version_ranges/consumer.micro/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Test Bundle
+Bundle-SymbolicName: consumer.micro
+Bundle-Version: 1.0.0.qualifier
+Import-Package: my.pkg;version="[1.0.0,1.0.1)"
+Require-Bundle: provider.bundle;bundle-version="[1.0.0,1.0.1)"
+

--- a/tycho-its/projects/tycho-version-plugin/set-version/version_ranges/consumer.micro/pom.xml
+++ b/tycho-its/projects/tycho-version-plugin/set-version/version_ranges/consumer.micro/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.tycho.its</groupId>
+		<artifactId>parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>consumer.micro</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/tycho-version-plugin/set-version/version_ranges/pom.xml
+++ b/tycho-its/projects/tycho-version-plugin/set-version/version_ranges/pom.xml
@@ -10,6 +10,7 @@
 	<packaging>pom</packaging>
 	<modules>
 		<module>provider.bundle</module>
+		<module>consumer.micro</module>
 		<module>consumer.narrow</module>
 		<module>consumer.wide</module>
 		<module>consumer.open</module>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/versionsplugin/TychoVersionsPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/versionsplugin/TychoVersionsPluginTest.java
@@ -150,6 +150,7 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		String expectedNewMavenVersion = "1.1.0-SNAPSHOT";
 		String expectedNewOSGiVersion = "1.1.0.qualifier";
 		String expectedPackageVersion = "1.1.0";
+		String expectedMicroVersionRange = "[" + expectedPackageVersion + ",1.1.1)";
 		String expectedNarrowVersionRange = "[" + expectedPackageVersion + ",1.2.0)";
 		String expectedWideVersionRange = "[" + expectedPackageVersion + ",2)";
 		// example call:
@@ -186,6 +187,13 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 					consumerNarrow.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
 			assertVersionRange(consumerNarrow, expectedNarrowVersionRange, Constants.IMPORT_PACKAGE);
 			assertVersionRange(consumerNarrow, expectedNarrowVersionRange, Constants.REQUIRE_BUNDLE);
+		}
+		{// check micro version range is updated
+			Manifest consumerNarrow = getManifest(verifier, "consumer.micro");
+			assertEquals("version in manifest was not updated for micro consumer bundle!", expectedNewOSGiVersion,
+					consumerNarrow.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+			assertVersionRange(consumerNarrow, expectedMicroVersionRange, Constants.IMPORT_PACKAGE);
+			assertVersionRange(consumerNarrow, expectedMicroVersionRange, Constants.REQUIRE_BUNDLE);
 		}
 	}
 

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/DefaultVersionRangeUpdateStrategy.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/DefaultVersionRangeUpdateStrategy.java
@@ -49,7 +49,12 @@ public class DefaultVersionRangeUpdateStrategy implements VersionRangeUpdateStra
             Version newReferencedVersion, Version newArtifactVersion) {
         VersionRange newVersionRange;
         if (updateMatchingBounds) {
-            if (isProviderRange(versionRange)) {
+            if (isMicroRange(versionRange)) {
+                return new VersionRange(
+                        VersionRange.LEFT_CLOSED, newReferencedVersion, new Version(newReferencedVersion.getMajor(),
+                                newReferencedVersion.getMinor(), newReferencedVersion.getMicro() + 1),
+                        VersionRange.RIGHT_OPEN);
+            } else if (isProviderRange(versionRange)) {
                 return new VersionRange(VersionRange.LEFT_CLOSED, newReferencedVersion,
                         new Version(newReferencedVersion.getMajor(), newReferencedVersion.getMinor() + 1, 0),
                         VersionRange.RIGHT_OPEN);
@@ -60,6 +65,19 @@ public class DefaultVersionRangeUpdateStrategy implements VersionRangeUpdateStra
         }
         return handleNewlyOutOfScopeVersions(newVersionRange, originalReferencedVersion, newReferencedVersion,
                 newArtifactVersion);
+    }
+
+    private boolean isMicroRange(VersionRange versionRange) {
+        if (versionRange.getLeftType() == VersionRange.LEFT_CLOSED
+                && versionRange.getRightType() == VersionRange.RIGHT_OPEN) {
+            Version right = versionRange.getRight();
+            if (right != null) {
+                Version left = versionRange.getLeft();
+                return left.getMajor() == right.getMajor() && left.getMinor() == right.getMinor()
+                        && right.getMicro() > left.getMicro();
+            }
+        }
+        return false;
     }
 
     private boolean isProviderRange(VersionRange versionRange) {


### PR DESCRIPTION
Currently when one uses a version range that even uses the micro version this is not properly updated when using tycho-versions:set-version and results in an invalid version update.

This adds a testcase and code to detect such a range to upate it accordingly.