### PR TITLE
set-version: Fix regression overwriting mismatching versions

### DIFF
--- a/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/p/m1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/p/m1/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Test Bundle
+Bundle-SymbolicName: m1
+Bundle-Version: 1.0.0

--- a/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/p/m1/pom.xml
+++ b/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/p/m1/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.tycho.its</groupId>
+		<artifactId>p</artifactId>
+		<version>1.0.0</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<groupId>org.tycho.its</groupId>
+	<artifactId>m1</artifactId>
+	<version>1.0.0</version>
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/p/pom.xml
+++ b/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/p/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>org.tycho.its</groupId>
+		<artifactId>root</artifactId>
+		<version>1.0.0</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<groupId>org.tycho.its</groupId>
+	<artifactId>p</artifactId>
+	<version>1.0.0</version><!-- This is the SAME version as the root -->
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>m1</module>
+	</modules>
+
+</project>

--- a/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/pom.xml
+++ b/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.tycho.its</groupId>
+	<artifactId>root</artifactId>
+	<version>1.0.0</version>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>p</module>
+		<module>q</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/q/m2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/q/m2/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Test Bundle
+Bundle-SymbolicName: m2
+Bundle-Version: 2.0.0

--- a/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/q/m2/pom.xml
+++ b/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/q/m2/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.tycho.its</groupId>
+		<artifactId>q</artifactId>
+		<version>2.0.0</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<groupId>org.tycho.its</groupId>
+	<artifactId>m2</artifactId>
+	<version>2.0.0</version>
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/q/pom.xml
+++ b/tycho-its/projects/tycho-version-plugin/set-version/only_same_version/q/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>org.tycho.its</groupId>
+		<artifactId>root</artifactId>
+		<version>1.0.0</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<groupId>org.tycho.its</groupId>
+	<artifactId>q</artifactId>
+	<version>2.0.0</version><!-- This is DIFFERENT than the version of the root -->
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>m2</module>
+	</modules>
+
+</project>

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/PomManipulator.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/PomManipulator.java
@@ -86,7 +86,8 @@ public class PomManipulator extends AbstractMetadataManipulator {
                             .ifPresent(moduleMeta -> {
                                 PomFile modulePom = moduleMeta.getMetadata(PomFile.class);
                                 if (modulePom != null && modulePom.isMutable()
-                                        && POM.equals(modulePom.getPackaging())) {
+                                        && POM.equals(modulePom.getPackaging())
+                                        && isVersionEquals(modulePom.getVersion(), change.getVersion())) {
                                     if (versionChangeContext.addVersionChange(
                                             new PomVersionChange(modulePom, change.getNewVersion()))) {
                                         moreChanges.set(true);


### PR DESCRIPTION
Fix regression introduced in #3343.

Also for the child modules the version of the change must match, so that it does not blindly overwrite the versions of the submodules.

Fixes #3808.