### PR TITLE
Adjust resolving tests for 4.31

### DIFF
--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2024 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -222,8 +222,8 @@ public class P2ResolverTest extends P2ResolverTestBase {
 
         result = singleEnv(impl.resolveTargetDependencies(getTargetPlatform(), projectToResolve));
 
-        assertEquals(3, result.getArtifacts().size());
-        assertEquals(3, result.getNonReactorUnits().size()); // + a.jre
+        assertEquals(4, result.getArtifacts().size());
+        assertEquals(4, result.getNonReactorUnits().size()); // + a.jre
 
         assertContainsUnit("org.eclipse.swt", result.getNonReactorUnits());
         assertContainsUnit("org.eclipse.swt.gtk.linux.x86_64", result.getNonReactorUnits());


### PR DESCRIPTION
With https://github.com/eclipse-equinox/p2/pull/446 and Tycho resolving all possibly needed bundles source bundle ends up there in case it's needed.