### PR TITLE
Make the build EEs available to the materialize-products

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/shared/StatusTool.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/shared/StatusTool.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.shared;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 
 public class StatusTool {
@@ -71,7 +72,8 @@ public class StatusTool {
 
         final String listSeparatorString;
 
-        HierarchyFormatter(String childrenStart, String indentationIncrement, String listSeparator, String childrenEnd) {
+        HierarchyFormatter(String childrenStart, String indentationIncrement, String listSeparator,
+                String childrenEnd) {
             this("", childrenStart, indentationIncrement, listSeparator, childrenEnd);
         }
 
@@ -150,5 +152,15 @@ public class StatusTool {
 
     private static boolean hasChildren(IStatus status) {
         return status.getChildren() != null && status.getChildren().length > 0;
+    }
+
+    public static IStatus findStatus(Throwable t) {
+        if (t == null) {
+            return null;
+        }
+        if (t instanceof CoreException e) {
+            return e.getStatus();
+        }
+        return findStatus(t.getCause());
     }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/director/shared/AbstractDirectorApplicationCommand.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/director/shared/AbstractDirectorApplicationCommand.java
@@ -14,6 +14,7 @@ package org.eclipse.tycho.p2.tools.director.shared;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -21,6 +22,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.eclipse.equinox.p2.engine.IPhaseSet;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.DependencySeed;
 import org.eclipse.tycho.TargetEnvironment;
@@ -47,6 +49,7 @@ public abstract class AbstractDirectorApplicationCommand implements DirectorRunt
     private File bundlePool;
     private IPhaseSet phaseSet;
     private boolean installSources;
+    private Collection<IInstallableUnit> eeUnits;
 
     @Override
     public final void addMetadataSources(Iterable<URI> metadataRepositories) {
@@ -170,6 +173,18 @@ public abstract class AbstractDirectorApplicationCommand implements DirectorRunt
             props.put(BundlesAction.FILTER_PROPERTY_INSTALL_SOURCE, "true");
         }
         return props;
+    }
+
+    @Override
+    public void setEEUnits(Collection<IInstallableUnit> eeUnits) {
+        this.eeUnits = eeUnits;
+    }
+
+    public Collection<IInstallableUnit> getEEUnits() {
+        if (eeUnits == null) {
+            return List.of();
+        }
+        return eeUnits;
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/director/shared/DirectorRuntime.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/director/shared/DirectorRuntime.java
@@ -14,9 +14,11 @@ package org.eclipse.tycho.p2.tools.director.shared;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Collection;
 import java.util.Map;
 
 import org.eclipse.equinox.p2.engine.IPhaseSet;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.tycho.DependencySeed;
 import org.eclipse.tycho.PlatformPropertiesUtils;
 import org.eclipse.tycho.TargetEnvironment;
@@ -63,6 +65,8 @@ public interface DirectorRuntime {
         void setPhaseSet(IPhaseSet phaseSet);
 
         void setInstallSources(boolean installSources);
+
+        void setEEUnits(Collection<IInstallableUnit> eeUnits);
     }
 
     /**

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/DirectorApplicationWrapper.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/DirectorApplicationWrapper.java
@@ -72,8 +72,9 @@ public final class DirectorApplicationWrapper implements DirectorRuntime {
             }
 
             try {
-                Object exitCode = new DirectorApplication(this, getPhaseSet(), agent, agentProvider)
-                        .run(arguments.toArray(new String[arguments.size()]));
+                DirectorApplication application = new DirectorApplication(this, getPhaseSet(), agent, agentProvider);
+                application.setExtraInstallableUnits(getEEUnits());
+                Object exitCode = application.run(arguments.toArray(new String[arguments.size()]));
                 if (!(EXIT_OK.equals(exitCode))) {
                     throw new DirectorCommandException("Call to p2 director application failed with exit code "
                             + exitCode + ". Program arguments were: " + arguments + ".");

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/DirectorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/DirectorApplication.java
@@ -632,6 +632,7 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
     private IPhaseSet phaseSet;
     private IProvisioningAgent defaultAgent;
     private IProvisioningAgentProvider provisioningAgentProvider;
+    private Collection<IInstallableUnit> extraUnits;
 
     public DirectorApplication(ILog log, IPhaseSet phaseSet, IProvisioningAgent defaultAgent,
             IProvisioningAgentProvider provisioningAgentProvider) {
@@ -990,7 +991,7 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
      *
      * @return the current default agent, never <code>null</code>
      * @throws CoreException
-     *                           when fetching the agent failed
+     *             when fetching the agent failed
      */
     protected IProvisioningAgent getDefaultAgent() throws CoreException {
         return defaultAgent;
@@ -1000,10 +1001,10 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
      * Creates a new agent for the given data area
      *
      * @param p2DataArea
-     *                       the data area to create a new agent
+     *            the data area to create a new agent
      * @return the new agent, never <code>null</code>
      * @throws CoreException
-     *                           if creation of the agent for the given location failed
+     *             if creation of the agent for the given location failed
      */
     protected IProvisioningAgent createAgent(URI p2DataArea) throws CoreException {
         IProvisioningAgent agent = provisioningAgentProvider.createAgent(p2DataArea);
@@ -1013,8 +1014,8 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
 
     /*
      * See bug: https://bugs.eclipse.org/340971 Using the event bus to detect whether or not a
-     * repository was added in a touchpoint action. If it was, then (if it exists) remove it from our
-     * list of repos to remove after we complete our install.
+     * repository was added in a touchpoint action. If it was, then (if it exists) remove it from
+     * our list of repos to remove after we complete our install.
      */
     @Override
     public void notify(EventObject o) {
@@ -1096,6 +1097,9 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
             context.setArtifactRepositories(artifactRepositoryLocations.stream().toArray(URI[]::new));
             context.setProperty(ProvisioningContext.FOLLOW_REPOSITORY_REFERENCES, String.valueOf(followReferences));
             context.setProperty(FOLLOW_ARTIFACT_REPOSITORY_REFERENCES, String.valueOf(followReferences));
+            if (extraUnits != null && !extraUnits.isEmpty()) {
+                context.setExtraInstallableUnits(List.copyOf(extraUnits));
+            }
             ProfileChangeRequest request = buildProvisioningRequest(profile, installs, uninstalls);
             printRequest(request);
             planAndExecute(profile, context, request);
@@ -1106,6 +1110,10 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
                 setRoaming(profile);
             }
         }
+    }
+
+    public void setExtraInstallableUnits(Collection<IInstallableUnit> extraUnits) {
+        this.extraUnits = extraUnits;
     }
 
     private void planAndExecute(IProfile profile, ProvisioningContext context, ProfileChangeRequest request)
@@ -1412,9 +1420,9 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
 
     /**
      * @param pairs
-     *                       a comma separated list of tag=value pairs
+     *            a comma separated list of tag=value pairs
      * @param properties
-     *                       the collection into which the pairs are put
+     *            the collection into which the pairs are put
      */
     private void putProperties(String pairs, Map<String, String> properties) {
         String[] propPairs = StringHelper.getArrayFromString(pairs, ',');


### PR DESCRIPTION
Currently the materialize-products mojo relies on the ee to be published as a preliminary step.

This now makes then generally available as extra IUs to the director so this mojo can be used without EEs published first.