### PR TITLE
Ignore unreleased for major updates when bump target

### DIFF
--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
@@ -143,7 +143,7 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
                         if (!updateMajorVersion) {
                             try {
                                 String[] strings = oldVersion.split("\\.");
-                                mavenDependency.setVersion("[," + (Integer.parseInt(strings[0]) + 1) + ")");
+                                mavenDependency.setVersion("[," + (Integer.parseInt(strings[0]) + 1) + "-alpha)");
                             } catch (RuntimeException e) {
                                 getLog().warn("Can't check for update of " + mavenDependency
                                         + " because the version format is not parseable: " + e);


### PR DESCRIPTION
Due to how maven versions work there are special qualifiers that are interpreted "lower" than the release version without a qualifier leading to unexpected updates.

This adds the "lowest" qualifier (-alpha) so it gets excluded as well.