### PR TITLE
Refactor Tycho to use copied application

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/AbstractPublisherApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/AbstractPublisherApplication.java
@@ -1,0 +1,376 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2017 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     EclipseSource - ongoing development
+ *******************************************************************************/
+package org.eclipse.equinox.p2.publisher;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.core.runtime.*;
+import org.eclipse.equinox.app.IApplication;
+import org.eclipse.equinox.app.IApplicationContext;
+import org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository;
+import org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository;
+import org.eclipse.equinox.internal.p2.publisher.Activator;
+import org.eclipse.equinox.internal.p2.publisher.Messages;
+import org.eclipse.equinox.p2.core.*;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.equinox.p2.repository.artifact.ArtifactKeyQuery;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.osgi.util.NLS;
+import org.osgi.framework.ServiceReference;
+
+public abstract class AbstractPublisherApplication implements IApplication {
+
+	// The mapping rules for in-place generation need to construct paths into the
+	// structure
+	// of an eclipse installation; in the future the default artifact mapping
+	// declared in
+	// SimpleArtifactRepository may change, for example, to not have a 'bundles'
+	// directory
+	// instead of a 'plugins' directory, so a separate constant is defined and used
+	// here.
+	protected static final String[][] INPLACE_MAPPING_RULES = {
+			{ "(& (classifier=osgi.bundle))", "${repoUrl}/plugins/${id}_${version}.jar" }, //$NON-NLS-1$//$NON-NLS-2$
+			{ "(& (classifier=binary))", "${repoUrl}/binary/${id}_${version}" }, //$NON-NLS-1$//$NON-NLS-2$
+			{ "(& (classifier=org.eclipse.update.feature))", "${repoUrl}/features/${id}_${version}.jar" } }; //$NON-NLS-1$//$NON-NLS-2$
+
+	protected PublisherInfo info;
+	protected String source;
+	protected URI metadataLocation;
+	protected String metadataRepoName;
+	protected URI artifactLocation;
+	protected String artifactRepoName;
+	protected URI[] contextMetadataRepositories;
+	protected URI[] contextArtifactRepositories;
+	// whether repository xml files should be compressed
+	protected boolean compress = false;
+	protected boolean inplace = false;
+	protected boolean append = false;
+	protected String[] configurations;
+	private IStatus status;
+
+	private ServiceReference<IProvisioningAgent> agentRef;
+
+	protected IProvisioningAgent agent;
+
+	public AbstractPublisherApplication() {
+		this(null);
+	}
+
+	public AbstractPublisherApplication(IProvisioningAgent agent) {
+		this.agent = agent;
+	}
+
+	/**
+	 * Returns the error message for this application, or the empty string if the
+	 * application terminated successfully.
+	 */
+	public IStatus getStatus() {
+		return status;
+	}
+
+	protected void initialize(PublisherInfo publisherInfo) throws ProvisionException {
+		if (inplace) {
+			File location = new File(source);
+			if (metadataLocation == null)
+				metadataLocation = location.toURI();
+			if (artifactLocation == null)
+				artifactLocation = location.toURI();
+			publisherInfo.setArtifactOptions(
+					publisherInfo.getArtifactOptions() | IPublisherInfo.A_INDEX | IPublisherInfo.A_PUBLISH);
+		}
+		initializeRepositories(publisherInfo);
+	}
+
+	protected IStatus createConfigurationEror(String message) {
+		return new Status(IStatus.ERROR, "org.eclipse.equinox.p2.publisher", message); //$NON-NLS-1$
+	}
+
+	private boolean isEmpty(IArtifactRepository repo) {
+		IQueryResult<IArtifactKey> result = repo.query(QueryUtil.createLimitQuery(ArtifactKeyQuery.ALL_KEYS, 1), null);
+		return result.isEmpty();
+	}
+
+	protected void initializeRepositories(PublisherInfo publisherInfo) throws ProvisionException {
+		if (artifactLocation != null) {
+			@SuppressWarnings("removal")
+			IArtifactRepository repo = Publisher.createArtifactRepository(agent, artifactLocation, artifactRepoName,
+					compress);
+			if (!append && !isEmpty(repo)) {
+				File repoLocation = URIUtil.toFile(artifactLocation);
+				if (repoLocation != null && source != null) {
+					if (repoLocation.isFile())
+						repoLocation = repoLocation.getParentFile();
+					if (repoLocation.equals(new File(source)))
+						throw new IllegalArgumentException(
+								NLS.bind(Messages.exception_artifactRepoNoAppendDestroysInput,
+										URIUtil.toUnencodedString(artifactLocation)));
+				}
+				repo.removeAll(new NullProgressMonitor());
+			}
+			publisherInfo.setArtifactRepository(repo);
+		} else if ((publisherInfo.getArtifactOptions() & IPublisherInfo.A_PUBLISH) > 0)
+			throw new ProvisionException(createConfigurationEror(Messages.exception_noArtifactRepo));
+		if (metadataLocation == null)
+			throw new ProvisionException(createConfigurationEror(Messages.exception_noMetadataRepo));
+		publisherInfo.setMetadataRepository(
+				Publisher.createMetadataRepository(agent, metadataLocation, metadataRepoName, append, compress));
+
+		if (contextMetadataRepositories != null && contextMetadataRepositories.length > 0) {
+			CompositeMetadataRepository contextMetadata = CompositeMetadataRepository.createMemoryComposite(agent);
+			if (contextMetadata != null) {
+				for (URI repositoryuri : contextMetadataRepositories) {
+					contextMetadata.addChild(repositoryuri);
+				}
+				if (contextMetadata.getChildren().size() > 0)
+					publisherInfo.setContextMetadataRepository(contextMetadata);
+			}
+		}
+		if (contextArtifactRepositories != null && contextArtifactRepositories.length > 0) {
+			CompositeArtifactRepository contextArtifact = CompositeArtifactRepository.createMemoryComposite(agent);
+			if (contextArtifact != null) {
+				for (URI repositoryuri : contextArtifactRepositories) {
+					contextArtifact.addChild(repositoryuri);
+				}
+
+				if (contextArtifact.getChildren().size() > 0)
+					publisherInfo.setContextArtifactRepository(contextArtifact);
+			}
+		}
+	}
+
+	protected void processCommandLineArguments(String[] args, PublisherInfo publisherInfo) throws Exception {
+		if (args == null)
+			return;
+		for (int i = 0; i < args.length; i++) {
+			// check for args without parameters (i.e., a flag arg)
+			processFlag(args[i], publisherInfo);
+
+			// check for args with parameters. If we are at the last argument or if the next
+			// one
+			// has a '-' as the first character, then we can't have an arg with a parm so
+			// continue.
+			if (i == args.length - 1 || args[i + 1].startsWith("-")) //$NON-NLS-1$
+				continue;
+			processParameter(args[i], args[++i], publisherInfo);
+		}
+	}
+
+	/**
+	 * Process application arguments.
+	 *
+	 * @throws URISyntaxException thrown by subclasses
+	 */
+	protected void processParameter(String arg, String parameter, PublisherInfo publisherInfo)
+			throws URISyntaxException {
+		try {
+			if (arg.equalsIgnoreCase("-metadataRepository") || arg.equalsIgnoreCase("-mr")) //$NON-NLS-1$ //$NON-NLS-2$
+				metadataLocation = URIUtil.fromString(parameter);
+
+			if (arg.equalsIgnoreCase("-artifactRepository") || arg.equalsIgnoreCase("-ar")) //$NON-NLS-1$ //$NON-NLS-2$
+				artifactLocation = URIUtil.fromString(parameter);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException(NLS.bind(Messages.exception_repoMustBeURL, parameter));
+		}
+
+		if (arg.equalsIgnoreCase("-metadataRepositoryName")) //$NON-NLS-1$
+			metadataRepoName = parameter;
+
+		if (arg.equalsIgnoreCase("-source")) { //$NON-NLS-1$
+			// check here to see if the location actually exists so we can fail gracefully
+			// now rather than unpredictably later
+			// see bug 272956 where we would fail with an NPE if someone gave us a URL
+			// instead of a file-system path
+			if (!new File(parameter).exists())
+				throw new IllegalArgumentException(NLS.bind(Messages.exception_sourcePath, parameter));
+			source = parameter;
+		}
+
+		if (arg.equalsIgnoreCase("-artifactRepositoryName")) //$NON-NLS-1$
+			artifactRepoName = parameter;
+
+		if (arg.equalsIgnoreCase("-configs")) //$NON-NLS-1$
+			publisherInfo.setConfigurations(AbstractPublisherAction.getArrayFromString(parameter, ",")); //$NON-NLS-1$
+
+		if (arg.equalsIgnoreCase("-contextMetadata")) //$NON-NLS-1$
+			setContextRepositories(processRepositoryList(parameter), contextArtifactRepositories);
+
+		if (arg.equalsIgnoreCase("-contextArtifacts")) //$NON-NLS-1$
+			setContextRepositories(contextMetadataRepositories, processRepositoryList(parameter));
+	}
+
+	private URI[] processRepositoryList(String parameter) {
+		String[] list = AbstractPublisherAction.getArrayFromString(parameter, ","); //$NON-NLS-1$
+		if (list == null || list.length == 0)
+			return null;
+
+		List<URI> result = new ArrayList<>(list.length);
+		if (result != null) {
+			for (String uri : list) {
+				try {
+					result.add(URIUtil.fromString(uri));
+				} catch (URISyntaxException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+		}
+		return result.toArray(new URI[result.size()]);
+	}
+
+	protected void processFlag(String arg, PublisherInfo publisherInfo) {
+		if (arg.equalsIgnoreCase("-publishArtifacts") || arg.equalsIgnoreCase("-pa")) //$NON-NLS-1$ //$NON-NLS-2$
+			publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_PUBLISH);
+
+		if (arg.equalsIgnoreCase("-publishArtifactRepository") || arg.equalsIgnoreCase("-par")) //$NON-NLS-1$ //$NON-NLS-2$
+			publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_INDEX);
+
+		if (arg.equalsIgnoreCase("-overwriteArtifacts")) //$NON-NLS-1$
+			publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_OVERWRITE);
+
+		if (arg.equalsIgnoreCase("-append")) //$NON-NLS-1$
+			append = true;
+
+		if (arg.equalsIgnoreCase("-compress")) //$NON-NLS-1$
+			compress = true;
+
+		if (arg.equalsIgnoreCase("-inplace")) //$NON-NLS-1$
+			inplace = true;
+	}
+
+	protected void setupAgent() throws ProvisionException {
+		if (agent == null) {
+			agentRef = Activator.getContext().getServiceReference(IProvisioningAgent.class);
+			if (agentRef != null) {
+				agent = Activator.getContext().getService(agentRef);
+				if (agent != null)
+					return;
+			}
+			ServiceReference<IProvisioningAgentProvider> providerRef = Activator.getContext()
+					.getServiceReference(IProvisioningAgentProvider.class);
+			if (providerRef == null)
+				throw new RuntimeException("No provisioning agent provider is available"); //$NON-NLS-1$
+			IProvisioningAgentProvider provider = Activator.getContext().getService(providerRef);
+			if (provider == null)
+				throw new RuntimeException("No provisioning agent provider is available"); //$NON-NLS-1$
+			// obtain agent for currently running system
+			agent = provider.createAgent(null);
+			Activator.getContext().ungetService(providerRef);
+		}
+	}
+
+	public Object run(String args[]) throws Exception {
+		try {
+			info = createPublisherInfo();
+			processCommandLineArguments(args, info);
+			Object result = run(info);
+			if (result != IApplication.EXIT_OK) {
+				System.out.println(NLS.bind(Messages.message_publisherArguments, null));
+				for (String arg : args) {
+					System.out.println(arg);
+				}
+			}
+			return result;
+		} catch (Exception e) {
+			if (e.getMessage() != null)
+				System.err.println(e.getMessage());
+			else
+				e.printStackTrace(System.err);
+			throw e;
+		}
+	}
+
+	protected PublisherInfo createPublisherInfo() {
+		return new PublisherInfo();
+	}
+
+	public Object run(PublisherInfo publisherInfo) throws Exception {
+		try {
+			this.info = publisherInfo;
+			setupAgent();
+			initialize(publisherInfo);
+			System.out.println(NLS.bind(Messages.message_generatingMetadata, publisherInfo.getSummary()));
+
+			long before = System.currentTimeMillis();
+			IPublisherAction[] actions = createActions();
+			Publisher publisher = createPublisher(publisherInfo);
+			IStatus result = publisher.publish(actions, new NullProgressMonitor());
+			long after = System.currentTimeMillis();
+
+			if (!result.isOK()) {
+				// TODO: improve the string representation of the result
+				System.out.println(result);
+				Throwable th = result.getException();
+				if (th != null) {
+					System.out.println();
+					System.out.println(NLS.bind(Messages.message_resultException, null));
+					th.printStackTrace(System.out);
+					System.out.println();
+				}
+			}
+			if (!result.matches(IStatus.ERROR | IStatus.CANCEL)) {
+				System.out.println(
+						NLS.bind(Messages.message_generationCompleted, String.valueOf((after - before) / 1000)));
+				return IApplication.EXIT_OK;
+			}
+		} catch (ProvisionException e) {
+			status = e.getStatus();
+			if (status.getSeverity() == IStatus.ERROR && status.getMessage() != null) {
+				System.out.println(status.getMessage());
+			}
+		}
+		return Integer.valueOf(1);
+	}
+
+	protected abstract IPublisherAction[] createActions();
+
+	protected Publisher createPublisher(PublisherInfo publisherInfo) {
+		return new Publisher(publisherInfo);
+	}
+
+	@Override
+	public Object start(IApplicationContext context) throws Exception {
+		return run((String[]) context.getArguments().get("application.args")); //$NON-NLS-1$
+	}
+
+	@Override
+	public void stop() {
+		if (agentRef != null) {
+			Activator.getContext().ungetService(agentRef);
+			agentRef = null;
+		}
+	}
+
+	public void setArtifactLocation(URI location) {
+		this.artifactLocation = location;
+	}
+
+	public void setMetadataLocation(URI location) {
+		this.metadataLocation = location;
+	}
+
+	public void setCompress(boolean value) {
+		compress = value;
+	}
+
+	public void setContextRepositories(URI[] metadata, URI[] artifacts) {
+		this.contextMetadataRepositories = metadata;
+		this.contextArtifactRepositories = artifacts;
+	}
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/AbstractPublisherApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/AbstractPublisherApplication.java
@@ -12,365 +12,345 @@
  *     IBM Corporation - initial API and implementation
  *     EclipseSource - ongoing development
  *******************************************************************************/
