### PR TITLE
Calculate BOM representation for each IU only once

### DIFF
--- a/tycho-sbom/src/main/java/org/eclipse/tycho/sbom/TychoProjectDependenciesConverter.java
+++ b/tycho-sbom/src/main/java/org/eclipse/tycho/sbom/TychoProjectDependenciesConverter.java
@@ -13,12 +13,14 @@
 package org.eclipse.tycho.sbom;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
 
@@ -53,6 +55,8 @@ public class TychoProjectDependenciesConverter extends DefaultProjectDependencie
 
 	@Inject
 	private P2DependencyTreeGenerator dependencyGenerator;
+
+	private final Map<IInstallableUnit, List<String>> bomRepresentations = new ConcurrentHashMap<>();
 
 	@Override
 	public void cleanupBomDependencies(Metadata metadata, Map<String, Component> components,
@@ -108,38 +112,38 @@ public class TychoProjectDependenciesConverter extends DefaultProjectDependencie
 	 * empty list is returned.
 	 * 
 	 * @param iu The installable unit for which to generate
-	 * @return A {@code mutable} list of all bom representation. matching the given
-	 *         IU.
+	 * @return An {@code immutable} list of all bom representations matching the
+	 *         given IU.
 	 */
 	private List<String> getBomRepresentation(IInstallableUnit iu) {
-		final MavenSession mavenSession = legacySupport.getSession();
-		final List<MavenProject> reactorProjects = mavenSession.getAllProjects();
-		// mutable!
-		List<String> bomRefs = new ArrayList<>();
-		// (I) IU describes local reactor project
-		for (MavenProject project : reactorProjects) {
-			ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-			Set<IInstallableUnit> initalUnits = reactorProject.getDependencyMetadata(DependencyMetadataType.INITIAL);
-			Set<IInstallableUnit> seedUnits = reactorProject.getDependencyMetadata(DependencyMetadataType.SEED);
-			if (initalUnits.contains(iu) || seedUnits.contains(iu)) {
-				String bomRef = modelConverter.generatePackageUrl(project.getArtifact());
+		return bomRepresentations.computeIfAbsent(iu, ignore -> {
+			final MavenSession mavenSession = legacySupport.getSession();
+			final List<MavenProject> reactorProjects = mavenSession.getAllProjects();
+			// (I) IU describes local reactor project
+			for (MavenProject project : reactorProjects) {
+				ReactorProject reactorProject = DefaultReactorProject.adapt(project);
+				Set<IInstallableUnit> initalUnits = reactorProject.getDependencyMetadata(DependencyMetadataType.INITIAL);
+				Set<IInstallableUnit> seedUnits = reactorProject.getDependencyMetadata(DependencyMetadataType.SEED);
+				if (initalUnits.contains(iu) || seedUnits.contains(iu)) {
+					String bomRef = modelConverter.generatePackageUrl(project.getArtifact());
+					if (bomRef == null) {
+						LOG.error("Unable to calculate BOM for: " + project);
+						return Collections.emptyList();
+					}
+					return Collections.singletonList(bomRef);
+				}
+			}
+			// (II) IU describes external artifact
+			final List<String> bomRefs = new ArrayList<>();
+			for (IArtifactKey p2artifactKey : iu.getArtifacts()) {
+				String bomRef = modelConverter.generateP2PackageUrl(p2artifactKey, true, true, false);
 				if (bomRef == null) {
-					LOG.error("Unable to calculate BOM for: " + project);
-					return bomRefs;
+					LOG.error("Unable to calculate BOM for: " + p2artifactKey);
+					continue;
 				}
 				bomRefs.add(bomRef);
-				return bomRefs;
 			}
-		}
-		// (II) IU describes external artifact
-		for (IArtifactKey p2artifactKey : iu.getArtifacts()) {
-			String bomRef = modelConverter.generateP2PackageUrl(p2artifactKey, true, true, false);
-			if (bomRef == null) {
-				LOG.error("Unable to calculate BOM for: " + p2artifactKey);
-				continue;
-			}
-			bomRefs.add(bomRef);
-		}
-		return bomRefs; // mutable!
+			return Collections.unmodifiableList(bomRefs);
+		});
 	}
 }


### PR DESCRIPTION
The BOM representation is currently calculated twice for each artifact. Within a reactor build, such IUs should always produce the same BOM representation and should therefore be cached.

Resolves https://github.com/eclipse-tycho/tycho/issues/3911