### PR TITLE
Make dependency to maven-core explicit in tycho-sbom plugin

### DIFF
--- a/tycho-sbom/pom.xml
+++ b/tycho-sbom/pom.xml
@@ -26,6 +26,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.cyclonedx</groupId>
 			<artifactId>cyclonedx-maven-plugin</artifactId>
 			<version>2.8.0</version>


### PR DESCRIPTION
This dependency is indirectly contributed by CycloneDX 2.8.0, but not by 2.8.1. Given that it is required for compilation and to avoid errors when updating this library, is it now added as an explicit dependency.

See https://github.com/eclipse-tycho/tycho/pull/4085