### PR TITLE
Add a timestamp provider that inherits the timestamp from the parent

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/ArtifactCollection.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/ArtifactCollection.java
@@ -40,6 +40,7 @@ import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.core.osgitools.DefaultArtifactDescriptor;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 public class ArtifactCollection {
     private static final Version VERSION_0_0_0 = new Version("0.0.0");
@@ -249,7 +250,14 @@ public class ArtifactCollection {
         if (version == null) {
             return relevantArtifacts.get(relevantArtifacts.firstKey()); // latest version
         }
-
+        if (version.startsWith("(") || version.startsWith("[")) {
+            VersionRange range = VersionRange.valueOf(version);
+            for (Entry<Version, ArtifactDescriptor> entry : relevantArtifacts.entrySet()) {
+                if (range.includes(entry.getKey())) {
+                    return entry.getValue();
+                }
+            }
+        }
         Version parsedVersion = new Version(version);
         if (VERSION_0_0_0.equals(parsedVersion)) {
             return relevantArtifacts.get(relevantArtifacts.firstKey()); // latest version

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
@@ -90,7 +90,11 @@ import org.osgi.framework.Version;
 @Mojo(name = "build-qualifier", defaultPhase = LifecyclePhase.VALIDATE, threadSafe = true)
 public class BuildQualifierMojo extends AbstractVersionMojo {
 
-    @Parameter(property = "session", readonly = true)
+	static final String PARAMETER_FORMAT = "format";
+
+	static final String DEFAULT_DATE_FORMAT = "yyyyMMddHHmm";
+
+	@Parameter(property = "session", readonly = true)
     protected MavenSession session;
 
     /**
@@ -98,7 +102,7 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
      * Specify a date format as specified by java.text.SimpleDateFormat. Timezone used is UTC.
      * </p>
      */
-	@Parameter(defaultValue = "yyyyMMddHHmm", property = "tycho.buildqualifier.format")
+	@Parameter(name = PARAMETER_FORMAT, defaultValue = DEFAULT_DATE_FORMAT, property = "tycho.buildqualifier.format")
     protected SimpleDateFormat format;
 
     @Parameter(property = "forceContextQualifier")

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/FragmentHostBuildTimestampProvider.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/FragmentHostBuildTimestampProvider.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 20024 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.buildversion;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.osgi.util.ManifestElement;
+import org.eclipse.tycho.ArtifactDescriptor;
+import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.DependencyArtifacts;
+import org.eclipse.tycho.build.BuildTimestampProvider;
+import org.eclipse.tycho.core.BundleProject;
+import org.eclipse.tycho.core.TychoProject;
+import org.eclipse.tycho.core.TychoProjectManager;
+import org.eclipse.tycho.helper.PluginConfigurationHelper;
+import org.eclipse.tycho.helper.PluginConfigurationHelper.Configuration;
+import org.osgi.framework.Constants;
+
+/**
+ * Build timestamp provider that inherits the timestamp of the fragment host
+ */
+@Component(role = BuildTimestampProvider.class, hint = FragmentHostBuildTimestampProvider.ROLE_HINT)
+public class FragmentHostBuildTimestampProvider implements BuildTimestampProvider {
+
+	static final String ROLE_HINT = "fragment-host";
+
+	@Requirement
+	private TychoProjectManager projectManager;
+
+	@Requirement
+	private Logger logger;
+
+	@Requirement
+	private TimestampFinder timestampFinder;
+
+	@Requirement
+	private PluginConfigurationHelper configurationHelper;
+
+	@Override
+	public Date getTimestamp(MavenSession session, MavenProject project, MojoExecution execution) {
+		Optional<TychoProject> tychoProject = projectManager.getTychoProject(project);
+		Exception exception = null;
+		if (tychoProject.isPresent()) {
+			if (tychoProject.get() instanceof BundleProject bundle) {
+				String fragmentHost = bundle.getManifestValue(Constants.FRAGMENT_HOST, project);
+				if (fragmentHost != null) {
+					try {
+						ManifestElement[] header = ManifestElement.parseHeader(Constants.FRAGMENT_HOST, fragmentHost);
+						for (ManifestElement element : header) {
+							DependencyArtifacts dependencyArtifacts = projectManager.getDependencyArtifacts(project)
+									.get();
+							ArtifactDescriptor descriptor = dependencyArtifacts.getArtifact(
+									ArtifactType.TYPE_ECLIPSE_PLUGIN, element.getValue(),
+									element.getAttribute(Constants.BUNDLE_VERSION_ATTRIBUTE));
+							if (descriptor != null) {
+
+								Configuration configuration = configurationHelper.getConfiguration();
+								Optional<String> formatString = configuration
+										.getString(BuildQualifierMojo.PARAMETER_FORMAT);
+								SimpleDateFormat format = formatString.map(SimpleDateFormat::new)
+										.orElseGet(() -> new SimpleDateFormat(BuildQualifierMojo.DEFAULT_DATE_FORMAT));
+								Date date = timestampFinder.findByDescriptor(descriptor, format);
+								if (date != null) {
+									return date;
+								}
+							}
+						}
+					} catch (Exception e) {
+						exception = e;
+					}
+				}
+			}
+		}
+		logger.warn("Can't determine fragment host, fallback to default.", exception);
+		return session.getStartTime();
+	}
+
+	@Override
+	public void setQuiet(boolean quiet) {
+
+	}
+}


### PR DESCRIPTION
In some special setups (e.g. if fragment version should always match host version) it could be useful to inherit the build timestamp from the fragment host.

This adds a new timestamp provider to allow this use-case by specify `<timestampProvider>fragment-host</timestampProvider>`.