### PR TITLE
Add regression test for linked .classpath and test source folder

### DIFF
--- a/tycho-baseline-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-baseline-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=17

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/.project
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/.project
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>junit5-with-linked-resources</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<linkedResources>
+		<!-- A linked file relative to the location of the project -->
+		<link>
+			<name>.classpath</name>
+			<type>1</type>
+			<locationURI>PROJECT_LOC/linkedresources/.classpath</locationURI>
+		</link>
+		<!-- A linked folder relative to the location of the project's parent and defined in a variable -->
+		<link>
+			<name>src_test</name>
+			<type>2</type>
+			<locationURI>VARIABLE_SELFREF_VIA_PARENT/linkedresources/src_test/</locationURI>
+		</link>
+	</linkedResources>
+	<variableList>
+		<variable>
+			<name>VARIABLE_SELFREF_VIA_PARENT</name>
+			<value>$%7BPARENT-1-PROJECT_LOC%7D/junit5-with-linked-files</value>
+		</variable>
+	</variableList>
+</projectDescription>

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: junit5-with-linked-resources
+Bundle-SymbolicName: junit5.with.linked.resources
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Export-Package: bundle.test

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/build.properties
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/linkedresources/.classpath
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/linkedresources/.classpath
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" output="test" path="src_test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/linkedresources/src_test/bundle/test/AdderTest.java
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/linkedresources/src_test/bundle/test/AdderTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich. - initial API and implementation
+ *******************************************************************************/
+package bundle.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class AdderTest {
+
+	@Test
+	public void incrementTest() {
+		Counter counter = new Counter();
+		counter.increment(1);
+		counter.increment(3);
+		assertEquals(4, counter.get());
+	}
+
+	@Test
+	public void decrementTest() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			Counter counter = new Counter();
+			counter.increment(-1);
+		});
+	}
+}

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/linkedresources/src_test/bundle/test/SubtractorTest.java
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/linkedresources/src_test/bundle/test/SubtractorTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich  - initial API and implementation
+ *******************************************************************************/
+package bundle.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class SubtractorTest {
+
+	@Test
+	public void incrementTest() {
+		CountDown counter = new CountDown(10);
+		counter.decrement(1);
+		counter.decrement(3);
+		assertEquals(6, counter.get());
+	}
+
+	@Test
+	public void decrementTest() {
+		assertThrows(IllegalArgumentException.class, ()->{
+			CountDown counter = new CountDown(10);
+			counter.decrement(-1);
+		});
+	}
+
+	@Test
+	public void decrementTest2() {
+		assertThrows(IllegalStateException.class, ()->{
+			CountDown counter = new CountDown(1);
+			counter.decrement(5);
+		});
+	}
+}

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/pom.xml
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.tycho.tycho-its.surefire</groupId>
+	<artifactId>junit5.with.linked.resources</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<version>1.0.0</version>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.2</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>junit-jupiter-engine</artifactId>
+						<version>5.9.1</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>surefire-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/src/bundle/test/CountDown.java
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/src/bundle/test/CountDown.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich. - initial API and implementation
+ *******************************************************************************/
+package bundle.test;
+
+public class CountDown {
+	
+	RefMe refFromOtherSourceFolder;
+
+	int count;
+
+	public CountDown(int initalValue) {
+		count = initalValue;
+	}
+
+	public void decrement(int x) {
+		if (x < 0) {
+			throw new IllegalArgumentException();
+		}
+		if (count-x < 0) {
+			throw new IllegalStateException();
+		}
+		count -= x;
+	}
+
+	public int get() {
+		return count;
+	}
+}

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/src/bundle/test/Counter.java
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/src/bundle/test/Counter.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich. - initial API and implementation
+ *******************************************************************************/
+package bundle.test;
+
+public class Counter {
+
+	int count;
+
+	public void increment(int x) {
+		if (x < 0) {
+			throw new IllegalArgumentException();
+		}
+		count += x;
+	}
+
+	public int get() {
+		return count;
+	}
+}

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/src/bundle/test/RefMe.java
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/src/bundle/test/RefMe.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich. - initial API and implementation
+ *******************************************************************************/
+
+package bundle.test;
+
+public class RefMe extends Counter{
+
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathEntryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathEntryTest.java
@@ -38,6 +38,16 @@ public class CompilerClasspathEntryTest extends AbstractTychoIntegrationTest {
 	}
 
 	@Test
+	public void testJUnit5ContainerWithLinkedResources() throws Exception {
+		Verifier verifier = getVerifier("compiler.junitcontainer/junit5-with-linked-resources", false, true);
+		verifier.executeGoal("test");
+		verifier.verifyErrorFreeLog();
+		verifier.verifyTextInLog("-- in bundle.test.AdderTest");
+		verifier.verifyTextInLog("-- in bundle.test.SubtractorTest");
+		verifier.verifyTextInLog("Tests run: 5, Failures: 0, Errors: 0, Skipped: 0");
+	}
+
+	@Test
 	public void testJUnit4Container() throws Exception {
 		Verifier verifier = getVerifier("compiler.junitcontainer/junit4-in-bundle", true);
 		verifier.executeGoal("test");

--- a/tycho-p2/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-p2/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=17

--- a/tycho-surefire/org.eclipse.tycho.bnd.executionlistener/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-surefire/org.eclipse.tycho.bnd.executionlistener/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
When using linked resources for a project's `.classpath` file defining a JUnit classpath container or test source folders, they are not detected by Tycho. So the JUnit classpath container and the test source folder are not considered during the build and the tests are not executed.

This adds a test case demonstrating the integration of the `.classpath` file and a test source folder via linked resources in different ways:
* file relative to the project location
* folder relative the project location's parent and extracted into a variable

This serves as a reproducer for #3803.

I have used the project contents from another integration test, which is why I kept the copyright information that were already present in those files.