### PR TITLE
Support updating (sub)incremental versions

### DIFF
--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/MavenLocationUpdater.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/MavenLocationUpdater.java
@@ -13,6 +13,8 @@
 package org.eclipse.tycho.versionbump;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -58,7 +60,9 @@ public class MavenLocationUpdater {
                 Dependency mavenDependency = getDependency(dependency);
                 Artifact dependencyArtifact = helper.createDependencyArtifact(mavenDependency);
                 ArtifactVersions versions = helper.lookupArtifactVersions(dependencyArtifact, false);
-                ArtifactVersion updateVersion = versions.getNewestUpdateWithinSegment(context.getSegment(), false);
+                ArtifactVersion updateVersion = context.getSegments()
+                        .map(seg -> versions.getNewestUpdateWithinSegment(Optional.of(seg), false))
+                        .filter(Objects::nonNull).findFirst().orElse(null);
                 if (updateVersion != null) {
                     String oldVersion = mavenDependency.getVersion();
                     String newVersion = updateVersion.toString();

--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
@@ -21,8 +21,9 @@ import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.Stream.Builder;
 
 import javax.inject.Inject;
 
@@ -89,6 +90,13 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
      */
     @Parameter(property = "allowIncrementalUpdates", defaultValue = "true")
     private boolean allowIncrementalUpdates;
+
+    /**
+     * Whether to allow the subIncremental version number to be changed.
+     *
+     */
+    @Parameter(property = "allowSubIncrementalUpdates", defaultValue = "true")
+    private boolean allowSubIncrementalUpdates;
 
     /**
      * A comma separated list of update site discovery strategies, the following is currently
@@ -205,16 +213,20 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
         }
     }
 
+    boolean isAllowSubIncrementalUpdates() {
+        return allowSubIncrementalUpdates;
+    }
+
     boolean isAllowIncrementalUpdates() {
         return allowIncrementalUpdates;
     }
 
-    boolean isAllowMajorUpdates() {
-        return allowMajorUpdates;
-    }
-
     boolean isAllowMinorUpdates() {
         return allowMinorUpdates;
+    }
+
+    boolean isAllowMajorUpdates() {
+        return allowMajorUpdates;
     }
 
     MavenSession getMavenSession() {
@@ -259,14 +271,21 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
         return mavenRulesUri;
     }
 
-    Optional<Segment> getSegment() {
-        if (isAllowMajorUpdates() && isAllowMinorUpdates() && isAllowIncrementalUpdates()) {
-            return Optional.empty();
+    Stream<Segment> getSegments() {
+        Builder<Segment> builder = Stream.builder();
+        if (isAllowMajorUpdates()) {
+            builder.accept(Segment.MAJOR);
         }
-        if (isAllowMinorUpdates() && isAllowIncrementalUpdates()) {
-            return Optional.of(Segment.MINOR);
+        if (isAllowMinorUpdates()) {
+            builder.accept(Segment.MINOR);
         }
-        return Optional.of(Segment.INCREMENTAL);
+        if (isAllowIncrementalUpdates()) {
+            builder.accept(Segment.INCREMENTAL);
+        }
+        if (isAllowSubIncrementalUpdates()) {
+            builder.accept(Segment.SUBINCREMENTAL);
+        }
+        return builder.build();
     }
 
 }


### PR DESCRIPTION
Currently due to how the underlying library works, if there is only a micro version update it is not considered. Also subincremental versions are only taken into account if major is allowed (what currently include all increments) what is inconsistent.

This now changes the single optional to a stream in order of update hierarchy and let the MavenLocationUpdater choose the first matching update offered and adding an option for subincremental updates as well.