### PR TITLE
Sort dependency tree root nodes

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/P2DependencyTreeGenerator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/P2DependencyTreeGenerator.java
@@ -68,7 +68,7 @@ public final class P2DependencyTreeGenerator {
      * Calculates and returns the dependency tree of the given Maven project. The list that is
      * returned by this method corresponds to the IUs which are directly required by the given
      * project.
-     * 
+     *
      * @param project
      *            One of the Maven projects of the current reactor build. If this project is not a
      *            Tycho project (e.g. the parent pom), an empty list is returned.
@@ -107,7 +107,7 @@ public final class P2DependencyTreeGenerator {
      * parent. Each IU is unique and must only appear once in the dependency tree.
      */
     public static class DependencyTreeNode {
-        private static final Comparator<IInstallableUnit> COMPARATOR = Comparator.comparing(IInstallableUnit::getId,
+        public static final Comparator<IInstallableUnit> COMPARATOR = Comparator.comparing(IInstallableUnit::getId,
                 String.CASE_INSENSITIVE_ORDER);
         private final IInstallableUnit iu;
         private final IRequirement satisfies;
@@ -144,7 +144,7 @@ public final class P2DependencyTreeGenerator {
          * each IU of {@code initial}. The children of a node correspond to all IUs that are
          * (directly) required by the parent IU. Each IU in {@code units} only appears once, even if
          * it required by multiple IUs.
-         * 
+         *
          * @param initial
          *            The "direct" IUs referenced by a given artifact.
          * @param units
@@ -175,7 +175,7 @@ public final class P2DependencyTreeGenerator {
          * is found, it is removed from {@code units}, meaning that each IU can only show up once in
          * the dependency tree. The children of each node are sorted lexicographically according to
          * {@link #COMPARATOR}.
-         * 
+         *
          * @param node
          *            The (intermediate) head of the dependency tree.
          * @param units

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/DependenciesTreeMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/DependenciesTreeMojo.java
@@ -10,6 +10,7 @@
 package org.eclipse.tycho.plugins.p2;
 
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -76,14 +77,16 @@ public class DependenciesTreeMojo extends AbstractMojo {
             throw new MojoFailureException(e);
         }
 
-        for (DependencyTreeNode rootNode : dependencyTree) {
+        for (DependencyTreeNode rootNode : dependencyTree.stream()
+                .sorted(Comparator.comparing(DependencyTreeNode::getInstallableUnit, DependencyTreeNode.COMPARATOR))
+                .toList()) {
             printUnit(rootNode, projectMap, 0);
         }
 
         if (!unmapped.isEmpty()) {
             getLog().info("Units that cannot be matched to any requirement:");
-            for (IInstallableUnit unit : unmapped) {
-                getLog().info(unit.toString());
+            for (IInstallableUnit unit : unmapped.stream().sorted(DependencyTreeNode.COMPARATOR).toList()) {
+                getLog().info("   " + unit.toString());
             }
         }
 


### PR DESCRIPTION
Also indent the unmapped IUs for better readability.

Fixes #3817

Looks like this afterwards: 
![grafik](https://github.com/eclipse-tycho/tycho/assets/406876/75eeff44-e1f8-4476-a125-0e5a82663468)
