### PR TITLE
Set the MIRROR_PARSE_ERROR_LEVEL to info severity

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/DefaultProvisioningAgent.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/DefaultProvisioningAgent.java
@@ -21,6 +21,8 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.internal.p2.artifact.repository.MirrorSelector;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
 import org.eclipse.sisu.equinox.EquinoxServiceFactory;
@@ -28,6 +30,10 @@ import org.eclipse.tycho.helper.MavenPropertyHelper;
 
 @Component(role = IProvisioningAgent.class)
 public class DefaultProvisioningAgent implements IProvisioningAgent {
+
+	static {
+		MirrorSelector.MIRROR_PARSE_ERROR_LEVEL = IStatus.INFO;
+	}
 
 	@Requirement
 	private Logger log;


### PR DESCRIPTION
Currently if parsing a mirror url list this results in an error, but the worst that can happen is that no mirrors are used.

In contrast the error gives the user the impression that something has failed completely.