### PR TITLE
Authentication fails when trying to resolve a target platform over an authenticated mirror that is a composite repository

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/RemoteMetadataRepositoryManager.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/RemoteMetadataRepositoryManager.java
@@ -63,7 +63,7 @@ class RemoteMetadataRepositoryManager implements IMetadataRepositoryManager {
 	public IMetadataRepository loadRepository(URI location, int flags, IProgressMonitor monitor)
 			throws ProvisionException, OperationCanceledException {
 		URI effectiveLocation = translateAndPrepareLoad(location);
-		authenticator.enterLoad(location);
+		authenticator.enterLoad(effectiveLocation);
 		try {
 			IMetadataRepository loadedRepository = delegate.loadRepository(effectiveLocation, flags, monitor);
 			failIfRepositoryContainsPartialIUs(loadedRepository, effectiveLocation);

--- a/tycho-its/projects/issue2331/bundle/platform.target
+++ b/tycho-its/projects/issue2331/bundle/platform.target
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.5"?>
+
+<target name="platform">
+  <locations>
+    <location includeAllPlatforms="false" includeMode="planner"
+      type="InstallableUnit">
+      <unit id='org.eclipse.osgi' version='3.4.3.R34x_v20081215-1030' />
+      <repository id="test-server" location="[url]" />
+    </location>
+  </locations>
+</target>

--- a/tycho-its/projects/issue2331/pom.xml
+++ b/tycho-its/projects/issue2331/pom.xml
@@ -14,11 +14,6 @@
 	<version>0.0.1-SNAPSHOT</version>
   	<packaging>pom</packaging>
 
-	<modules>
-		<module>bundle</module>
-		<module>product</module>
-	</modules>
-
   <build>
     <plugins>
       <plugin>
@@ -41,6 +36,10 @@
   <profiles>
     <profile>
       <id>repository</id>
+      <modules>
+		<module>bundle</module>
+		<module>product</module>
+	  </modules>
       <repositories>
         <repository>
           <id>test-server</id>
@@ -52,6 +51,9 @@
 
     <profile>
       <id>target-definition</id>
+	  <modules>
+		<module>bundle</module>
+	  </modules>
       <build>
         <plugins>
           <plugin>

--- a/tycho-its/projects/issue2331/settings-auth-mirror.xml
+++ b/tycho-its/projects/issue2331/settings-auth-mirror.xml
@@ -1,0 +1,18 @@
+<settings>
+  <servers>
+    <server>
+      <id>test-auth-mirror</id>
+      <username>mirror-user</username>
+      <password>mirror-password</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>test-auth-mirror</id>      
+      <url>${p2.authMirror}</url>
+      <mirrorOf>test-server</mirrorOf>
+      <layout>p2</layout>
+      <mirrorOfLayouts>p2</mirrorOfLayouts>
+	</mirror>	  
+  </mirrors>
+</settings>

--- a/tycho-its/projects/issue2331/settings-encrypted.xml
+++ b/tycho-its/projects/issue2331/settings-encrypted.xml
@@ -1,0 +1,9 @@
+<settings>
+  <servers>
+    <server>
+      <id>test-server</id>
+      <username>test-user</username>
+      <password>{Gnn5SYwzVmUHEaxkXS/F3PJlVeqCXstNJ61EtCTqNEU=}</password>
+    </server>
+  </servers>
+</settings>

--- a/tycho-its/projects/issue2331/settings-mirror.xml
+++ b/tycho-its/projects/issue2331/settings-mirror.xml
@@ -1,0 +1,11 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>test-mirror</id>      
+      <url>${p2.mirror}</url>	
+      <mirrorOf>test-server</mirrorOf>
+      <layout>p2</layout>
+      <mirrorOfLayouts>p2</mirrorOfLayouts>
+	</mirror>	  
+  </mirrors>
+</settings>

--- a/tycho-its/projects/issue2331/settings-security.xml
+++ b/tycho-its/projects/issue2331/settings-security.xml
@@ -1,0 +1,3 @@
+<settingsSecurity>
+  <master>{d0cIDW8DS4wHiBuKkPDps5v0kZ/OAX1REXQFCZRmS2g=}</master>
+</settingsSecurity>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedCompositeP2RepositoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedCompositeP2RepositoryTest.java
@@ -19,6 +19,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.ResourceUtil;
+import org.eclipse.tycho.test.util.TargetDefinitionUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,22 +29,152 @@ public class PasswordProtectedCompositeP2RepositoryTest extends AbstractTychoInt
 	private HttpServer server;
 	private String p2RepoUrl;
 
+	private HttpServer mirror;
+	private String p2MirrorUrl;
+
+	private HttpServer authMirror;
+	private String p2AuthMirrorUrl;
+
 	@Before
 	public void startServer() throws Exception {
 		server = HttpServer.startServer("test-user", "test-password");
 		p2RepoUrl = server.addServer("foo", ResourceUtil.resolveTestResource("repositories/issue_2331_reproducer"))
 				+ "/bundles";
+
+		mirror = HttpServer.startServer();
+		p2MirrorUrl = mirror.addServer("bar", ResourceUtil.resolveTestResource("repositories/issue_2331_reproducer"))
+				+ "/bundles";
+
+		authMirror = HttpServer.startServer("mirror-user", "mirror-password");
+		p2AuthMirrorUrl = authMirror.addServer("bar",
+				ResourceUtil.resolveTestResource("repositories/issue_2331_reproducer")) + "/bundles";
 	}
 
 	@After
 	public void stopServer() throws Exception {
+		authMirror.stop();
+		mirror.stop();
 		server.stop();
 	}
 
+	/**
+	 * Tries to access a composite p2 repository over an authenticated composite
+	 * mirror.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testAuthMirror() throws Exception {
+		Verifier verifier = createVerifier("settings-auth-mirror.xml");
+		verifier.setSystemProperty("p2.authMirror", p2AuthMirrorUrl);
+		verifier.addCliOption("-P=repository");
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	/**
+	 * Tries to access a composite p2 repository over a composite mirror with no
+	 * authentication.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testMirror() throws Exception {
+		Verifier verifier = createVerifier("settings-mirror.xml");
+		verifier.setSystemProperty("p2.mirror", p2MirrorUrl);
+		verifier.addCliOption("-P=repository");
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	/**
+	 * Tries to access a composite p2 repository.
+	 * 
+	 * @throws Exception
+	 */
 	@Test
 	public void testRepository() throws Exception {
 		Verifier verifier = createVerifier("settings.xml");
 		verifier.addCliOption("-P=repository");
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	/**
+	 * Tries to access an authenticated composite p2 repository whose password is
+	 * encrypted.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testRepositoryEncrypted() throws Exception {
+		Verifier verifier = createVerifier("settings-encrypted.xml", "settings-security.xml");
+		verifier.addCliOption("-P=repository");
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	/**
+	 * Tries to resolve a target platform from a composite p2 repository.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testTargetDefinition() throws Exception {
+		Verifier verifier = createVerifier("settings.xml");
+		File platformFile = new File(verifier.getBasedir(), "bundle/platform.target");
+		TargetDefinitionUtil.setRepositoryURLs(platformFile, p2RepoUrl);
+		verifier.addCliOption("-P=target-definition");
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	/**
+	 * Tries to resolve a target definition from a composite p2 repository accessed
+	 * over a composite mirror with no authentication.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testTargetDefinitionMirror() throws Exception {
+		Verifier verifier = createVerifier("settings-mirror.xml");
+		File platformFile = new File(verifier.getBasedir(), "bundle/platform.target");
+		TargetDefinitionUtil.setRepositoryURLs(platformFile, p2RepoUrl);
+		verifier.setSystemProperty("p2.mirror", p2MirrorUrl);
+		verifier.addCliOption("-P=target-definition");
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	/**
+	 * Tries to resolve a target definition from a composite p2 repository accessed
+	 * over an authenticated composite mirror.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testTargetDefinitionAuthMirror() throws Exception {
+		Verifier verifier = createVerifier("settings-auth-mirror.xml");
+		File platformFile = new File(verifier.getBasedir(), "bundle/platform.target");
+		TargetDefinitionUtil.setRepositoryURLs(platformFile, p2RepoUrl);
+		verifier.setSystemProperty("p2.authMirror", p2AuthMirrorUrl);
+		verifier.addCliOption("-P=target-definition");
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	/**
+	 * Tries to resolve a target definition from an authenticated composite p2
+	 * repository whose password is encrypted.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testTargetDefinitionEncrypted() throws Exception {
+		Verifier verifier = createVerifier("settings-encrypted.xml", "settings-security.xml");
+		File platformFile = new File(verifier.getBasedir(), "bundle/platform.target");
+		TargetDefinitionUtil.setRepositoryURLs(platformFile, p2RepoUrl);
+		verifier.addCliOption("-P=target-definition");
 		verifier.executeGoal("package");
 		verifier.verifyErrorFreeLog();
 	}
@@ -60,7 +191,7 @@ public class PasswordProtectedCompositeP2RepositoryTest extends AbstractTychoInt
 			// see
 			// org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher#SYSTEM_PROPERTY_SEC_LOCATION
 			systemProperties.setProperty("settings.security",
-					new File("projects/target.httpAuthentication/" + settingsSecurityFile).getAbsolutePath());
+					new File("projects/issue2331/" + settingsSecurityFile).getAbsolutePath());
 		}
 		return verifier;
 	}


### PR DESCRIPTION
Test created for reproducing the bug as described in #3501:

- _testTargetDefinitionAuthMirror_: tries to resolve a target definition from a composite p2 repository accessed over an authenticated composite mirror.

On the other hand, the following tests pass and have been created just for completion:

- _testAuthMirror_: tries to access a composite p2 repository over an authenticated composite mirror.
- _testMirror_: tries to access a composite p2 repository over a composite mirror with no authentication.
- _testRepositoryEncrypted_: tries to access an authenticated composite p2 repository whose password is encrypted.
- _testTargetDefinition_: tries to resolve a target platform from a composite p2 repository.
- _testTargetDefinitionEncrypted_: tries to resolve a target definition from an authenticated composite p2 repository whose password is encrypted.
- _testTargetDefinitionMirror_: tries to resolve a target definition from a composite p2 repository accessed over a composite mirror with no authentication.
