### PR TITLE
TargetPlatformFactoryImpl.gatherP2InfUnits should use artifact version

### DIFF
--- a/tycho-its/projects/p2Inf.virtualUnit/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2Inf.virtualUnit/bundle/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: pvu.bundle
 Bundle-SymbolicName: pvu.bundle;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: TEST
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/p2Inf.virtualUnit/bundle/META-INF/p2.inf
+++ b/tycho-its/projects/p2Inf.virtualUnit/bundle/META-INF/p2.inf
@@ -1,11 +1,17 @@
 # Create the virtual IU
 units.0.id=configure.pvu.bundle
-units.0.version=1.0.0
+units.0.version=$version$
 units.0.provides.1.namespace=org.eclipse.equinox.p2.iu
 units.0.provides.1.name=configure.pvu.bundle
-units.0.provides.1.version=1.0.0
+units.0.provides.1.version=$version$
 
 # Require in this bundle the created virtual IU
 requires.0.namespace=org.eclipse.equinox.p2.iu
 requires.0.name=configure.pvu.bundle
-requires.0.range=0.0.0
+requires.0.range=$version$
+
+# Specify update advice with a version range that is invalid if $version$ expands to 1.0.0
+# For this example it should expand to 2.0.0
+update.id = update.pvu.bundle
+update.range = [1.0.0,$version$)
+update.severity = 0

--- a/tycho-its/projects/p2Inf.virtualUnit/bundle/pom.xml
+++ b/tycho-its/projects/p2Inf.virtualUnit/bundle/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tycho-its-project.p2Inf.virtualUnit</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pvu.bundle</artifactId>

--- a/tycho-its/projects/p2Inf.virtualUnit/pom.xml
+++ b/tycho-its/projects/p2Inf.virtualUnit/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tycho-its-project.p2Inf.virtualUnit</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Currently the implementation hard codes the version to 1.0.0 when parsing advice from a p2.inf.  This can result in an IAE if the version is used in a range such as [1.0.0,$version$) where because [1.0.0,1.0.0) is not a valid range.