### PR TITLE
Fix [DS] Validation of transitive generated 'osgi.extender=osgi.component' requirement fails

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/ReactorProjectIdentities.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/ReactorProjectIdentities.java
@@ -46,4 +46,10 @@ public abstract class ReactorProjectIdentities {
         return Objects.hash(getArtifactId(), getGroupId(), getVersion());
     }
 
+    @Override
+    public String toString() {
+        return "ReactorProjectIdentities [GroupId=" + getGroupId() + ", ArtifactId=" + getArtifactId() + ", Version="
+                + getVersion() + ", Basedir=" + getBasedir() + "]";
+    }
+
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
@@ -451,8 +451,7 @@ public class P2GeneratorImpl extends AbstractMetadataGenerator implements P2Gene
         PublisherOptions options = new PublisherOptions();
         options.setGenerateDownloadStats(generateDownloadStatsProperty);
         options.setGenerateChecksums(generateChecksums);
-        Map<String, IP2Artifact> generatedMetadata = generateMetadata(artifacts, options, targetDir);
-        return generatedMetadata;
+        return generateMetadata(artifacts, options, targetDir);
     }
 
     @Override

--- a/tycho-its/projects/eeProfile.resolution.fragments/org.eclipse.swt.gtk.linux.x86/pom.xml
+++ b/tycho-its/projects/eeProfile.resolution.fragments/org.eclipse.swt.gtk.linux.x86/pom.xml
@@ -13,5 +13,20 @@
 	<artifactId>org.eclipse.swt.gtk.linux.x86</artifactId>
 	<version>3.102.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
-
+	<build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+                <configuration>
+                    <dependency-resolution>
+                        <optionalDependencies>ignore</optionalDependencies>
+                        <profileProperties>
+                            <org.eclipse.swt.buildtime>true</org.eclipse.swt.buildtime>
+                        </profileProperties>
+                    </dependency-resolution>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tycho-its/projects/tycho-ds-dependency/.mvn/extensions.xml
+++ b/tycho-its/projects/tycho-ds-dependency/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>${tycho-version}</version>
+  </extension>
+</extensions>

--- a/tycho-its/projects/tycho-ds-dependency/.mvn/maven.config
+++ b/tycho-its/projects/tycho-ds-dependency/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho.localArtifacts=ignore

--- a/tycho-its/projects/tycho-ds-dependency/plugin.a/.classpath
+++ b/tycho-its/projects/tycho-ds-dependency/plugin.a/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/tycho-its/projects/tycho-ds-dependency/plugin.a/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-ds-dependency/plugin.a/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: plugin.a
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Import-Package: org.osgi.service.event;version="[1.4.0,2.0.0)"

--- a/tycho-its/projects/tycho-ds-dependency/plugin.a/build.properties
+++ b/tycho-its/projects/tycho-ds-dependency/plugin.a/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/tycho-ds-dependency/plugin.a/src/foo/bar/MyComponent.java
+++ b/tycho-its/projects/tycho-ds-dependency/plugin.a/src/foo/bar/MyComponent.java
@@ -1,0 +1,12 @@
+package foo.bar;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.Event;
+
+@Component(service = EventHandler.class)
+public class MyComponent implements EventHandler {
+	@Override
+	public void handleEvent(Event event) {
+	}
+}

--- a/tycho-its/projects/tycho-ds-dependency/plugin.b/.classpath
+++ b/tycho-its/projects/tycho-ds-dependency/plugin.b/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/tycho-its/projects/tycho-ds-dependency/plugin.b/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-ds-dependency/plugin.b/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: plugin.b
+Bundle-Version: 1.0.0.qualifier
+Require-Bundle: plugin.a;bundle-version="1.0.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/tycho-ds-dependency/plugin.b/build.properties
+++ b/tycho-its/projects/tycho-ds-dependency/plugin.b/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/tycho-ds-dependency/pom.xml
+++ b/tycho-its/projects/tycho-ds-dependency/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>foo</groupId>
+	<artifactId>foo</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>plugin.a</module>
+		<module>plugin.b</module>
+	</modules>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>platform</id>
+			<url>${target-platform}</url>
+			<layout>p2</layout>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-ds-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<dsVersion>1.4</dsVersion>
+					<enabled>true</enabled>
+				</configuration>
+			</plugin>
+
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathEntryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathEntryTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -87,6 +88,15 @@ public class CompilerClasspathEntryTest extends AbstractTychoIntegrationTest {
 		File generated = new File(verifier.getBasedir(), "target/classes/OSGI-INF");
 		assertTrue(new File(generated, "tycho.ds.TestComponent.xml").isFile());
 		assertFalse(new File(generated, "tycho.ds.TestComponent2.xml").isFile());
+	}
+
+	@Test
+	public void testTransitiveDSComponents() throws Exception {
+		Verifier verifier = getVerifier("tycho-ds-dependency", true, true);
+		verifier.executeGoals(List.of("clean", "verify"));
+		verifier.verifyErrorFreeLog();
+		Path generated = Path.of(verifier.getBasedir(), "plugin.a/target/classes/OSGI-INF");
+		assertTrue(Files.isRegularFile(generated.resolve("foo.bar.MyComponent.xml")));
 	}
 
 	@Test


### PR DESCRIPTION
Currently Tycho always uses the `INITIAL` dependency metadata to compute
the preliminary target platform. As this metadata can change once the
project is packed (e.g. headers added / removed) this can lead to
problems in plugins that depend on the changed plugin because P2 sees
the updated metadata afterwards and fails.

This now distinguish both cases and used the `SEED` metadata if the
project was already packed.

Fix https://github.com/eclipse-tycho/tycho/issues/3824