### PR TITLE
Fix display of logo in readme after master->main branch change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Eclipse Tycho](https://github.com/eclipse-tycho/tycho/blob/master/assets/LOGO%20TYCHO_README.png)
+![Eclipse Tycho](https://github.com/eclipse-tycho/tycho/blob/main/assets/LOGO%20TYCHO_README.png)
 =============
 
 [![Build Tycho](https://github.com/eclipse-tycho/tycho/actions/workflows/maven.yml/badge.svg)](https://github.com/eclipse-tycho/tycho/actions/workflows/maven.yml) [![Unit Test Results](https://github.com/eclipse-tycho/tycho/actions/workflows/check.yml/badge.svg)](https://github.com/eclipse-tycho/tycho/actions/workflows/check.yml) [![License check](https://github.com/eclipse-tycho/tycho/actions/workflows/licensecheck.yml/badge.svg)](https://github.com/eclipse-tycho/tycho/actions/workflows/licensecheck.yml)


### PR DESCRIPTION
Here is how README is displayed in GitHub without this change:

<img width="908" alt="Screenshot 2024-07-30 at 10 21 28" src="https://github.com/user-attachments/assets/4ebddb8f-bfc4-4ebb-9c8d-69c21bd0db0c">