-package org.eclipse.equinox.p2.publisher;
+package org.eclipse.tycho.p2tools.copiedfromp2;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.core.runtime.*;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 import org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository;
 import org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository;
-import org.eclipse.equinox.internal.p2.publisher.Activator;
 import org.eclipse.equinox.internal.p2.publisher.Messages;
-import org.eclipse.equinox.p2.core.*;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
+import org.eclipse.equinox.p2.publisher.AbstractPublisherAction;
+import org.eclipse.equinox.p2.publisher.IPublisherAction;
+import org.eclipse.equinox.p2.publisher.IPublisherInfo;
+import org.eclipse.equinox.p2.publisher.Publisher;
+import org.eclipse.equinox.p2.publisher.PublisherInfo;
 import org.eclipse.equinox.p2.query.IQueryResult;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.artifact.ArtifactKeyQuery;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.osgi.util.NLS;
-import org.osgi.framework.ServiceReference;
 
 public abstract class AbstractPublisherApplication implements IApplication {
 
-	// The mapping rules for in-place generation need to construct paths into the
-	// structure
-	// of an eclipse installation; in the future the default artifact mapping
-	// declared in
-	// SimpleArtifactRepository may change, for example, to not have a 'bundles'
-	// directory
-	// instead of a 'plugins' directory, so a separate constant is defined and used
-	// here.
-	protected static final String[][] INPLACE_MAPPING_RULES = {
-			{ "(& (classifier=osgi.bundle))", "${repoUrl}/plugins/${id}_${version}.jar" }, //$NON-NLS-1$//$NON-NLS-2$
-			{ "(& (classifier=binary))", "${repoUrl}/binary/${id}_${version}" }, //$NON-NLS-1$//$NON-NLS-2$
-			{ "(& (classifier=org.eclipse.update.feature))", "${repoUrl}/features/${id}_${version}.jar" } }; //$NON-NLS-1$//$NON-NLS-2$
+    // The mapping rules for in-place generation need to construct paths into the
+    // structure
+    // of an eclipse installation; in the future the default artifact mapping
+    // declared in
+    // SimpleArtifactRepository may change, for example, to not have a 'bundles'
+    // directory
+    // instead of a 'plugins' directory, so a separate constant is defined and used
+    // here.
+    protected static final String[][] INPLACE_MAPPING_RULES = {
+            { "(& (classifier=osgi.bundle))", "${repoUrl}/plugins/${id}_${version}.jar" }, //$NON-NLS-1$//$NON-NLS-2$
+            { "(& (classifier=binary))", "${repoUrl}/binary/${id}_${version}" }, //$NON-NLS-1$//$NON-NLS-2$
+            { "(& (classifier=org.eclipse.update.feature))", "${repoUrl}/features/${id}_${version}.jar" } }; //$NON-NLS-1$//$NON-NLS-2$
 
-	protected PublisherInfo info;
-	protected String source;
-	protected URI metadataLocation;
-	protected String metadataRepoName;
-	protected URI artifactLocation;
-	protected String artifactRepoName;
-	protected URI[] contextMetadataRepositories;
-	protected URI[] contextArtifactRepositories;
-	// whether repository xml files should be compressed
-	protected boolean compress = false;
-	protected boolean inplace = false;
-	protected boolean append = false;
-	protected String[] configurations;
-	private IStatus status;
+    protected PublisherInfo info;
+    protected String source;
+    protected URI metadataLocation;
+    protected String metadataRepoName;
+    protected URI artifactLocation;
+    protected String artifactRepoName;
+    protected URI[] contextMetadataRepositories;
+    protected URI[] contextArtifactRepositories;
+    // whether repository xml files should be compressed
+    protected boolean compress = false;
+    protected boolean inplace = false;
+    protected boolean append = false;
+    protected String[] configurations;
+    private IStatus status;
 
-	private ServiceReference<IProvisioningAgent> agentRef;
+    protected final IProvisioningAgent agent;
 
-	protected IProvisioningAgent agent;
+    public AbstractPublisherApplication(IProvisioningAgent agent) {
+        this.agent = agent;
+        //TODO is this still required?
+        agent.getService(IArtifactRepositoryManager.class); //force init P2 services
+    }
 
-	public AbstractPublisherApplication() {
-		this(null);
-	}
+    /**
+     * Returns the error message for this application, or the empty string if the application
+     * terminated successfully.
+     */
+    public IStatus getStatus() {
+        return status;
+    }
 
-	public AbstractPublisherApplication(IProvisioningAgent agent) {
-		this.agent = agent;
-	}
+    protected void initialize(PublisherInfo publisherInfo) throws ProvisionException {
+        if (inplace) {
+            File location = new File(source);
+            if (metadataLocation == null)
+                metadataLocation = location.toURI();
+            if (artifactLocation == null)
+                artifactLocation = location.toURI();
+            publisherInfo.setArtifactOptions(
+                    publisherInfo.getArtifactOptions() | IPublisherInfo.A_INDEX | IPublisherInfo.A_PUBLISH);
+        }
+        initializeRepositories(publisherInfo);
+    }
 
-	/**
-	 * Returns the error message for this application, or the empty string if the
-	 * application terminated successfully.
-	 */
-	public IStatus getStatus() {
-		return status;
-	}
+    protected IStatus createConfigurationEror(String message) {
+        return new Status(IStatus.ERROR, "org.eclipse.equinox.p2.publisher", message); //$NON-NLS-1$
+    }
 
-	protected void initialize(PublisherInfo publisherInfo) throws ProvisionException {
-		if (inplace) {
-			File location = new File(source);
-			if (metadataLocation == null)
-				metadataLocation = location.toURI();
-			if (artifactLocation == null)
-				artifactLocation = location.toURI();
-			publisherInfo.setArtifactOptions(
-					publisherInfo.getArtifactOptions() | IPublisherInfo.A_INDEX | IPublisherInfo.A_PUBLISH);
-		}
-		initializeRepositories(publisherInfo);
-	}
+    private boolean isEmpty(IArtifactRepository repo) {
+        IQueryResult<IArtifactKey> result = repo.query(QueryUtil.createLimitQuery(ArtifactKeyQuery.ALL_KEYS, 1), null);
+        return result.isEmpty();
+    }
 
-	protected IStatus createConfigurationEror(String message) {
-		return new Status(IStatus.ERROR, "org.eclipse.equinox.p2.publisher", message); //$NON-NLS-1$
-	}
+    protected void initializeRepositories(PublisherInfo publisherInfo) throws ProvisionException {
+        if (artifactLocation != null) {
+            @SuppressWarnings("removal")
+            IArtifactRepository repo = Publisher.createArtifactRepository(agent, artifactLocation, artifactRepoName,
+                    compress);
+            if (!append && !isEmpty(repo)) {
+                File repoLocation = URIUtil.toFile(artifactLocation);
+                if (repoLocation != null && source != null) {
+                    if (repoLocation.isFile())
+                        repoLocation = repoLocation.getParentFile();
+                    if (repoLocation.equals(new File(source)))
+                        throw new IllegalArgumentException(
+                                NLS.bind(Messages.exception_artifactRepoNoAppendDestroysInput,
+                                        URIUtil.toUnencodedString(artifactLocation)));
+                }
+                repo.removeAll(new NullProgressMonitor());
+            }
+            publisherInfo.setArtifactRepository(repo);
+        } else if ((publisherInfo.getArtifactOptions() & IPublisherInfo.A_PUBLISH) > 0)
+            throw new ProvisionException(createConfigurationEror(Messages.exception_noArtifactRepo));
+        if (metadataLocation == null)
+            throw new ProvisionException(createConfigurationEror(Messages.exception_noMetadataRepo));
+        publisherInfo.setMetadataRepository(
+                Publisher.createMetadataRepository(agent, metadataLocation, metadataRepoName, append, compress));
 
-	private boolean isEmpty(IArtifactRepository repo) {
-		IQueryResult<IArtifactKey> result = repo.query(QueryUtil.createLimitQuery(ArtifactKeyQuery.ALL_KEYS, 1), null);
-		return result.isEmpty();
-	}
+        if (contextMetadataRepositories != null && contextMetadataRepositories.length > 0) {
+            CompositeMetadataRepository contextMetadata = CompositeMetadataRepository.createMemoryComposite(agent);
+            if (contextMetadata != null) {
+                for (URI repositoryuri : contextMetadataRepositories) {
+                    contextMetadata.addChild(repositoryuri);
+                }
+                if (contextMetadata.getChildren().size() > 0)
+                    publisherInfo.setContextMetadataRepository(contextMetadata);
+            }
+        }
+        if (contextArtifactRepositories != null && contextArtifactRepositories.length > 0) {
+            CompositeArtifactRepository contextArtifact = CompositeArtifactRepository.createMemoryComposite(agent);
+            if (contextArtifact != null) {
+                for (URI repositoryuri : contextArtifactRepositories) {
+                    contextArtifact.addChild(repositoryuri);
+                }
 
-	protected void initializeRepositories(PublisherInfo publisherInfo) throws ProvisionException {
-		if (artifactLocation != null) {
-			@SuppressWarnings("removal")
-			IArtifactRepository repo = Publisher.createArtifactRepository(agent, artifactLocation, artifactRepoName,
-					compress);
-			if (!append && !isEmpty(repo)) {
-				File repoLocation = URIUtil.toFile(artifactLocation);
-				if (repoLocation != null && source != null) {
-					if (repoLocation.isFile())
-						repoLocation = repoLocation.getParentFile();
-					if (repoLocation.equals(new File(source)))
-						throw new IllegalArgumentException(
-								NLS.bind(Messages.exception_artifactRepoNoAppendDestroysInput,
-										URIUtil.toUnencodedString(artifactLocation)));
-				}
-				repo.removeAll(new NullProgressMonitor());
-			}
-			publisherInfo.setArtifactRepository(repo);
-		} else if ((publisherInfo.getArtifactOptions() & IPublisherInfo.A_PUBLISH) > 0)
-			throw new ProvisionException(createConfigurationEror(Messages.exception_noArtifactRepo));
-		if (metadataLocation == null)
-			throw new ProvisionException(createConfigurationEror(Messages.exception_noMetadataRepo));
-		publisherInfo.setMetadataRepository(
-				Publisher.createMetadataRepository(agent, metadataLocation, metadataRepoName, append, compress));
+                if (contextArtifact.getChildren().size() > 0)
+                    publisherInfo.setContextArtifactRepository(contextArtifact);
+            }
+        }
+    }
 
-		if (contextMetadataRepositories != null && contextMetadataRepositories.length > 0) {
-			CompositeMetadataRepository contextMetadata = CompositeMetadataRepository.createMemoryComposite(agent);
-			if (contextMetadata != null) {
-				for (URI repositoryuri : contextMetadataRepositories) {
-					contextMetadata.addChild(repositoryuri);
-				}
-				if (contextMetadata.getChildren().size() > 0)
-					publisherInfo.setContextMetadataRepository(contextMetadata);
-			}
-		}
-		if (contextArtifactRepositories != null && contextArtifactRepositories.length > 0) {
-			CompositeArtifactRepository contextArtifact = CompositeArtifactRepository.createMemoryComposite(agent);
-			if (contextArtifact != null) {
-				for (URI repositoryuri : contextArtifactRepositories) {
-					contextArtifact.addChild(repositoryuri);
-				}
+    protected void processCommandLineArguments(String[] args, PublisherInfo publisherInfo) throws Exception {
+        if (args == null)
+            return;
+        for (int i = 0; i < args.length; i++) {
+            // check for args without parameters (i.e., a flag arg)
+            processFlag(args[i], publisherInfo);
 
-				if (contextArtifact.getChildren().size() > 0)
-					publisherInfo.setContextArtifactRepository(contextArtifact);
-			}
-		}
-	}
+            // check for args with parameters. If we are at the last argument or if the next
+            // one
+            // has a '-' as the first character, then we can't have an arg with a parm so
+            // continue.
+            if (i == args.length - 1 || args[i + 1].startsWith("-")) //$NON-NLS-1$
+                continue;
+            processParameter(args[i], args[++i], publisherInfo);
+        }
+    }
 
-	protected void processCommandLineArguments(String[] args, PublisherInfo publisherInfo) throws Exception {
-		if (args == null)
-			return;
-		for (int i = 0; i < args.length; i++) {
-			// check for args without parameters (i.e., a flag arg)
-			processFlag(args[i], publisherInfo);
+    /**
+     * Process application arguments.
+     *
+     * @throws URISyntaxException
+     *             thrown by subclasses
+     */
+    protected void processParameter(String arg, String parameter, PublisherInfo publisherInfo)
+            throws URISyntaxException {
+        try {
+            if (arg.equalsIgnoreCase("-metadataRepository") || arg.equalsIgnoreCase("-mr")) //$NON-NLS-1$ //$NON-NLS-2$
+                metadataLocation = URIUtil.fromString(parameter);
 
-			// check for args with parameters. If we are at the last argument or if the next
-			// one
-			// has a '-' as the first character, then we can't have an arg with a parm so
-			// continue.
-			if (i == args.length - 1 || args[i + 1].startsWith("-")) //$NON-NLS-1$
-				continue;
-			processParameter(args[i], args[++i], publisherInfo);
-		}
-	}
+            if (arg.equalsIgnoreCase("-artifactRepository") || arg.equalsIgnoreCase("-ar")) //$NON-NLS-1$ //$NON-NLS-2$
+                artifactLocation = URIUtil.fromString(parameter);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(NLS.bind(Messages.exception_repoMustBeURL, parameter));
+        }
 
-	/**
-	 * Process application arguments.
-	 *
-	 * @throws URISyntaxException thrown by subclasses
-	 */
-	protected void processParameter(String arg, String parameter, PublisherInfo publisherInfo)
-			throws URISyntaxException {
-		try {
-			if (arg.equalsIgnoreCase("-metadataRepository") || arg.equalsIgnoreCase("-mr")) //$NON-NLS-1$ //$NON-NLS-2$
-				metadataLocation = URIUtil.fromString(parameter);
+        if (arg.equalsIgnoreCase("-metadataRepositoryName")) //$NON-NLS-1$
+            metadataRepoName = parameter;
 
-			if (arg.equalsIgnoreCase("-artifactRepository") || arg.equalsIgnoreCase("-ar")) //$NON-NLS-1$ //$NON-NLS-2$
-				artifactLocation = URIUtil.fromString(parameter);
-		} catch (URISyntaxException e) {
-			throw new IllegalArgumentException(NLS.bind(Messages.exception_repoMustBeURL, parameter));
-		}
+        if (arg.equalsIgnoreCase("-source")) { //$NON-NLS-1$
+            // check here to see if the location actually exists so we can fail gracefully
+            // now rather than unpredictably later
+            // see bug 272956 where we would fail with an NPE if someone gave us a URL
+            // instead of a file-system path
+            if (!new File(parameter).exists())
+                throw new IllegalArgumentException(NLS.bind(Messages.exception_sourcePath, parameter));
+            source = parameter;
+        }
 
-		if (arg.equalsIgnoreCase("-metadataRepositoryName")) //$NON-NLS-1$
-			metadataRepoName = parameter;
+        if (arg.equalsIgnoreCase("-artifactRepositoryName")) //$NON-NLS-1$
+            artifactRepoName = parameter;
 
-		if (arg.equalsIgnoreCase("-source")) { //$NON-NLS-1$
-			// check here to see if the location actually exists so we can fail gracefully
-			// now rather than unpredictably later
-			// see bug 272956 where we would fail with an NPE if someone gave us a URL
-			// instead of a file-system path
-			if (!new File(parameter).exists())
-				throw new IllegalArgumentException(NLS.bind(Messages.exception_sourcePath, parameter));
-			source = parameter;
-		}
+        if (arg.equalsIgnoreCase("-configs")) //$NON-NLS-1$
+            publisherInfo.setConfigurations(AbstractPublisherAction.getArrayFromString(parameter, ",")); //$NON-NLS-1$
 
-		if (arg.equalsIgnoreCase("-artifactRepositoryName")) //$NON-NLS-1$
-			artifactRepoName = parameter;
+        if (arg.equalsIgnoreCase("-contextMetadata")) //$NON-NLS-1$
+            setContextRepositories(processRepositoryList(parameter), contextArtifactRepositories);
 
-		if (arg.equalsIgnoreCase("-configs")) //$NON-NLS-1$
-			publisherInfo.setConfigurations(AbstractPublisherAction.getArrayFromString(parameter, ",")); //$NON-NLS-1$
+        if (arg.equalsIgnoreCase("-contextArtifacts")) //$NON-NLS-1$
+            setContextRepositories(contextMetadataRepositories, processRepositoryList(parameter));
+    }
 
-		if (arg.equalsIgnoreCase("-contextMetadata")) //$NON-NLS-1$
-			setContextRepositories(processRepositoryList(parameter), contextArtifactRepositories);
+    private URI[] processRepositoryList(String parameter) {
+        String[] list = AbstractPublisherAction.getArrayFromString(parameter, ","); //$NON-NLS-1$
+        if (list == null || list.length == 0)
+            return null;
 
-		if (arg.equalsIgnoreCase("-contextArtifacts")) //$NON-NLS-1$
-			setContextRepositories(contextMetadataRepositories, processRepositoryList(parameter));
-	}
+        List<URI> result = new ArrayList<>(list.length);
+        if (result != null) {
+            for (String uri : list) {
+                try {
+                    result.add(URIUtil.fromString(uri));
+                } catch (URISyntaxException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            }
+        }
+        return result.toArray(new URI[result.size()]);
+    }
 
-	private URI[] processRepositoryList(String parameter) {
-		String[] list = AbstractPublisherAction.getArrayFromString(parameter, ","); //$NON-NLS-1$
-		if (list == null || list.length == 0)
-			return null;
+    protected void processFlag(String arg, PublisherInfo publisherInfo) {
+        if (arg.equalsIgnoreCase("-publishArtifacts") || arg.equalsIgnoreCase("-pa")) //$NON-NLS-1$ //$NON-NLS-2$
+            publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_PUBLISH);
 
-		List<URI> result = new ArrayList<>(list.length);
-		if (result != null) {
-			for (String uri : list) {
-				try {
-					result.add(URIUtil.fromString(uri));
-				} catch (URISyntaxException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
-			}
-		}
-		return result.toArray(new URI[result.size()]);
-	}
+        if (arg.equalsIgnoreCase("-publishArtifactRepository") || arg.equalsIgnoreCase("-par")) //$NON-NLS-1$ //$NON-NLS-2$
+            publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_INDEX);
 
-	protected void processFlag(String arg, PublisherInfo publisherInfo) {
-		if (arg.equalsIgnoreCase("-publishArtifacts") || arg.equalsIgnoreCase("-pa")) //$NON-NLS-1$ //$NON-NLS-2$
-			publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_PUBLISH);
+        if (arg.equalsIgnoreCase("-overwriteArtifacts")) //$NON-NLS-1$
+            publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_OVERWRITE);
 
-		if (arg.equalsIgnoreCase("-publishArtifactRepository") || arg.equalsIgnoreCase("-par")) //$NON-NLS-1$ //$NON-NLS-2$
-			publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_INDEX);
+        if (arg.equalsIgnoreCase("-append")) //$NON-NLS-1$
+            append = true;
 
