### PR TITLE
Do not update to the next major version unless explicitly requested

### DIFF
--- a/tycho-its/projects/tycho-version-bump-plugin/update-target/update-target.target
+++ b/tycho-its/projects/tycho-version-bump-plugin/update-target/update-target.target
@@ -17,6 +17,18 @@
 					<version>1.2</version>
 					<type>jar</type>
 				</dependency>
+				<dependency>
+					<groupId>jakarta.annotation</groupId>
+					<artifactId>jakarta.annotation-api</artifactId>
+					<version>1.3.5</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>jakarta.annotation</groupId>
+					<artifactId>jakarta.annotation-api</artifactId>
+					<version>2.0.0</version>
+					<type>jar</type>
+				</dependency>
 			</dependencies>
 		</location>
 	</locations>


### PR DESCRIPTION
Currently the update-target mojo just updates to the highest version, but in some cases it is desirable to not update to the next "major" version.

This adds a new parameter to prevent major updates unless explicitly requested.