### PR TITLE
ExpandedProduct.getFeatures(ROOT_FEATURES) returns over-qualified IDs

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/ExpandedProduct.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/ExpandedProduct.java
@@ -46,7 +46,8 @@ class ExpandedProduct implements IProductDescriptor {
     private final String expandedVersion;
     private List<IVersionedId> expandedBundles = null;
     private List<IVersionedId> expandedFeatures = null;
-    private List<IInstallableUnit> expandedRootFeatures = Collections.emptyList();
+    private List<IVersionedId> expandedRootFeatures = Collections.emptyList();
+    private List<IInstallableUnit> expandedRootFeatureIUs = Collections.emptyList();
 
     private final MultiLineLogger logger;
 
@@ -93,7 +94,7 @@ class ExpandedProduct implements IProductDescriptor {
     }
 
     public List<IInstallableUnit> getRootFeatures() {
-        return expandedRootFeatures;
+        return expandedRootFeatureIUs;
     }
 
     private void expandVersions() {
@@ -106,7 +107,9 @@ class ExpandedProduct implements IProductDescriptor {
         if (contentType != ProductContentType.BUNDLES) {
             expandedFeatures = resolver.resolveReferences("feature", ArtifactType.TYPE_ECLIPSE_FEATURE,
                     defaults.getFeatures(INCLUDED_FEATURES));
-            expandedRootFeatures = resolver.resolveReferencesToIUs("feature", ArtifactType.TYPE_ECLIPSE_FEATURE,
+            expandedRootFeatures = resolver.resolveReferences("feature", ArtifactType.TYPE_ECLIPSE_FEATURE,
+                    defaults.getFeatures(ROOT_FEATURES));
+            expandedRootFeatureIUs = resolver.resolveReferencesToIUs("feature", ArtifactType.TYPE_ECLIPSE_FEATURE,
                     defaults.getFeatures(ROOT_FEATURES));
         }
         resolver.reportErrors(logger);

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishProductToolTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishProductToolTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -272,9 +271,11 @@ public class PublishProductToolTest extends TychoPlexusTestCase {
         assertThat(productUnit.getRequirements(),
                 hasItem(requirement("org.eclipse.rcp.feature.group", "4.4.0.v20140128")));
         assertThat(productUnit.getRequirements(), hasItem(requirement("org.eclipse.e4.rcp.feature.group", "1.0")));
-        assertThat(productUnit.getRequirements(),
-                not(hasItem(requirement("org.eclipse.help.feature.group", "2.0.102.v20140128"))));
-        assertThat(productUnit.getRequirements(), not(hasItem(requirement("org.eclipse.egit.feature.group", "2.0"))));
+        assertThat(productUnit.getRequirements(), hasItem(requirement("org.eclipse.help.feature.group",
+                "2.0.102.v20140128",
+                "(|(org.eclipse.equinox.p2.install.mode.root=true)(product.with.root.features.install.mode.root=true))")));
+        assertThat(productUnit.getRequirements(), hasItem(requirement("org.eclipse.egit.feature.group", "2.0",
+                "(|(org.eclipse.equinox.p2.install.mode.root=true)(product.with.root.features.install.mode.root=true))")));
 
         assertEquals("org.eclipse.help", seeds.get(1).getId());
         assertThat(seeds.get(1).getInstallableUnit(), is(unitWithId("org.eclipse.help.feature.group")));

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/InstallableUnitMatchers.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/InstallableUnitMatchers.java
@@ -16,13 +16,16 @@ import static org.eclipse.tycho.test.util.InstallableUnitUtil.IU_CAPABILITY_NS;
 import static org.eclipse.tycho.test.util.InstallableUnitUtil.PRODUCT_TYPE_PROPERTY;
 
 import java.util.Map;
+import java.util.Objects;
 
+import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IProvidedCapability;
 import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.equinox.p2.metadata.ITouchpointData;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.metadata.expression.IMatchExpression;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -164,6 +167,26 @@ public class InstallableUnitMatchers {
                 description.appendText("the capability osgi.ee/" + eeName + "/" + parsedVersion);
             }
 
+        };
+    }
+
+    public static Matcher<? super IRequirement> requirement(final String id, final String version,
+            final String filter) {
+        IMatchExpression<IInstallableUnit> filterEpxression = InstallableUnit.parseFilter(filter);
+        final IInstallableUnit unit = InstallableUnitUtil.createIU(id, version);
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("a require of unit ").appendText(id).appendText(":").appendText(version)
+                        .appendText(";filter=").appendText(filter);
+            }
+
+            @Override
+            protected boolean matchesSafely(IRequirement item) {
+                IMatchExpression<IInstallableUnit> requirementFilter = item.getFilter();
+                return item.isMatch(unit) && Objects.equals(filterEpxression, requirementFilter);
+            }
         };
     }
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho188P2EnabledRcpTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho188P2EnabledRcpTest.java
@@ -127,9 +127,12 @@ public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 		Optional<File> rootFeatureInRepo = p2Repository.findFeatureArtifact("pi.root-level-installed-feature");
 		assertTrue(rootFeatureInRepo.isPresent());
 
-		// ... although there is no dependency from the product IU.
-		assertThat(p2Repository.getUniqueIU("main.product.id").getRequiredIds(),
-				not(hasItem("pi.root-level-installed-feature.feature.group")));
+		// ... although there is no unfiltered dependency from the product IU.
+		var unfilteredRequiredIds = p2Repository.getUniqueIU("main.product.id").getUnfilteredRequiredIds();
+		assertThat(unfilteredRequiredIds, not(hasItem("pi.root-level-installed-feature.feature.group")));
+
+		// There are the expected unfiltered requirement such as this one.
+		assertThat(unfilteredRequiredIds, hasItem("pi.example.feature.feature.group"));
 	}
 
 	@Test

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/P2RepositoryTool.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/P2RepositoryTool.java
@@ -283,6 +283,17 @@ public class P2RepositoryTool {
             return getValues(unitElement, "requires/required/@name");
         }
 
+        public List<String> getUnfilteredRequiredIds() throws Exception {
+            return XMLTool.getMatchingNodes(unitElement, "requires/required").stream().filter(node -> {
+                try {
+                    var nodes = getNodes(node, "filter");
+                    return nodes.isEmpty();
+                } catch (XPathExpressionException e) {
+                    throw new RuntimeException(e);
+                }
+            }).map(node -> node.getAttributes().getNamedItem("name")).map(Node::getNodeValue).toList();
+        }
+
         /**
          * Returns the IDs of IUs required with strict version range.
          */


### PR DESCRIPTION
It returns IVersionedId instances where the ID is that of the installable unit, i.e., with an extra .feature.group suffix, rather than the ID of the feature itself.
ExpandedProduct.getFeatures(INCLUDED_FEATURES) returns the correct result. A problem arises from this now because with the 4.31 changes to org.eclipse.equinox.p2.publisher.eclipse.ProductAction to generate filtered requirements for the installMode="root" features, this inconsistency produces invalid requirements, i.e., a requirement on xyz.feature.group.feature.group, which does not exist, rather than on xyz.feature.group.