-		if (arg.equalsIgnoreCase("-overwriteArtifacts")) //$NON-NLS-1$
-			publisherInfo.setArtifactOptions(publisherInfo.getArtifactOptions() | IPublisherInfo.A_OVERWRITE);
+        if (arg.equalsIgnoreCase("-compress")) //$NON-NLS-1$
+            compress = true;
 
-		if (arg.equalsIgnoreCase("-append")) //$NON-NLS-1$
-			append = true;
+        if (arg.equalsIgnoreCase("-inplace")) //$NON-NLS-1$
+            inplace = true;
+    }
 
-		if (arg.equalsIgnoreCase("-compress")) //$NON-NLS-1$
-			compress = true;
+    public Object run(String args[]) throws Exception {
+        try {
+            info = createPublisherInfo();
+            processCommandLineArguments(args, info);
+            Object result = run(info);
+            if (result != IApplication.EXIT_OK) {
+                System.out.println(NLS.bind(Messages.message_publisherArguments, null));
+                for (String arg : args) {
+                    System.out.println(arg);
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            if (e.getMessage() != null)
+                System.err.println(e.getMessage());
+            else
+                e.printStackTrace(System.err);
+            throw e;
+        }
+    }
 
-		if (arg.equalsIgnoreCase("-inplace")) //$NON-NLS-1$
-			inplace = true;
-	}
+    protected PublisherInfo createPublisherInfo() {
+        return new PublisherInfo();
+    }
 
-	protected void setupAgent() throws ProvisionException {
-		if (agent == null) {
-			agentRef = Activator.getContext().getServiceReference(IProvisioningAgent.class);
-			if (agentRef != null) {
-				agent = Activator.getContext().getService(agentRef);
-				if (agent != null)
-					return;
-			}
-			ServiceReference<IProvisioningAgentProvider> providerRef = Activator.getContext()
-					.getServiceReference(IProvisioningAgentProvider.class);
-			if (providerRef == null)
-				throw new RuntimeException("No provisioning agent provider is available"); //$NON-NLS-1$
-			IProvisioningAgentProvider provider = Activator.getContext().getService(providerRef);
-			if (provider == null)
-				throw new RuntimeException("No provisioning agent provider is available"); //$NON-NLS-1$
-			// obtain agent for currently running system
-			agent = provider.createAgent(null);
-			Activator.getContext().ungetService(providerRef);
-		}
-	}
+    public Object run(PublisherInfo publisherInfo) throws Exception {
+        try {
+            this.info = publisherInfo;
+            initialize(publisherInfo);
+            System.out.println(NLS.bind(Messages.message_generatingMetadata, publisherInfo.getSummary()));
 
-	public Object run(String args[]) throws Exception {
-		try {
-			info = createPublisherInfo();
-			processCommandLineArguments(args, info);
-			Object result = run(info);
-			if (result != IApplication.EXIT_OK) {
-				System.out.println(NLS.bind(Messages.message_publisherArguments, null));
-				for (String arg : args) {
-					System.out.println(arg);
-				}
-			}
-			return result;
-		} catch (Exception e) {
-			if (e.getMessage() != null)
-				System.err.println(e.getMessage());
-			else
-				e.printStackTrace(System.err);
-			throw e;
-		}
-	}
+            long before = System.currentTimeMillis();
+            IPublisherAction[] actions = createActions();
+            Publisher publisher = createPublisher(publisherInfo);
+            IStatus result = publisher.publish(actions, new NullProgressMonitor());
+            long after = System.currentTimeMillis();
 
-	protected PublisherInfo createPublisherInfo() {
-		return new PublisherInfo();
-	}
+            if (!result.isOK()) {
+                // TODO: improve the string representation of the result
+                System.out.println(result);
+                Throwable th = result.getException();
+                if (th != null) {
+                    System.out.println();
+                    System.out.println(NLS.bind(Messages.message_resultException, null));
+                    th.printStackTrace(System.out);
+                    System.out.println();
+                }
+            }
+            if (!result.matches(IStatus.ERROR | IStatus.CANCEL)) {
+                System.out.println(
+                        NLS.bind(Messages.message_generationCompleted, String.valueOf((after - before) / 1000)));
+                return IApplication.EXIT_OK;
+            }
+        } catch (ProvisionException e) {
+            status = e.getStatus();
+            if (status.getSeverity() == IStatus.ERROR && status.getMessage() != null) {
+                System.out.println(status.getMessage());
+            }
+        }
+        return Integer.valueOf(1);
+    }
 
-	public Object run(PublisherInfo publisherInfo) throws Exception {
-		try {
-			this.info = publisherInfo;
-			setupAgent();
-			initialize(publisherInfo);
-			System.out.println(NLS.bind(Messages.message_generatingMetadata, publisherInfo.getSummary()));
+    protected abstract IPublisherAction[] createActions();
 
-			long before = System.currentTimeMillis();
-			IPublisherAction[] actions = createActions();
-			Publisher publisher = createPublisher(publisherInfo);
-			IStatus result = publisher.publish(actions, new NullProgressMonitor());
-			long after = System.currentTimeMillis();
+    protected Publisher createPublisher(PublisherInfo publisherInfo) {
+        return new Publisher(publisherInfo);
+    }
 
-			if (!result.isOK()) {
-				// TODO: improve the string representation of the result
-				System.out.println(result);
-				Throwable th = result.getException();
-				if (th != null) {
-					System.out.println();
-					System.out.println(NLS.bind(Messages.message_resultException, null));
-					th.printStackTrace(System.out);
-					System.out.println();
-				}
-			}
-			if (!result.matches(IStatus.ERROR | IStatus.CANCEL)) {
-				System.out.println(
-						NLS.bind(Messages.message_generationCompleted, String.valueOf((after - before) / 1000)));
-				return IApplication.EXIT_OK;
-			}
-		} catch (ProvisionException e) {
-			status = e.getStatus();
-			if (status.getSeverity() == IStatus.ERROR && status.getMessage() != null) {
-				System.out.println(status.getMessage());
-			}
-		}
-		return Integer.valueOf(1);
-	}
+    @Override
+    public Object start(IApplicationContext context) throws Exception {
+        return run((String[]) context.getArguments().get("application.args")); //$NON-NLS-1$
+    }
 
-	protected abstract IPublisherAction[] createActions();
+    @Override
+    public void stop() {
+    }
 
-	protected Publisher createPublisher(PublisherInfo publisherInfo) {
-		return new Publisher(publisherInfo);
-	}
+    public void setArtifactLocation(URI location) {
+        this.artifactLocation = location;
+    }
 
-	@Override
-	public Object start(IApplicationContext context) throws Exception {
-		return run((String[]) context.getArguments().get("application.args")); //$NON-NLS-1$
-	}
+    public void setMetadataLocation(URI location) {
+        this.metadataLocation = location;
+    }
 
-	@Override
-	public void stop() {
-		if (agentRef != null) {
-			Activator.getContext().ungetService(agentRef);
-			agentRef = null;
-		}
-	}
+    public void setCompress(boolean value) {
+        compress = value;
+    }
 
-	public void setArtifactLocation(URI location) {
-		this.artifactLocation = location;
-	}
-
-	public void setMetadataLocation(URI location) {
-		this.metadataLocation = location;
-	}
-
-	public void setCompress(boolean value) {
-		compress = value;
-	}
-
-	public void setContextRepositories(URI[] metadata, URI[] artifacts) {
-		this.contextMetadataRepositories = metadata;
-		this.contextArtifactRepositories = artifacts;
-	}
+    public void setContextRepositories(URI[] metadata, URI[] artifacts) {
+        this.contextMetadataRepositories = metadata;
+        this.contextArtifactRepositories = artifacts;
+    }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/CategoryPublisherApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/CategoryPublisherApplication.java
@@ -12,82 +12,81 @@
  * Contributors: 
  *   EclipseSource - initial API and implementation
  ******************************************************************************/
-package org.eclipse.equinox.internal.p2.updatesite;
+package org.eclipse.tycho.p2tools.copiedfromp2;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+
 import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.equinox.internal.p2.updatesite.CategoryXMLAction;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
-import org.eclipse.equinox.p2.publisher.*;
+import org.eclipse.equinox.p2.publisher.IPublisherAction;
+import org.eclipse.equinox.p2.publisher.Publisher;
+import org.eclipse.equinox.p2.publisher.PublisherInfo;
 import org.eclipse.equinox.p2.repository.IRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 
 /**
  * <p>
- * This application categorizes the elements in a repo based on a category
- * definition file. The category definition file is specified with
- * <source>-categoryDefinition</source>
+ * This application categorizes the elements in a repo based on a category definition file. The
+ * category definition file is specified with <source>-categoryDefinition</source>
  * </p>
  */
 public class CategoryPublisherApplication extends AbstractPublisherApplication {
 
-	private String categoryQualifier = null;
-	private URI categoryDefinition = null;
+    private String categoryQualifier = null;
+    private URI categoryDefinition = null;
 
-	public CategoryPublisherApplication() {
-		super();
-	}
+    public CategoryPublisherApplication(IProvisioningAgent agent) {
+        super(agent);
+    }
 
-	public CategoryPublisherApplication(IProvisioningAgent agent) {
-		super(agent);
-	}
+    /*
+     * Check to see if an existing repository already has the "compressed" flag set
+     */
+    @Override
+    protected void initializeRepositories(PublisherInfo publisherInfo) throws ProvisionException {
+        try {
+            if (metadataLocation != null) {
+                // Try to load the metadata repository. If it loads, check the "compressed"
+                // flag, and cache it.
+                // If there are any errors loading it (i.e. it doesn't exist), just skip this
+                // step
+                // If there are serious problems with the repository, the superclass
+                // initializeRepositories method
+                // will handle it.
+                IMetadataRepository result = Publisher.loadMetadataRepository(agent, metadataLocation, true, true);
+                if (result != null) {
+                    Object property = result.getProperties().get(IRepository.PROP_COMPRESSED);
+                    if (property != null) {
+                        boolean compressProperty = Boolean.valueOf((String) property);
+                        this.compress = compressProperty || compress;
+                    }
+                }
+            }
+        } catch (ProvisionException e) {
+            // do nothing
+        }
+        super.initializeRepositories(publisherInfo);
+    }
 
-	/*
-	 * Check to see if an existing repository already has the "compressed" flag set
-	 */
-	@Override
-	protected void initializeRepositories(PublisherInfo publisherInfo) throws ProvisionException {
-		try {
-			if (metadataLocation != null) {
-				// Try to load the metadata repository. If it loads, check the "compressed"
-				// flag, and cache it.
-				// If there are any errors loading it (i.e. it doesn't exist), just skip this
-				// step
-				// If there are serious problems with the repository, the superclass
-				// initializeRepositories method
-				// will handle it.
-				IMetadataRepository result = Publisher.loadMetadataRepository(agent, metadataLocation, true, true);
-				if (result != null) {
-					Object property = result.getProperties().get(IRepository.PROP_COMPRESSED);
-					if (property != null) {
-						boolean compressProperty = Boolean.valueOf((String) property);
-						this.compress = compressProperty || compress;
-					}
-				}
-			}
-		} catch (ProvisionException e) {
-			// do nothing
-		}
-		super.initializeRepositories(publisherInfo);
-	}
+    @Override
+    protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
+        super.processParameter(arg, parameter, pinfo);
 
-	@Override
-	protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
-		super.processParameter(arg, parameter, pinfo);
+        this.append = true; // Always append, otherwise we will end up with nothing
 
-		this.append = true; // Always append, otherwise we will end up with nothing
+        if (arg.equalsIgnoreCase("-categoryQualifier")) //$NON-NLS-1$
+            categoryQualifier = parameter;
 
-		if (arg.equalsIgnoreCase("-categoryQualifier")) //$NON-NLS-1$
-			categoryQualifier = parameter;
+        if (arg.equalsIgnoreCase("-categoryDefinition")) //$NON-NLS-1$
+            categoryDefinition = URIUtil.fromString(parameter);
 
-		if (arg.equalsIgnoreCase("-categoryDefinition")) //$NON-NLS-1$
-			categoryDefinition = URIUtil.fromString(parameter);
+    }
 
-	}
-
-	@Override
-	protected IPublisherAction[] createActions() {
-		return new IPublisherAction[] { new CategoryXMLAction(categoryDefinition, categoryQualifier) };
-	}
+    @Override
+    protected IPublisherAction[] createActions() {
+        return new IPublisherAction[] { new CategoryXMLAction(categoryDefinition, categoryQualifier) };
+    }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/CategoryPublisherApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/CategoryPublisherApplication.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 EclipseSource and others.
+ *
+ * This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License 2.0 which accompanies this distribution, and is
+ * available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors: 
+ *   EclipseSource - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.updatesite;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.publisher.*;
+import org.eclipse.equinox.p2.repository.IRepository;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+
+/**
+ * <p>
+ * This application categorizes the elements in a repo based on a category
+ * definition file. The category definition file is specified with
+ * <source>-categoryDefinition</source>
+ * </p>
+ */
+public class CategoryPublisherApplication extends AbstractPublisherApplication {
+
+	private String categoryQualifier = null;
+	private URI categoryDefinition = null;
+
+	public CategoryPublisherApplication() {
+		super();
+	}
+
+	public CategoryPublisherApplication(IProvisioningAgent agent) {
+		super(agent);
+	}
+
+	/*
+	 * Check to see if an existing repository already has the "compressed" flag set
+	 */
+	@Override
+	protected void initializeRepositories(PublisherInfo publisherInfo) throws ProvisionException {
+		try {
+			if (metadataLocation != null) {
+				// Try to load the metadata repository. If it loads, check the "compressed"
+				// flag, and cache it.
+				// If there are any errors loading it (i.e. it doesn't exist), just skip this
+				// step
+				// If there are serious problems with the repository, the superclass
+				// initializeRepositories method
+				// will handle it.
+				IMetadataRepository result = Publisher.loadMetadataRepository(agent, metadataLocation, true, true);
+				if (result != null) {
+					Object property = result.getProperties().get(IRepository.PROP_COMPRESSED);
+					if (property != null) {
+						boolean compressProperty = Boolean.valueOf((String) property);
+						this.compress = compressProperty || compress;
+					}
+				}
+			}
+		} catch (ProvisionException e) {
+			// do nothing
+		}
+		super.initializeRepositories(publisherInfo);
+	}
+
+	@Override
+	protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
+		super.processParameter(arg, parameter, pinfo);
+
+		this.append = true; // Always append, otherwise we will end up with nothing
+
+		if (arg.equalsIgnoreCase("-categoryQualifier")) //$NON-NLS-1$
+			categoryQualifier = parameter;
+
+		if (arg.equalsIgnoreCase("-categoryDefinition")) //$NON-NLS-1$
+			categoryDefinition = URIUtil.fromString(parameter);
+
+	}
+
+	@Override
+	protected IPublisherAction[] createActions() {
+		return new IPublisherAction[] { new CategoryXMLAction(categoryDefinition, categoryQualifier) };
+	}
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/FeaturesAndBundlesPublisherApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/FeaturesAndBundlesPublisherApplication.java
@@ -12,86 +12,86 @@
  * Contributors: 
  *   Code 9 - initial API and implementation
  ******************************************************************************/
