### PR TITLE
Remove equinox-launcher fragments handling in AbstractArtifactDependencyWalker

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactDependencyWalker.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactDependencyWalker.java
@@ -28,7 +28,6 @@ import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.DependencyArtifacts;
-import org.eclipse.tycho.PlatformPropertiesUtils;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.core.ArtifactDependencyVisitor;
@@ -120,35 +119,6 @@ public abstract class AbstractArtifactDependencyWalker implements ArtifactDepend
             ArtifactKey key = artifact.getKey();
             if (ArtifactType.TYPE_ECLIPSE_PLUGIN.equals(key.getType())) {
                 bundles.add(key.getId());
-            }
-        }
-
-        if (environments != null && product.includeLaunchers()) {
-            for (TargetEnvironment environment : environments) {
-                String os = environment.getOs();
-                String ws = environment.getWs();
-                String arch = environment.getArch();
-
-                String id;
-
-                // for Mac OS X there is no org.eclipse.equinox.launcher.carbon.macosx.x86 or org.eclipse.equinox.launcher.carbon.macosx.ppc folder,
-                // only a org.eclipse.equinox.launcher.carbon.macosx folder.
-                // see https://jira.codehaus.org/browse/MNGECLIPSE-1075
-                if (PlatformPropertiesUtils.OS_MACOSX.equals(os) && (PlatformPropertiesUtils.ARCH_X86.equals(arch)
-                        || PlatformPropertiesUtils.ARCH_PPC.equals(arch))) {
-                    id = "org.eclipse.equinox.launcher." + ws + "." + os;
-                } else {
-                    id = "org.eclipse.equinox.launcher." + ws + "." + os + "." + arch;
-                }
-
-                if (!bundles.contains(id)) {
-                    PluginRef ref = new PluginRef("plugin");
-                    ref.setId(id);
-                    ref.setOs(os);
-                    ref.setWs(ws);
-                    ref.setArch(arch);
-                    traversePlugin(ref, visitor, visited);
-                }
             }
         }
     }


### PR DESCRIPTION
The AbstractArtifactDependencyWalker is only used to determine the build-qualifier of of features, products and repositories and for that should only consider what's contained in those assembly-artifacts. It therefore should not add any special fragments to the set of considered artifacts.

This also helps to simplify the situation for equinox-launcher fragments for Mac, where still a special treatment for CARBON API artifacts exists, although the  org.eclipse.equinox.launcher.carbon.macosx artifact is not supported anymore since 2012 [1].

Required for https://github.com/eclipse-equinox/equinox/pull/622

[1] - https://download.eclipse.org/eclipse/updates/4.2/R-4.2-201206081400