### PR TITLE
Print not mapped API messages to the log

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -92,6 +92,7 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     private String resolver;
 
     private List<TargetEnvironment> environments = new ArrayList<>();
+    private List<TargetEnvironment> filteredEnvironments = new ArrayList<>();
 
     private boolean implicitTargetEnvironment = true;
 
@@ -338,6 +339,14 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     public void addTargetLocation(Xpp3Dom locationDom) {
         xmlFragments.add(locationDom);
+    }
+
+    public void addFilteredEnvironment(TargetEnvironment environment) {
+        filteredEnvironments.add(environment);
+    }
+
+    public List<TargetEnvironment> getFilteredEnvironments() {
+        return filteredEnvironments;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
@@ -63,7 +63,6 @@ import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
 import org.eclipse.tycho.helper.PluginRealmHelper;
 import org.eclipse.tycho.model.project.EclipseProject;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
-import org.osgi.framework.Filter;
 
 import aQute.bnd.osgi.Processor;
 
@@ -185,10 +184,10 @@ public class TychoProjectManager {
     public Collection<TargetEnvironment> getTargetEnvironments(MavenProject project) {
         TychoProject tychoProject = projectTypes.get(project.getPackaging());
         if (tychoProject != null) {
-            Filter environmentFilter = tychoProject.getTargetEnvironmentFilter(project);
-            return getTargetPlatformConfiguration(project).getEnvironments().stream()
-                    .filter(te -> te.match(environmentFilter)).toList();
+        	//these will already be filtered at reading the target configuration
+            return getTargetPlatformConfiguration(project).getEnvironments();
         }
+        //if no tycho project, just assume the default running environment
         return List.of(TargetEnvironment.getRunningEnvironment());
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -21,7 +21,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -332,8 +331,8 @@ public class DefaultTargetPlatformConfigurationReader {
     /**
      * Take the constraints of the configured execution environment into account when resolving
      * dependencies or target definitions. These constraints include the list of system packages and
-     * the <code>Bundle-RequiredExecutionEnvironment</code> header. When set to <code>true</code>, the
-     * dependency resolution verifies that the bundle and all required bundles can be used in an
+     * the <code>Bundle-RequiredExecutionEnvironment</code> header. When set to <code>true</code>,
+     * the dependency resolution verifies that the bundle and all required bundles can be used in an
      * OSGi container with the configured execution environment.
      */
     private void setResolveWithEEContraints(TargetPlatformConfiguration result, Xpp3Dom resolverDom) {
@@ -372,20 +371,20 @@ public class DefaultTargetPlatformConfigurationReader {
             Xpp3Dom environmentsDom = configuration.getChild(ENVIRONMENTS);
             if (environmentsDom != null) {
                 Filter filter = getTargetEnvironmentFilter(tychoProject, project);
-                List<TargetEnvironment> skipped = new ArrayList<>();
                 for (Xpp3Dom environmentDom : environmentsDom.getChildren("environment")) {
                     TargetEnvironment environment = newTargetEnvironment(environmentDom);
                     if (environment.match(filter)) {
                         result.addEnvironment(environment);
                     } else {
-                        skipped.add(environment);
+                        result.addFilteredEnvironment(environment);
                     }
                 }
-                if (!skipped.isEmpty()) {
+                List<TargetEnvironment> filteredEnvironments = result.getFilteredEnvironments();
+                if (!filteredEnvironments.isEmpty()) {
                     logger.debug(MessageFormat.format(
                             "Declared TargetEnvironment(s) {0} are skipped for {1} as they do not match the project filter {2}.",
-                            skipped.stream().map(TargetEnvironment::toFilterProperties).map(String::valueOf)
-                                    .collect(Collectors.joining(", ")),
+                            filteredEnvironments.stream().map(TargetEnvironment::toFilterProperties)
+                                    .map(String::valueOf).collect(Collectors.joining(", ")),
                             project.getId(), filter));
                 }
             }


### PR DESCRIPTION
Currently if a message can't be mapped to the logfile it is simply ignored.

This now always print them to the log if they can't be mapped and print a waring about the issue as it is usually some configuration problem.