-package org.eclipse.equinox.p2.publisher.eclipse;
+package org.eclipse.tycho.p2tools.copiedfromp2;
 
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.Version;
-import org.eclipse.equinox.p2.publisher.*;
+import org.eclipse.equinox.p2.publisher.AbstractPublisherAction;
+import org.eclipse.equinox.p2.publisher.IPublisherAction;
+import org.eclipse.equinox.p2.publisher.PublisherInfo;
 import org.eclipse.equinox.p2.publisher.actions.RootIUAction;
 import org.eclipse.equinox.p2.publisher.actions.RootIUResultFilterAdvice;
+import org.eclipse.equinox.p2.publisher.eclipse.FeaturesAction;
+import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 
 /**
  * <p>
- * This application generates meta-data and artifact repositories from a set of
- * features and bundles. If {@code -source <localdir>} parameter is given, it
- * specifies the directory under which to find the features and bundles (in the
- * standard "features" and "plugins" sub-directories).
+ * This application generates meta-data and artifact repositories from a set of features and
+ * bundles. If {@code -source <localdir>} parameter is given, it specifies the directory under which
+ * to find the features and bundles (in the standard "features" and "plugins" sub-directories).
  * </p>
  * <p>
- * Optionally, the {@code -features <csv of file locations>} and
- * {@code -bundles <csv} of file locations> arguments can be specified. If
- * given, these override the defaults derived from a supplied -source parameter.
+ * Optionally, the {@code -features <csv of file locations>} and {@code -bundles <csv} of file
+ * locations> arguments can be specified. If given, these override the defaults derived from a
+ * supplied -source parameter.
  * </p>
  */
 public class FeaturesAndBundlesPublisherApplication extends AbstractPublisherApplication {
 
-	protected File[] features = null;
-	protected File[] bundles = null;
+    protected File[] features = null;
+    protected File[] bundles = null;
 
-	protected String rootIU = null;
-	protected String rootVersion = null;
+    protected String rootIU = null;
+    protected String rootVersion = null;
 
-	public FeaturesAndBundlesPublisherApplication() {
-		super();
-	}
+    public FeaturesAndBundlesPublisherApplication(IProvisioningAgent agent) {
+        super(agent);
+    }
 
-	public FeaturesAndBundlesPublisherApplication(IProvisioningAgent agent) {
-		super(agent);
-	}
+    @Override
+    protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
+        super.processParameter(arg, parameter, pinfo);
 
-	@Override
-	protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
-		super.processParameter(arg, parameter, pinfo);
+        if (arg.equalsIgnoreCase("-features")) //$NON-NLS-1$
+            features = createFiles(parameter);
 
-		if (arg.equalsIgnoreCase("-features")) //$NON-NLS-1$
-			features = createFiles(parameter);
+        if (arg.equalsIgnoreCase("-bundles")) //$NON-NLS-1$
+            bundles = createFiles(parameter);
 
-		if (arg.equalsIgnoreCase("-bundles")) //$NON-NLS-1$
-			bundles = createFiles(parameter);
+        if (arg.equalsIgnoreCase("-iu")) //$NON-NLS-1$
+            rootIU = parameter;
 
-		if (arg.equalsIgnoreCase("-iu")) //$NON-NLS-1$
-			rootIU = parameter;
+        if (arg.equalsIgnoreCase("-version")) //$NON-NLS-1$
+            rootVersion = parameter;
+    }
 
