### PR TITLE
Use dependency metadata instead of MavenProjectDependencyProcessor

### DIFF
--- a/tycho-its/projects/sbom/.mvn/maven.config
+++ b/tycho-its/projects/sbom/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Dtycho-version=5.0.0-SNAPSHOT
+-Dtycho.localArtifacts=ignore

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/reactor/BomCreationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/reactor/BomCreationTest.java
@@ -19,7 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.maven.it.Verifier;
 import org.cyclonedx.exception.ParseException;
@@ -242,7 +244,8 @@ public class BomCreationTest extends AbstractTychoIntegrationTest {
 	}
 
 	private void verifyDependency(List<Dependency> dependencies, String ref) {
-		if (dependencies.stream().noneMatch(dependency -> match(dependency, ref))) {
+		if (Optional.ofNullable(dependencies).stream().flatMap(Collection::stream)
+				.noneMatch(dependency -> match(dependency, ref))) {
 			fail("No dependency found matching: " + ref);
 		}
 	}


### PR DESCRIPTION
Currently full dependency closure is computed to determine if a unit is a reactor project. Instead one could/should use the dependency metadata.

FYI @ptziegler 