### PR TITLE
use SPDX identifier for license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	</ciManagement>
 	<licenses>
 		<license>
-			<name>Eclipse Public License</name>
+			<name>EPL-2.0</name>
 			<url>https://www.eclipse.org/legal/epl-v20.html</url>
 			<distribution>repo</distribution>
 		</license>


### PR DESCRIPTION
As recommended by https://maven.apache.org/pom.html#Licenses. This simplifies using the license-maven-plugin due to less manual license mapping.