-		if (arg.equalsIgnoreCase("-version")) //$NON-NLS-1$
-			rootVersion = parameter;
-	}
+    private File[] createFiles(String parameter) {
+        String[] filespecs = AbstractPublisherAction.getArrayFromString(parameter, ","); //$NON-NLS-1$
+        File[] result = new File[filespecs.length];
+        for (int i = 0; i < filespecs.length; i++)
+            result[i] = new File(filespecs[i]);
+        return result;
+    }
 
-	private File[] createFiles(String parameter) {
-		String[] filespecs = AbstractPublisherAction.getArrayFromString(parameter, ","); //$NON-NLS-1$
-		File[] result = new File[filespecs.length];
-		for (int i = 0; i < filespecs.length; i++)
-			result[i] = new File(filespecs[i]);
-		return result;
-	}
+    @Override
+    protected IPublisherAction[] createActions() {
+        ArrayList<IPublisherAction> result = new ArrayList<>();
+        if (features == null)
+            features = new File[] { new File(source, "features") }; //$NON-NLS-1$
+        result.add(new FeaturesAction(features));
+        if (bundles == null)
+            bundles = new File[] { new File(source, "plugins") }; //$NON-NLS-1$
+        result.add(new BundlesAction(bundles));
 
-	@Override
-	protected IPublisherAction[] createActions() {
-		ArrayList<IPublisherAction> result = new ArrayList<>();
-		if (features == null)
-			features = new File[] {new File(source, "features")}; //$NON-NLS-1$
-		result.add(new FeaturesAction(features));
-		if (bundles == null)
-			bundles = new File[] {new File(source, "plugins")}; //$NON-NLS-1$
-		result.add(new BundlesAction(bundles));
+        if (rootIU != null) {
+            result.add(new RootIUAction(rootIU, Version.parseVersion(rootVersion), rootIU));
+            info.addAdvice(new RootIUResultFilterAdvice(null));
+        }
 
-		if (rootIU != null) {
-			result.add(new RootIUAction(rootIU, Version.parseVersion(rootVersion), rootIU));
-			info.addAdvice(new RootIUResultFilterAdvice(null));
-		}
-
-		return result.toArray(new IPublisherAction[result.size()]);
-	}
+        return result.toArray(new IPublisherAction[result.size()]);
+    }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/FeaturesAndBundlesPublisherApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/FeaturesAndBundlesPublisherApplication.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2017 Code 9 and others.
+ *
+ * This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License 2.0 which accompanies this distribution, and is
+ * available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors: 
+ *   Code 9 - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.equinox.p2.publisher.eclipse;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.publisher.*;
+import org.eclipse.equinox.p2.publisher.actions.RootIUAction;
+import org.eclipse.equinox.p2.publisher.actions.RootIUResultFilterAdvice;
+
+/**
+ * <p>
+ * This application generates meta-data and artifact repositories from a set of
+ * features and bundles. If {@code -source <localdir>} parameter is given, it
+ * specifies the directory under which to find the features and bundles (in the
+ * standard "features" and "plugins" sub-directories).
+ * </p>
+ * <p>
+ * Optionally, the {@code -features <csv of file locations>} and
+ * {@code -bundles <csv} of file locations> arguments can be specified. If
+ * given, these override the defaults derived from a supplied -source parameter.
+ * </p>
+ */
+public class FeaturesAndBundlesPublisherApplication extends AbstractPublisherApplication {
+
+	protected File[] features = null;
+	protected File[] bundles = null;
+
+	protected String rootIU = null;
+	protected String rootVersion = null;
+
+	public FeaturesAndBundlesPublisherApplication() {
+		super();
+	}
+
+	public FeaturesAndBundlesPublisherApplication(IProvisioningAgent agent) {
+		super(agent);
+	}
+
+	@Override
+	protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
+		super.processParameter(arg, parameter, pinfo);
+
+		if (arg.equalsIgnoreCase("-features")) //$NON-NLS-1$
+			features = createFiles(parameter);
+
+		if (arg.equalsIgnoreCase("-bundles")) //$NON-NLS-1$
+			bundles = createFiles(parameter);
+
+		if (arg.equalsIgnoreCase("-iu")) //$NON-NLS-1$
+			rootIU = parameter;
+
+		if (arg.equalsIgnoreCase("-version")) //$NON-NLS-1$
+			rootVersion = parameter;
+	}
+
+	private File[] createFiles(String parameter) {
+		String[] filespecs = AbstractPublisherAction.getArrayFromString(parameter, ","); //$NON-NLS-1$
+		File[] result = new File[filespecs.length];
+		for (int i = 0; i < filespecs.length; i++)
+			result[i] = new File(filespecs[i]);
+		return result;
+	}
+
+	@Override
+	protected IPublisherAction[] createActions() {
+		ArrayList<IPublisherAction> result = new ArrayList<>();
+		if (features == null)
+			features = new File[] {new File(source, "features")}; //$NON-NLS-1$
+		result.add(new FeaturesAction(features));
+		if (bundles == null)
+			bundles = new File[] {new File(source, "plugins")}; //$NON-NLS-1$
+		result.add(new BundlesAction(bundles));
+
+		if (rootIU != null) {
+			result.add(new RootIUAction(rootIU, Version.parseVersion(rootVersion), rootIU));
+			info.addAdvice(new RootIUResultFilterAdvice(null));
+		}
+
+		return result.toArray(new IPublisherAction[result.size()]);
+	}
+}

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/UpdateSitePublisherApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/UpdateSitePublisherApplication.java
@@ -12,66 +12,64 @@
  * Contributors: 
  *   Code 9 - initial API and implementation
  ******************************************************************************/
