### PR TITLE
Improve GOAWAY handling

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/Headers.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/Headers.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.transport;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+public interface Headers extends AutoCloseable {
+
+	String ENCODING_IDENTITY = "identity";
+	String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
+	String HEADER_CONTENT_ENCODING = "Content-Encoding";
+	String ENCODING_GZIP = "gzip";
+	String ETAG_HEADER = "ETag";
+	String LAST_MODIFIED_HEADER = "Last-Modified";
+	String EXPIRES_HEADER = "Expires";
+	String CACHE_CONTROL_HEADER = "Cache-Control";
+	String MAX_AGE_DIRECTIVE = "max-age";
+	String MUST_REVALIDATE_DIRECTIVE = "must-revalidate";
+
+	int statusCode() throws IOException;
+
+	Map<String, List<String>> headers();
+
+	@Override
+	void close();
+
+	URI getURI();
+
+	String getHeader(String header);
+
+	long getLastModified();
+
+	default void checkResponseCode() throws FileNotFoundException, IOException {
+		int code = statusCode();
+		if (code >= HttpURLConnection.HTTP_BAD_REQUEST) {
+			if (code == HttpURLConnection.HTTP_NOT_FOUND || code == HttpURLConnection.HTTP_GONE) {
+				throw new FileNotFoundException(getURI().toString());
+			} else {
+				throw new java.io.IOException("Server returned HTTP code: " + code + " for URL " + getURI().toString());
+			}
+		}
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/HttpTransport.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/HttpTransport.java
@@ -1,14 +1,15 @@
 package org.eclipse.tycho.p2maven.transport;
 
 import java.io.IOException;
-import java.io.InputStream;
+
+import org.eclipse.tycho.p2maven.transport.Response.ResponseConsumer;
 
 public interface HttpTransport {
 
 	void setHeader(String key, String value);
 
-	Response<InputStream> get() throws IOException;
+	<T> T get(ResponseConsumer<T> consumer) throws IOException;
 
-	Response<Void> head() throws IOException;
+	Headers head() throws IOException;
 
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/URLHttpTransportFactory.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/URLHttpTransportFactory.java
@@ -14,6 +14,7 @@ package org.eclipse.tycho.p2maven.transport;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -25,6 +26,7 @@ import java.util.Map;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.tycho.p2maven.helper.ProxyHelper;
+import org.eclipse.tycho.p2maven.transport.Response.ResponseConsumer;
 
 @Component(role = HttpTransportFactory.class, hint = URLHttpTransportFactory.HINT)
 public class URLHttpTransportFactory implements HttpTransportFactory {
@@ -60,10 +62,10 @@ public class URLHttpTransportFactory implements HttpTransportFactory {
 		}
 
 		@Override
-		public Response<InputStream> get() throws IOException {
+		public <T> T get(ResponseConsumer<T> consumer) throws IOException {
 			HttpURLConnection connection = createConnection();
 			connection.connect();
-			return new HttpResponse<>(connection) {
+			try (HttpResponse response = new HttpResponse(connection) {
 
 				@Override
 				public void close() {
@@ -90,11 +92,16 @@ public class URLHttpTransportFactory implements HttpTransportFactory {
 				}
 
 				@Override
-				public InputStream body() throws IOException {
-					return connection.getInputStream();
+				public void transferTo(OutputStream outputStream, ContentEncoding transportEncoding)
+						throws IOException {
+					transportEncoding.decode(connection.getInputStream()).transferTo(outputStream);
+
 				}
 
-			};
+
+			}) {
+				return consumer.handleResponse(response);
+			}
 		}
 
 		private HttpURLConnection createConnection() throws IOException, MalformedURLException {
@@ -107,11 +114,11 @@ public class URLHttpTransportFactory implements HttpTransportFactory {
 		}
 
 		@Override
-		public Response<Void> head() throws IOException {
+		public Response head() throws IOException {
 			HttpURLConnection connection = createConnection();
 			connection.setRequestMethod("HEAD");
 			connection.connect();
-			return new HttpResponse<>(connection) {
+			return new HttpResponse(connection) {
 
 				@Override
 				public void close() {
@@ -119,14 +126,16 @@ public class URLHttpTransportFactory implements HttpTransportFactory {
 				}
 
 				@Override
-				public Void body() throws IOException {
-					return null;
+				public void transferTo(OutputStream outputStream, ContentEncoding transportEncoding)
+						throws IOException {
+					throw new IOException("Only headers!");
 				}
+
 			};
 		}
 	}
 
-	private static abstract class HttpResponse<T> implements Response<T> {
+	private static abstract class HttpResponse implements Response {
 
 		private HttpURLConnection connection;
 


### PR DESCRIPTION
Currently GOAWAY is detected/handled only in the connection phase but sometimes can happen in the transfer phase as well.

This now wraps the whole request inside a block that is retried if a GOAWAY is detected.