### PR TITLE
assemble-repository: Prevent sources from being included inadvertently

### DIFF
--- a/tycho-its/projects/product.productRepository/pom.xml
+++ b/tycho-its/projects/product.productRepository/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>tycho-its-project.product.productRepository</groupId>
+  <artifactId>product.product</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-repository</packaging>
+
+  <repositories>
+    <repository>
+      <id>e431</id>
+      <layout>p2</layout>
+      <!-- Important: This update site must have already been generated with the new P2 that adds the source as optional dependencyies with <filter>(org.eclipse.update.install.sources=true)</filter> metadata for the problem to show -->
+      <url>https://download.eclipse.org/eclipse/updates/4.31/R-4.31-202402290520/</url>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <extensions>true</extensions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <environments>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+          </environments>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-repository-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <includeAllDependencies>true</includeAllDependencies>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-director-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <executions>
+          <execution>
+            <id>materialize-products</id>
+            <goals>
+              <goal>materialize-products</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <products>
+              <product>
+                  <id>product.product</id>
+              </product>
+          </products>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>withsources</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-p2-repository-plugin</artifactId>
+            <version>${tycho-version}</version>
+            <configuration>
+              <includeAllSources>true</includeAllSources>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-p2-director-plugin</artifactId>
+            <version>${tycho-version}</version>
+            <configuration>
+              <installSources>true</installSources>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/tycho-its/projects/product.productRepository/product.product
+++ b/tycho-its/projects/product.productRepository/product.product
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="product.product" id="product" application="application" version="1.0.0.qualifier" useFeatures="false" includeLaunchers="false">
+
+   <plugins>
+      <plugin id="org.eclipse.osgi"/>
+   </plugins>
+
+</product>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductRepositoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductRepositoryTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    SAP SE - [Issue #3522] product / repository contains source jars by default
+ *******************************************************************************/
+package org.eclipse.tycho.test.product;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class ProductRepositoryTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testShouldNotContainSources() throws Exception {
+		Verifier verifier = getVerifier("product.productRepository", false);
+		verifier.executeGoals(Arrays.asList("clean", "verify"));
+		verifier.verifyErrorFreeLog();
+		assertFileExists(new File(verifier.getBasedir()), //
+				"target/repository/plugins/org.eclipse.osgi_*.jar");
+		assertFileDoesNotExist(new File(verifier.getBasedir()), //
+				"target/repository/plugins/org.eclipse.osgi.source_*.jar");
+		assertFileExists(new File(verifier.getBasedir()), //
+				"target/products/product.product/linux/gtk/x86_64/plugins/org.eclipse.osgi_*.jar");
+		assertFileDoesNotExist(new File(verifier.getBasedir()), //
+				"target/products/product.product/linux/gtk/x86_64/plugins/org.eclipse.osgi.source_*.jar");
+	}
+
+	@Test
+	public void testShouldContainSourcesWhenExlicitlyIncluded() throws Exception {
+		Verifier verifier = getVerifier("product.productRepository", false);
+		verifier.addCliOption("-Pwithsources");
+		verifier.executeGoals(Arrays.asList("clean", "verify"));
+		verifier.verifyErrorFreeLog();
+		assertFileExists(new File(verifier.getBasedir()), //
+				"target/repository/plugins/org.eclipse.osgi_*.jar");
+		assertFileExists(new File(verifier.getBasedir()), //
+				"target/repository/plugins/org.eclipse.osgi.source_*.jar");
+		assertFileExists(new File(verifier.getBasedir()), //
+				"target/products/product.product/linux/gtk/x86_64/plugins/org.eclipse.osgi_*.jar");
+		assertFileExists(new File(verifier.getBasedir()), //
+				"target/products/product.product/linux/gtk/x86_64/plugins/org.eclipse.osgi.source_*.jar");
+	}
+}


### PR DESCRIPTION
In the presence of products, P2 adds a virtual `tooling.source.default`
IU which optionally depends on all sources.

If these sources are available in the target platform, this would cause
them to be picked up even if assemble-repository was configured with

```
  <includeAllDependencies>true<includeAllDependencies>
```

but with

```
  <includeAllSources>false</includeAllSources>.
```

This scenario has become much more likely with recent changes to P2 [1].

We do not want includeAllDependencies to imply includeAllSources, so
we actively prevent this from happening by ignoring the

```
  <required namespace='org.eclipse.equinox.p2.eclipse.type'
            name='source'
            range='0.0.0'
            optional='true'
            multiple='true'
            greedy='false'/>
```

requirements if `includeAllSources` is not specified.

Fixes #3522.

[1] https://github.com/eclipse-equinox/p2/pull/446