-package org.eclipse.equinox.internal.p2.updatesite;
+package org.eclipse.tycho.p2tools.copiedfromp2;
 
 import java.net.URISyntaxException;
+
+import org.eclipse.equinox.internal.p2.updatesite.LocalUpdateSiteAction;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
-import org.eclipse.equinox.p2.publisher.*;
+import org.eclipse.equinox.p2.publisher.IPublisherAction;
+import org.eclipse.equinox.p2.publisher.PublisherInfo;
 import org.eclipse.equinox.p2.publisher.actions.JREAction;
 
 /**
  * <p>
- * This application generates meta-data/artifact repositories from a local
- * update site. The -source <localdir> parameter must specify the top-level
- * directory containing the update site.
+ * This application generates meta-data/artifact repositories from a local update site. The -source
+ * <localdir> parameter must specify the top-level directory containing the update site.
  * </p>
  */
 public class UpdateSitePublisherApplication extends AbstractPublisherApplication {
 
-	private String categoryQualifier = null;
-	private String categoryVersion = null;
+    private String categoryQualifier = null;
+    private String categoryVersion = null;
 
-	public UpdateSitePublisherApplication() {
-		super();
-	}
+    public UpdateSitePublisherApplication(IProvisioningAgent agent) {
+        super(agent);
+    }
 
-	public UpdateSitePublisherApplication(IProvisioningAgent agent) {
-		super(agent);
-	}
+    @Override
+    protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
+        super.processParameter(arg, parameter, pinfo);
 
-	@Override
-	protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
-		super.processParameter(arg, parameter, pinfo);
+        if (arg.equalsIgnoreCase("-categoryQualifier")) //$NON-NLS-1$
+            categoryQualifier = parameter;
 
-		if (arg.equalsIgnoreCase("-categoryQualifier")) //$NON-NLS-1$
-			categoryQualifier = parameter;
+        if (arg.equalsIgnoreCase("-categoryVersion")) //$NON-NLS-1$
+            categoryVersion = parameter;
+    }
 
