### PR TITLE
Add follow repository references

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,36 +30,36 @@ with Maven.
 
 Just get in contact with us through the [discussions](https://github.com/eclipse-tycho/tycho/discussions) and share your [ideas](https://github.com/eclipse-tycho/tycho/discussions/new) or report [issues](https://github.com/eclipse-tycho/tycho/issues).
 
-Please bear in mind that this is a community project, and not a product you contracted support for and as a result, some contributors may or may not look at your support requests on demand and if you do not provide the fix/implementation yourself the issue might even never get fixed.
+Please bear in mind that this is a community project and not a product you contracted support for and as a result, some contributors may or may not look at your support requests on demand and if you do not provide the fix/implementation yourself, the issue might even never get fixed.
 
-If you require dedicated help with Tycho, want to make sure a bugfix or feature is handled with priority, the following companies offers commercial support for Tycho 
+If you require dedicated help with Tycho or want to make sure a bugfix or feature is handled with priority, the following companies offer commercial support for Tycho 
 * ![](https://läubisoft.gmbh/favicon.ico) [Läubisoft GmbH](https://xn--lubisoft-0za.gmbh/en/)
 
 
 # Support Tycho  
 
-In general, if Tycho is key technology for your Organization, you can help with the following things:
+In general, if Tycho is a key technology for your Organization, you can help with the following:
 
 ### Help testing
-Test snapshots of Tycho early and often so that regressions are found early before we start the release process, this gives faster release and maybe even more often releases if we are certain that snapshots are production-ready.
+Test snapshots of Tycho early and often so that regressions are found early before we start the release process. This results in faster releases and maybe even more frequent releases if we are certain that snapshots are production-ready.
 
 ### Donate some time
-Consider donate some developer time to improve code (e.g. fixing bugs), enhancing documentation, help with review of open PRs, [answer questions on the discussions](https://github.com/eclipse-tycho/tycho/discussions), or [providing integration test](https://github.com/eclipse-tycho/tycho/wiki#providing-an-integration-test) to cover your important features.
+Consider donating some developer time to improve code (e.g., fixing bugs), enhance documentation, help with review of open PRs, [answer questions on the discussions](https://github.com/eclipse-tycho/tycho/discussions), or [providing integration tests](https://github.com/eclipse-tycho/tycho/wiki#providing-an-integration-test) to cover your important features.
 
 ## Sponsor individual contributors
-If you want to help with development of Tycho itself but can't afford to do it by yourself, you can sponsor some of the contributors of Tycho directly:
+If you want to help with the development of Tycho itself but can't afford to do it by yourself, you can sponsor some of the contributors of Tycho directly:
 
 * [Christoph Läubrich](https://github.com/sponsors/laeubi) - A sample of his recent work can be seen [here](https://github.com/eclipse-tycho/tycho/commits?author=laeubi).
 
 ### Support us with processing power
 Tycho has a very large user-base and thus we use exhaustive test-suites to ensure everything works well. This comes at a cost of also using a lot of processing power.
 
-The following Organizations support Tycho getting processing power for their builds:
+The following Organizations support Tycho by providing processing power for their builds:
 * <img src="https://www.eclipse.org/favicon.ico" width="16" height="16"> [Eclipse Foundation](https://www.eclipse.org/sponsor/) - host our CI Infrastructure, become a friend of Eclipse and support the Eclipse Foundation in general
 * <img src="https://www.renesas.com/favicon.ico" width="16" height="16"> [Renesas Electronics Corporation](https://www.eclipse.org/membership/showMember.php?member_id=1069) - sponsors a resource pack with 2 CPU / 8 GB RAM
 * <img src="https://www.sap.com/favicon.ico"     width="16" height="16"> [SAP SE](https://www.eclipse.org/membership/showMember.php?member_id=665) - sponsors two resource packs with 2 CPU / 8 GB RAM each
-* <img src="https://www.redhat.com/themes/custom/rhdc/favicon.ico"  width="16" height="16"> [Red Hat, Inc.](https://www.eclipse.org/membership/showMember.php?member_id=731) - sponsors a resource pack with 2 CPU / 8 GB RAM
+* <img src="https://www.redhat.com/favicon.ico"  width="16" height="16"> [Red Hat, Inc.](https://www.eclipse.org/membership/showMember.php?member_id=731) - sponsors a resource pack with 2 CPU / 8 GB RAM
 * <img src="https://www.sigasi.com/img/logoSquare.png"  width="16" height="16"> [Sigasi](https://www.eclipse.org/membership/showMember.php?member_id=990) - sponsors a resource pack with 2 CPU / 8 GB RAM
 
 
-If your Organizations is an [Eclipse Member](https://www.eclipse.org/membership/exploreMembership.php) you can help us by [sponsoring one of the included resource packs](https://github.com/eclipse-cbi/cbi/wiki#assigning-additional-resources-to-a-project) to speed up builds. Organizations can check how many Resource Packs they have left for project sponsoring on the [membership portal](https://membership.eclipse.org/portal/login).
+If your Organization is an [Eclipse Member](https://www.eclipse.org/membership/exploreMembership.php) you can help us by [sponsoring one of the included resource packs](https://github.com/eclipse-cbi/cbi/wiki#assigning-additional-resources-to-a-project) to speed up builds. Organizations can check how many Resource Packs they have left for project sponsoring on the [membership portal](https://membership.eclipse.org/portal/login).

--- a/tycho-baseline-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-baseline-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=17

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/URITargetDefinitionContent.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/URITargetDefinitionContent.java
@@ -125,7 +125,7 @@ public class URITargetDefinitionContent implements TargetDefinitionContent {
             Collection<IRepositoryReference> references = repository.getReferences();
             subMonitor.setWorkRemaining(references.size());
             for (IRepositoryReference reference : references) {
-                if ((reference.getOptions() | IRepository.ENABLED) != 0) {
+                if ((reference.getOptions() & IRepository.ENABLED) != 0) {
                     URI location = reference.getLocation();
                     if (reference.getType() == IRepository.TYPE_METADATA) {
                         try {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/InstallableUnitResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/InstallableUnitResolver.java
@@ -183,7 +183,7 @@ public class InstallableUnitResolver {
             throws TargetDefinitionResolutionException {
         if (includeAllEnvironments) {
             logger.warn(
-                    "includeAllPlatforms='true' and includeMode='planner' are incompatible. ignore includeAllPlatforms flag");
+                    "includeAllPlatforms='true' and includeMode='planner' are incompatible. Ignoring 'includeAllPlatforms' flag");
         }
         ProjectorResolutionStrategy strategy = new ProjectorResolutionStrategy(logger);
         strategy.setData(data);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolver.java
@@ -141,7 +141,7 @@ public final class TargetDefinitionResolver {
         Map<String, URITargetDefinitionContent> uriRepositories = new LinkedHashMap<>();
         List<TargetDefinitionContent> mavenLocations = new ArrayList<>();
         List<TargetDefinitionContent> referencedTargetLocations = new ArrayList<>();
-        List<TargetDefinitionContent> repositorytLocations = new ArrayList<>();
+        List<TargetDefinitionContent> repositoryLocations = new ArrayList<>();
         for (Location locationDefinition : definition.getLocations()) {
             if (locationDefinition instanceof InstallableUnitLocation installableUnitLocation) {
                 if (installableUnitResolver == null) {
@@ -234,7 +234,7 @@ public final class TargetDefinitionResolver {
                 logger.info("Loading " + resolvedUri + "...");
                 RepositoryLocationContent content = new RepositoryLocationContent(resolvedUri,
                         repositoryLocation.getRequirements(), provisioningAgent, logger);
-                repositorytLocations.add(content);
+                repositoryLocations.add(content);
                 IQueryResult<IInstallableUnit> result = content.query(QueryUtil.ALL_UNITS,
                         new LoggingProgressMonitor(logger));
                 unitResultSet.addAll(result);
@@ -273,7 +273,7 @@ public final class TargetDefinitionResolver {
             artifactRepositories.add(referenceContent.getArtifactRepository());
         }
         //preliminary step: add all repository locations:
-        for (TargetDefinitionContent referenceContent : repositorytLocations) {
+        for (TargetDefinitionContent referenceContent : repositoryLocations) {
             metadataRepositories.add(referenceContent.getMetadataRepository());
             artifactRepositories.add(referenceContent.getArtifactRepository());
         }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolver.java
@@ -63,6 +63,7 @@ import org.eclipse.tycho.p2maven.ListCompositeArtifactRepository;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
 import org.eclipse.tycho.targetplatform.TargetDefinition.DirectoryLocation;
 import org.eclipse.tycho.targetplatform.TargetDefinition.FeaturesLocation;
+import org.eclipse.tycho.targetplatform.TargetDefinition.FollowRepositoryReferences;
 import org.eclipse.tycho.targetplatform.TargetDefinition.InstallableUnitLocation;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Location;
 import org.eclipse.tycho.targetplatform.TargetDefinition.MavenGAVLocation;
@@ -149,12 +150,21 @@ public final class TargetDefinitionResolver {
                             includeSourceMode, logger);
                 }
                 List<URITargetDefinitionContent> locations = new ArrayList<>();
+                var followRepositoryReferences = installableUnitLocation.followRepositoryReferences();
+                final ReferencedRepositoryMode followReferences;
+                if (followRepositoryReferences == FollowRepositoryReferences.DEFAULT) {
+                    followReferences = referencedRepositoryMode;
+                } else if (followRepositoryReferences == FollowRepositoryReferences.ENABLED) {
+                    followReferences = ReferencedRepositoryMode.include;
+                } else {
+                    followReferences = ReferencedRepositoryMode.ignore;
+                }
                 for (Repository repository : installableUnitLocation.getRepositories()) {
                     URI location = resolveRepositoryLocation(repository.getLocation());
                     String key = location.normalize().toASCIIString();
                     locations.add(
                             uriRepositories.computeIfAbsent(key, s -> new URITargetDefinitionContent(provisioningAgent,
-                                    location, repository.getId(), referencedRepositoryMode, logger)));
+                                    location, repository.getId(), followReferences, logger)));
                 }
                 IQueryable<IInstallableUnit> locationUnits = QueryUtil.compoundQueryable(locations);
                 Collection<IInstallableUnit> rootUnits = installableUnitResolver

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverTest.java
@@ -366,6 +366,11 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
         public boolean includeSource() {
             return false;
         }
+
+        @Override
+        public boolean includeConfigurePhase() {
+            return false;
+        }
     }
 
     private static class OtherLocationStub implements Location {

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverWithPlatformSpecificUnitsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverWithPlatformSpecificUnitsTest.java
@@ -203,6 +203,11 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
         public boolean includeSource() {
             return false;
         }
+
+        @Override
+        public boolean includeConfigurePhase() {
+            return false;
+        }
     }
 
 }

--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
@@ -35,6 +35,7 @@ import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.core.resolver.P2ResolutionResult;
 import org.eclipse.tycho.p2resolver.TargetDefinitionVariableResolver;
 import org.eclipse.tycho.targetplatform.TargetDefinition;
+import org.eclipse.tycho.targetplatform.TargetDefinition.FollowRepositoryReferences;
 import org.eclipse.tycho.targetplatform.TargetDefinition.IncludeMode;
 import org.eclipse.tycho.targetplatform.TargetDefinition.InstallableUnitLocation;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Unit;
@@ -168,6 +169,16 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
         @Override
         public boolean includeSource() {
             return delegate.includeSource();
+        }
+
+        @Override
+        public boolean includeConfigurePhase() {
+            return delegate.includeConfigurePhase();
+        }
+
+        @Override
+        public FollowRepositoryReferences followRepositoryReferences() {
+            return delegate.followRepositoryReferences();
         }
 
     }

--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
@@ -97,7 +97,7 @@ import org.eclipse.tycho.p2maven.tools.TychoFeaturesAndBundlesPublisherApplicati
  * <pre>
     &lt;repository>
     &lt;id>my-p2-maven-site</id>
-        &lt;url>mvn:[grouId]:[artifactId]:[version]:zip:p2site</url>
+        &lt;url>mvn:[groupId]:[artifactId]:[version]:zip:p2site</url>
         &lt;layout>p2</layout>
     &lt;/repository>
  * </pre>
@@ -106,7 +106,7 @@ import org.eclipse.tycho.p2maven.tools.TychoFeaturesAndBundlesPublisherApplicati
  * 
  * <pre>
  *  &lt;location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-        &lt;repository location="mvn:[grouId]:[artifactId]:[version]:zip:p2site"/>
+        &lt;repository location="mvn:[groupId]:[artifactId]:[version]:zip:p2site"/>
         -- list desired units here --
     &lt;/location>
  * </pre>

--- a/tycho-p2/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-p2/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=17

--- a/tycho-surefire/org.eclipse.tycho.bnd.executionlistener/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-surefire/org.eclipse.tycho.bnd.executionlistener/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/tycho-targetplatform/pom.xml
+++ b/tycho-targetplatform/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>tycho-targetplatform</artifactId>
 	<name>Tycho Target Platform</name>
-	<description>Contains the neccesary bits to handle target platform files.</description>
+	<description>Contains the necessary bits to handle target platform files.</description>
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>

--- a/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinition.java
+++ b/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinition.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import org.bouncycastle.jcajce.provider.drbg.DRBG.Default;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.MavenArtifactRepositoryReference;
 import org.osgi.resource.Requirement;
@@ -66,10 +67,16 @@ public interface TargetDefinition {
 
 	}
 
+	public enum FollowRepositoryReferences {
+		DEFAULT,
+		ENABLED,
+		DISABLED,
+	}
+
 	public interface InstallableUnitLocation extends Location {
 
 		public static String TYPE = "InstallableUnit";
-
+		
 		public List<? extends Repository> getRepositories();
 
 		public List<? extends Unit> getUnits();
@@ -79,6 +86,19 @@ public interface TargetDefinition {
 		public boolean includeAllEnvironments();
 
 		public boolean includeSource();
+		
+		/**
+		 * Read for completeness but not used
+		 */
+		public boolean includeConfigurePhase();
+		
+		/**
+		 * When {@link FollowRepositoryReferences.Default} the global {@link IncludeSourceMode} should be used instead.
+		 * @return whether repository references should be used, never null
+		 */
+		public default FollowRepositoryReferences followRepositoryReferences() {
+			return FollowRepositoryReferences.DEFAULT;
+		}
 
 		@Override
 		public default String getTypeDescription() {

--- a/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinitionFile.java
+++ b/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinitionFile.java
@@ -413,14 +413,19 @@ public final class TargetDefinitionFile implements TargetDefinition {
         private final IncludeMode includeMode;
         private final boolean includeAllEnvironments;
         private final boolean includeSource;
+        private final boolean includeConfigurePhase;
+        private final FollowRepositoryReferences followRepositoryReferences;
 
         IULocation(List<Unit> units, List<Repository> repositories, IncludeMode includeMode,
-                boolean includeAllEnvironments, boolean includeSource) {
+                boolean includeAllEnvironments, boolean includeSource, boolean includeConfigurePhase,
+                FollowRepositoryReferences followRepositoryReferences) {
             this.units = units;
             this.repositories = repositories;
             this.includeMode = includeMode;
             this.includeAllEnvironments = includeAllEnvironments;
             this.includeSource = includeSource;
+            this.includeConfigurePhase = includeConfigurePhase;
+            this.followRepositoryReferences = followRepositoryReferences;
         }
 
         @Override
@@ -446,6 +451,16 @@ public final class TargetDefinitionFile implements TargetDefinition {
         @Override
         public boolean includeSource() {
             return includeSource;
+        }
+
+        @Override
+        public boolean includeConfigurePhase() {
+            return includeConfigurePhase;
+        }
+
+        @Override
+        public FollowRepositoryReferences followRepositoryReferences() {
+            return followRepositoryReferences;
         }
     }
 
@@ -743,9 +758,23 @@ public final class TargetDefinitionFile implements TargetDefinition {
             String uri = node.getAttribute("location");
             repositories.add(new Repository(id, uri));
         }
+        
+        String rawFollowRepositoryReferences = dom.getAttribute("followRepositoryReferences");
+        final FollowRepositoryReferences followRepositoryReferences;
+        if (rawFollowRepositoryReferences == null || rawFollowRepositoryReferences.isEmpty()) {
+            followRepositoryReferences = FollowRepositoryReferences.DEFAULT;
+        } else if (Boolean.parseBoolean(rawFollowRepositoryReferences)) {
+            followRepositoryReferences = FollowRepositoryReferences.ENABLED;
+        } else {
+            followRepositoryReferences = FollowRepositoryReferences.DISABLED;
+        }
+        
         return new IULocation(Collections.unmodifiableList(units), Collections.unmodifiableList(repositories),
                 parseIncludeMode(dom), Boolean.parseBoolean(dom.getAttribute("includeAllPlatforms")),
-                Boolean.parseBoolean(dom.getAttribute("includeSource")));
+                Boolean.parseBoolean(dom.getAttribute("includeSource")),
+                Boolean.parseBoolean(dom.getAttribute("includeConfigurePhase")),
+                followRepositoryReferences
+                );
     }
 
     private static String parseTargetEE(Element dom) {


### PR DESCRIPTION
Adding support for the new PDE option `followRepositoryReferences` for `.target` files.

See https://github.com/eclipse-pde/eclipse.pde/pull/1253/files