### PR TITLE
Fix qualifier validation when qualifier is empty for release build

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -27,6 +27,7 @@ public interface TychoConstants {
     public static final String NAME_JUSTJ_JRE = "jre";
 
     static final String ANY_QUALIFIER = "qualifier";
+    static final String QUALIFIER_NONE = "none";
 
     static final boolean USE_SMART_BUILDER = Boolean
             .parseBoolean(System.getProperty("tycho.build.smartbuilder", "true"));

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/TychoCiFriendlyVersions.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/TychoCiFriendlyVersions.java
@@ -47,6 +47,7 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.tycho.TychoConstants;
 
 @Priority(100)
 @Component(role = ModelVersionProcessor.class)
@@ -95,7 +96,7 @@ public class TychoCiFriendlyVersions extends DefaultModelVersionProcessor implem
 		} else {
 			String forceContextQualifier = request.getSystemProperties().getProperty(PROPERTY_FORCE_QUALIFIER);
 			if (forceContextQualifier != null) {
-				modelProperties.put(BUILD_QUALIFIER, "." + forceContextQualifier);
+				modelProperties.put(BUILD_QUALIFIER, TychoConstants.QUALIFIER_NONE.equals(forceContextQualifier) ? "" : "." + forceContextQualifier);
 			} else {
 				String formatString = request.getSystemProperties().getProperty(PROPERTY_BUILDQUALIFIER_FORMAT);
 				if (formatString != null) {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
@@ -100,11 +100,10 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 	}
 
 	@Test
-	public void testReleaseBuildQualifier() throws Exception {
+	public void testReleaseBuildWithForcedContextQualifier() throws Exception {
 		Verifier verifier = getVerifier("ci-friendly/buildqualifier", false, true);
-		// this uses an empty/release qualifier
-		verifier.addCliOption("-Dqualifier=");
-		verifier.addCliOption("-Dtycho.buildqualifier.format=");
+		// this uses force context qualifier set to none
+		verifier.addCliOption("-DforceContextQualifier=none");
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0.jar");

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
@@ -99,6 +99,19 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		checkManifestVersion(file, "1.0.0.zzz");
 	}
 
+	@Test
+	public void testReleaseBuildQualifier() throws Exception {
+		Verifier verifier = getVerifier("ci-friendly/buildqualifier", false, true);
+		// this uses an empty/release qualifier
+		verifier.addCliOption("-Dqualifier=");
+		verifier.addCliOption("-Dtycho.buildqualifier.format=");
+		verifier.executeGoals(List.of("clean", "package"));
+		verifier.verifyErrorFreeLog();
+		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0.jar");
+		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		checkManifestVersion(file, "1.0.0");
+	}
+
 	private static void checkManifestVersion(File file, String expectedVersion) throws IOException {
 		try (JarFile jarFile = new JarFile(file)) {
 			assertEquals(expectedVersion, jarFile.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION));

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
@@ -175,7 +175,9 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
         }
 		String qualifier = getDesiredQualifier(timestamp);
 
-        validateQualifier(qualifier);
+		if (!"".equals(qualifier)) {
+			validateQualifier(qualifier);
+		}
 
 		String pomOSGiVersion = getUnqualifiedVersion();
 		String suffix = "." + qualifier;

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
@@ -188,26 +188,26 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
 		return new TychoProjectVersion(pomOSGiVersion, qualifier);
     }
 
-	protected String getDesiredQualifier(String forceContextQualifier, Date timestamp) throws MojoExecutionException {
-		String qualifier = forceContextQualifier;
-		if (TychoConstants.QUALIFIER_NONE.equals(qualifier)) {
-			qualifier = "";
-		}
+    protected String getDesiredQualifier(String forceContextQualifier, Date timestamp) throws MojoExecutionException {
+        String qualifier = forceContextQualifier;
+        if (TychoConstants.QUALIFIER_NONE.equals(qualifier)) {
+            qualifier = "";
+        }
 
         if (qualifier == null) {
             qualifier = getQualifier(timestamp);
         }
-		return qualifier;
-	}
+        return qualifier;
+    }
 
-	private String getForceContextQualifier() {
-		String qualifier = forceContextQualifier;
+    private String getForceContextQualifier() {
+        String qualifier = forceContextQualifier;
 
         if (qualifier == null) {
-			qualifier = buildPropertiesParser.parse(DefaultReactorProject.adapt(project)).getForceContextQualifier();
+            qualifier = buildPropertiesParser.parse(DefaultReactorProject.adapt(project)).getForceContextQualifier();
         }
-		return qualifier;
-	}
+        return qualifier;
+    }
 
     private Version getParsedOSGiVersion() throws MojoFailureException {
         String osgiVersionString = getOSGiVersion();
@@ -222,10 +222,10 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
         }
     }
 
-	void validateQualifier(String forceContextQualifier, String qualifier) throws MojoFailureException {
-		if (TychoConstants.QUALIFIER_NONE.equals(forceContextQualifier)) {
-			return;
-		}
+    void validateQualifier(String forceContextQualifier, String qualifier) throws MojoFailureException {
+        if (TychoConstants.QUALIFIER_NONE.equals(forceContextQualifier)) {
+            return;
+        }
         // parse a valid version with the given qualifier to check if the qualifier is valid
         try {
             Version.parseVersion("1.0.0." + qualifier);

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
@@ -173,11 +173,11 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
                 return new TychoProjectVersion(unqualifiedVersion, osgiVersion.getQualifier());
             }
         }
-		String qualifier = getDesiredQualifier(timestamp);
 
-		if (!"".equals(qualifier)) {
-			validateQualifier(qualifier);
-		}
+		String forceContextQualifier = getForceContextQualifier();
+		String qualifier = getDesiredQualifier(forceContextQualifier, timestamp);
+
+		validateQualifier(forceContextQualifier, qualifier);
 
 		String pomOSGiVersion = getUnqualifiedVersion();
 		String suffix = "." + qualifier;
@@ -188,15 +188,23 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
 		return new TychoProjectVersion(pomOSGiVersion, qualifier);
     }
 
-	protected String getDesiredQualifier(Date timestamp) throws MojoExecutionException {
+	protected String getDesiredQualifier(String forceContextQualifier, Date timestamp) throws MojoExecutionException {
+		String qualifier = forceContextQualifier;
+		if (TychoConstants.QUALIFIER_NONE.equals(qualifier)) {
+			qualifier = "";
+		}
+
+        if (qualifier == null) {
+            qualifier = getQualifier(timestamp);
+        }
+		return qualifier;
+	}
+
+	private String getForceContextQualifier() {
 		String qualifier = forceContextQualifier;
 
         if (qualifier == null) {
 			qualifier = buildPropertiesParser.parse(DefaultReactorProject.adapt(project)).getForceContextQualifier();
-        }
-
-        if (qualifier == null) {
-            qualifier = getQualifier(timestamp);
         }
 		return qualifier;
 	}
@@ -214,7 +222,10 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
         }
     }
 
-    void validateQualifier(String qualifier) throws MojoFailureException {
+	void validateQualifier(String forceContextQualifier, String qualifier) throws MojoFailureException {
+		if (TychoConstants.QUALIFIER_NONE.equals(forceContextQualifier)) {
+			return;
+		}
         // parse a valid version with the given qualifier to check if the qualifier is valid
         try {
             Version.parseVersion("1.0.0." + qualifier);


### PR DESCRIPTION
Fixes https://github.com/eclipse-tycho/tycho/issues/3887

The fix allows to skip qualifier validation when qualifier is empty for release build defined using maven CI friendly versions.
The provided integration test verifies that build is not failing on validation and proceeds further.