-		if (arg.equalsIgnoreCase("-categoryVersion")) //$NON-NLS-1$
-			categoryVersion = parameter;
-	}
+    @Override
+    protected IPublisherAction[] createActions() {
+        LocalUpdateSiteAction action = new LocalUpdateSiteAction(source, categoryQualifier);
+        action.setCategoryVersion(categoryVersion);
+        if (addJRE) {
+            return new IPublisherAction[] { action, new JREAction((String) null) };
+        }
+        return new IPublisherAction[] { action };
+    }
 
-	@Override
-	protected IPublisherAction[] createActions() {
-		LocalUpdateSiteAction action = new LocalUpdateSiteAction(source, categoryQualifier);
-		action.setCategoryVersion(categoryVersion);
-		if (addJRE) {
-			return new IPublisherAction[] { action, new JREAction((String) null) };
-		}
-		return new IPublisherAction[] { action };
-	}
+    /** by default don't generate the JRE IU */
+    private boolean addJRE = false;
 
-	/** by default don't generate the JRE IU */
-	private boolean addJRE = false;
-
-	/**
-	 * Detect the flag -addJREIU to turn on the generation of the JREIU.
-	 */
-	@Override
-	protected void processFlag(String flag, PublisherInfo publisherInfo) {
-		super.processFlag(flag, publisherInfo);
-		if (flag.equalsIgnoreCase("-addJREIU"))//$NON-NLS-1$
-		{
-			addJRE = true;
-		}
-	}
+    /**
+     * Detect the flag -addJREIU to turn on the generation of the JREIU.
+     */
+    @Override
+    protected void processFlag(String flag, PublisherInfo publisherInfo) {
+        super.processFlag(flag, publisherInfo);
+        if (flag.equalsIgnoreCase("-addJREIU"))//$NON-NLS-1$
+        {
+            addJRE = true;
+        }
+    }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/UpdateSitePublisherApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/UpdateSitePublisherApplication.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2017 Code 9 and others.
+ *
+ * This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License 2.0 which accompanies this distribution, and is
+ * available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors: 
+ *   Code 9 - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.updatesite;
+
+import java.net.URISyntaxException;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.publisher.*;
+import org.eclipse.equinox.p2.publisher.actions.JREAction;
+
+/**
+ * <p>
+ * This application generates meta-data/artifact repositories from a local
+ * update site. The -source <localdir> parameter must specify the top-level
+ * directory containing the update site.
+ * </p>
+ */
+public class UpdateSitePublisherApplication extends AbstractPublisherApplication {
+
+	private String categoryQualifier = null;
+	private String categoryVersion = null;
+
+	public UpdateSitePublisherApplication() {
+		super();
+	}
+
+	public UpdateSitePublisherApplication(IProvisioningAgent agent) {
+		super(agent);
+	}
+
+	@Override
+	protected void processParameter(String arg, String parameter, PublisherInfo pinfo) throws URISyntaxException {
+		super.processParameter(arg, parameter, pinfo);
+
+		if (arg.equalsIgnoreCase("-categoryQualifier")) //$NON-NLS-1$
+			categoryQualifier = parameter;
+
+		if (arg.equalsIgnoreCase("-categoryVersion")) //$NON-NLS-1$
+			categoryVersion = parameter;
+	}
+
+	@Override
+	protected IPublisherAction[] createActions() {
+		LocalUpdateSiteAction action = new LocalUpdateSiteAction(source, categoryQualifier);
+		action.setCategoryVersion(categoryVersion);
+		if (addJRE) {
+			return new IPublisherAction[] { action, new JREAction((String) null) };
+		}
+		return new IPublisherAction[] { action };
+	}
+
+	/** by default don't generate the JRE IU */
+	private boolean addJRE = false;
+
+	/**
+	 * Detect the flag -addJREIU to turn on the generation of the JREIU.
+	 */
+	@Override
+	protected void processFlag(String flag, PublisherInfo publisherInfo) {
+		super.processFlag(flag, publisherInfo);
+		if (flag.equalsIgnoreCase("-addJREIU"))//$NON-NLS-1$
+		{
+			addJRE = true;
+		}
+	}
+}

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/PublishFeaturesAndBundlesMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/PublishFeaturesAndBundlesMojo.java
@@ -27,8 +27,7 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
-import org.eclipse.equinox.p2.publisher.eclipse.FeaturesAndBundlesPublisherApplication;
-import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
+import org.eclipse.tycho.p2tools.copiedfromp2.FeaturesAndBundlesPublisherApplication;
 
 /**
  * This goal invokes the feature and bundle publisher on a folder.
@@ -106,8 +105,7 @@ public class PublishFeaturesAndBundlesMojo extends AbstractMojo {
             List<String> contentArgs = new ArrayList<>();
             contentArgs.add("-source");
             contentArgs.add(sourceRepositoryDir.toString());
-            agent.getService(IArtifactRepositoryManager.class); //force init P2 services
-            FeaturesAndBundlesPublisherApplication application = new FeaturesAndBundlesPublisherApplication();
+            FeaturesAndBundlesPublisherApplication application = new FeaturesAndBundlesPublisherApplication(agent);
             List<String> arguments = new ArrayList<String>();
             arguments.add("-artifactRepository");
             arguments.add(artifactRepositoryDir.toURL().toString());

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/AbstractP2MetadataMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/AbstractP2MetadataMojo.java
@@ -21,10 +21,12 @@ import java.util.List;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.equinox.app.IApplication;
-import org.eclipse.equinox.p2.publisher.AbstractPublisherApplication;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.tycho.p2tools.copiedfromp2.AbstractPublisherApplication;
 
 public abstract class AbstractP2MetadataMojo extends AbstractMojo {
 
@@ -68,6 +70,9 @@ public abstract class AbstractP2MetadataMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private boolean compressRepository;
 
+    @Component
+    private IProvisioningAgent agent;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (!generateP2Metadata) {
@@ -101,7 +106,7 @@ public abstract class AbstractP2MetadataMojo extends AbstractMojo {
             arguments.add(argLine);
         }
 
-        Object result = getPublisherApplication().run(arguments.toArray(String[]::new));
+        Object result = getPublisherApplication(agent).run(arguments.toArray(String[]::new));
         if (result != IApplication.EXIT_OK) {
             throw new MojoFailureException("P2 publisher return code was " + result);
         }
@@ -124,7 +129,7 @@ public abstract class AbstractP2MetadataMojo extends AbstractMojo {
         }
     }
 
-    protected abstract AbstractPublisherApplication getPublisherApplication();
+    protected abstract AbstractPublisherApplication getPublisherApplication(IProvisioningAgent agent);
 
     protected File getUpdateSiteLocation() {
         return target;

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/CategoryP2MetadataMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/CategoryP2MetadataMojo.java
@@ -25,8 +25,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.eclipse.equinox.internal.p2.updatesite.CategoryPublisherApplication;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.internal.repository.tools.XZCompressor;
+import org.eclipse.tycho.p2tools.copiedfromp2.CategoryPublisherApplication;
 
 /**
  * Adds category IUs to existing metadata repository.
@@ -41,8 +42,8 @@ public class CategoryP2MetadataMojo extends AbstractP2MetadataMojo {
     private File categoryDefinition;
 
     @Override
-    protected CategoryPublisherApplication getPublisherApplication() {
-        return new CategoryPublisherApplication();
+    protected CategoryPublisherApplication getPublisherApplication(IProvisioningAgent agent) {
+        return new CategoryPublisherApplication(agent);
     }
 
     @Override

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/FeatureP2MetadataMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/FeatureP2MetadataMojo.java
@@ -15,15 +15,16 @@ package org.eclipse.tycho.plugins.p2;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.eclipse.equinox.p2.publisher.eclipse.FeaturesAndBundlesPublisherApplication;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.tycho.p2tools.copiedfromp2.FeaturesAndBundlesPublisherApplication;
 
 @Mojo(name = "feature-p2-metadata", threadSafe = true)
 public class FeatureP2MetadataMojo extends AbstractP2MetadataMojo {
     private static final Object LOCK = new Object();
 
     @Override
-    protected FeaturesAndBundlesPublisherApplication getPublisherApplication() {
-        return new FeaturesAndBundlesPublisherApplication();
+    protected FeaturesAndBundlesPublisherApplication getPublisherApplication(IProvisioningAgent agent) {
+        return new FeaturesAndBundlesPublisherApplication(agent);
     }
 
     @Override

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/UpdateSiteP2MetadataMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/UpdateSiteP2MetadataMojo.java
@@ -15,15 +15,16 @@ package org.eclipse.tycho.plugins.p2;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.eclipse.equinox.internal.p2.updatesite.UpdateSitePublisherApplication;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.tycho.p2tools.copiedfromp2.UpdateSitePublisherApplication;
 
 @Mojo(name = "update-site-p2-metadata", threadSafe = true)
 public class UpdateSiteP2MetadataMojo extends AbstractP2MetadataMojo {
     private static final Object LOCK = new Object();
 
     @Override
-    protected UpdateSitePublisherApplication getPublisherApplication() {
-        return new UpdateSitePublisherApplication();
+    protected UpdateSitePublisherApplication getPublisherApplication(IProvisioningAgent agent) {
+        return new UpdateSitePublisherApplication(agent);
     }
 
     @Override


### PR DESCRIPTION
P2 and Tycho have different demands when it comes to "Applications" e.g.
Tycho often want to programmatically set things, while in P2 they are
called in means of CLI. Also in the past it has shown its very hard to
maintain "extensibility" together with "compatibility".

Because of this, this now also imports the set of Publisher applications
to Tycho, this will open us with a large set of new opportunities e.g.
getting rid of argument building just that these arguments are later
passed back into fields/objects.