### PR TITLE
Allow to specify additional update sites to install items in p2 mode

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/RepositoryReferences.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/RepositoryReferences.java
@@ -54,6 +54,17 @@ public final class RepositoryReferences {
     }
 
     /**
+     * Adds a co-located metadata/artifact repository at the given location.
+     * 
+     * @param repository
+     *            A URL pointing to a p2 repository
+     */
+    public void addRepository(URI repository) {
+        addArtifactRepository(repository);
+        addMetadataRepository(repository);
+    }
+
+    /**
      * Adds the artifact repository at the given location.
      * 
      * @param artifactRepositoryLocation

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilder.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilder.java
@@ -130,7 +130,7 @@ public class ProvisionedInstallationBuilder {
         command.setProfileName(profileName);
         command.setInstallFeatures(installFeatures);
         command.setEnvironment(env);
-        log.info("Installing IUs " + ius + " to " + effectiveDestination);
+        log.info("Installing IUs " + ius + " to " + effectiveDestination + " using " + command.getProfileProperties());
         try {
             command.execute();
         } catch (DirectorCommandException e) {


### PR DESCRIPTION
Currently only the project target platform items can be selected if a p2installed runtime is used.

This now adds a new option to specify additional repositories in p2installed mode.