### PR TITLE
Remove no longer valid checksum properties

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/RecreateRepositoryApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/RecreateRepositoryApplication.java
@@ -151,8 +151,22 @@ public class RecreateRepositoryApplication extends AbstractApplication {
                     }
                     Map<String, String> checksumsToProperties = ChecksumUtilities
                             .checksumsToProperties(IArtifactDescriptor.DOWNLOAD_CHECKSUM, checksums);
+                    //remove checksums that are no longer marked for publishing
+                    String checksumProperty = IArtifactDescriptor.DOWNLOAD_CHECKSUM + ".";
+                    for (String property : newDescriptor.getProperties().keySet().toArray(String[]::new)) {
+                        if (property.startsWith(checksumProperty)) {
+                            String id = property.substring(checksumProperty.length());
+                            if (checksumsToProperties.containsKey(id)) {
+                                continue;
+                            }
+                            newDescriptor.setProperty(checksumProperty + id, null);
+                        }
+                    }
+                    //remove legacy property if present
+                    if (!checksumsToProperties.containsKey("md5")) {
+                        newDescriptor.setProperty("download.md5", null);
+                    }
                     newDescriptor.addProperties(checksumsToProperties);
-
                     repository.addDescriptor(newDescriptor, null);
                 }
             }

--- a/tycho-its/projects/p2Repository.fixArtifactsMetadata.oldChecksums/category.xml
+++ b/tycho-its/projects/p2Repository.fixArtifactsMetadata.oldChecksums/category.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <bundle id="org.slf4j.api" version="0.0.0"/>
+</site>

--- a/tycho-its/projects/p2Repository.fixArtifactsMetadata.oldChecksums/pom.xml
+++ b/tycho-its/projects/p2Repository.fixArtifactsMetadata.oldChecksums/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project.p2Repository.fixArtifactsMetadata.oldChecksums</groupId>
+	<artifactId>pfo.repository</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>eclipse-repository</packaging>
+
+	<properties>
+		<tycho-version>4.0.8</tycho-version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>test.target</file>
+					</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>fix</id>
+						<goals>
+							<goal>fix-artifacts-metadata</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>verify</id>
+						<goals>
+							<goal>verify-repository</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2Repository.fixArtifactsMetadata.oldChecksums/test.target
+++ b/tycho-its/projects/p2Repository.fixArtifactsMetadata.oldChecksums/test.target
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+
+<target name="p2Repository.fixArtifactsMetadata.oldChecksums.target" sequenceNumber="1">
+
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
+			<unit id="org.slf4j.api" version="0.0.0"/>
+
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository/"/>
+		</location>
+	</locations>
+
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryFixArtifactsMetadataOldChecksumsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryFixArtifactsMetadataOldChecksumsTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin D'Aloia and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.test.p2Repository;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.maven.it.Verifier;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+import org.tukaani.xz.XZInputStream;
+
+/**
+ * Test that the goal `tycho-p2-repository:fix-artifacts-metadata` removes
+ * old checksums if they are present in the source metadata.
+ * New p2 libs are configured to not publish them anymore.
+ * <p>
+ * If not removed, they are checked during the product assembly and because
+ * they continue to keep an old value (if a IU was modified for example to
+ * (re)sign it) this step fails to complete due to checksum mismatch.
+ *
+ * See https://github.com/eclipse-tycho/tycho/issues/2875
+ */
+public class P2RepositoryFixArtifactsMetadataOldChecksumsTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testRemoveOldChecksumsNotRecalculated() throws Exception {
+		Verifier verifier = getVerifier("/p2Repository.fixArtifactsMetadata.oldChecksums", false);
+		verifier.executeGoals(asList("verify"));
+		verifier.verifyErrorFreeLog();
+
+		Path repositoryPath = Path.of(verifier.getBasedir(), "target/repository");
+		Path artifactPath = repositoryPath.resolve("artifacts.xml.xz");
+		assertTrue(artifactPath.toFile().isFile());
+
+		Xpp3Dom dom;
+		try (XZInputStream stream = new XZInputStream(Files.newInputStream(artifactPath))) {
+			dom = Xpp3DomBuilder.build(stream, StandardCharsets.UTF_8.displayName());
+		} catch (IOException | XmlPullParserException e) {
+			fail(e.getMessage());
+			throw e;
+		}
+
+		Map<String, String> artifactProperties = getArtifactProperties(dom, "org.slf4j.api");
+
+		String[] checksumsThatMustNotBePresent = {"download.md5", "download.checksum.md5"};
+		for(String checksumKey : checksumsThatMustNotBePresent) {
+			String checksumValue = artifactProperties.get(checksumKey);
+
+			assertNull("Property '" + checksumKey + "' is present in artifacts metadata", checksumValue);
+		}
+	}
+
+	private Map<String, String> getArtifactProperties(Xpp3Dom element, String artifactId) {
+		return Arrays.stream(element.getChild("artifacts").getChildren())
+				.filter(it -> artifactId.equals(it.getAttribute("id")))
+				.flatMap(it -> Arrays.stream(it.getChild("properties").getChildren()))
+				.collect(Collectors.toMap(it -> it.getAttribute("name"), it -> it.getAttribute("value")));
+	}
+
+}


### PR DESCRIPTION
Currently Tycho/P2 only *adds* checksums but as some are now disabled for publish this can lead to the case where an existing checksum is kept as-is.

This now performs and additional check if there are old checksums and remove them when recreate the repository.

This should fix 
- https://github.com/eclipse-tycho/tycho/issues/2875

but a testcase is missing.