### PR TITLE
Check that the 34 test is seeing an older version

### DIFF
--- a/tycho-its/projects/TYCHO0367localRepositoryCrosstalk/bundle02/src/TYCHO0367localRepositoryCrosstalk/bundle02/Eclipse35Test.java
+++ b/tycho-its/projects/TYCHO0367localRepositoryCrosstalk/bundle02/src/TYCHO0367localRepositoryCrosstalk/bundle02/Eclipse35Test.java
@@ -25,7 +25,7 @@ public class Eclipse35Test extends TestCase {
         Bundle equinox = getBundle("org.eclipse.osgi");
 
         assertEquals(3, equinox.getVersion().getMajor());
-        assertEquals(20, equinox.getVersion().getMinor());
+        assertTrue(equinox.getVersion().getMinor() > 13);
     }
 
     public Bundle getBundle(String id) {


### PR DESCRIPTION
Exact version check complicates things as it has to be updated for every minor bump of equinox.

FYI @akurtakov  so we do not need to increment this on every equinox change!