### PR TITLE
Always use full-named o.e.equinox.launcher artifact

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactDependencyWalker.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactDependencyWalker.java
@@ -28,7 +28,6 @@ import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.DependencyArtifacts;
-import org.eclipse.tycho.PlatformPropertiesUtils;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.core.ArtifactDependencyVisitor;
@@ -128,18 +127,7 @@ public abstract class AbstractArtifactDependencyWalker implements ArtifactDepend
                 String os = environment.getOs();
                 String ws = environment.getWs();
                 String arch = environment.getArch();
-
-                String id;
-
-                // for Mac OS X there is no org.eclipse.equinox.launcher.carbon.macosx.x86 or org.eclipse.equinox.launcher.carbon.macosx.ppc folder,
-                // only a org.eclipse.equinox.launcher.carbon.macosx folder.
-                // see https://jira.codehaus.org/browse/MNGECLIPSE-1075
-                if (PlatformPropertiesUtils.OS_MACOSX.equals(os) && (PlatformPropertiesUtils.ARCH_X86.equals(arch)
-                        || PlatformPropertiesUtils.ARCH_PPC.equals(arch))) {
-                    id = "org.eclipse.equinox.launcher." + ws + "." + os;
-                } else {
-                    id = "org.eclipse.equinox.launcher." + ws + "." + os + "." + arch;
-                }
+                String id = "org.eclipse.equinox.launcher." + ws + "." + os + "." + arch;
 
                 if (!bundles.contains(id)) {
                     PluginRef ref = new PluginRef("plugin");


### PR DESCRIPTION
For for Mac OS X there was no equinox-launcher fragment for CARBON with full name, i.e. with <ws>.<os>.<arch> suffix, but only a org.eclipse.equinox.launcher.carbon.macosx fragment. But since Eclipse 4.2, released 2012, CARBON is not supported anymore at all [1]. Therefore the code adjust to that special naming schema, which also imposed difficulties or new supported architectures on Macos should be removed.

See also https://github.com/eclipse-equinox/equinox/pull/622

[1] - https://download.eclipse.org/eclipse/updates/4.2/R-4.2-201206081400