### PR TITLE
Adopt new o.e.e.p2.publisher.eclipse API for IMacOsBundleUrlType

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/ExpandedProduct.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/ExpandedProduct.java
@@ -27,6 +27,7 @@ import org.eclipse.equinox.internal.p2.publisher.eclipse.IProductDescriptor;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductContentType;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
+import org.eclipse.equinox.p2.publisher.eclipse.IMacOsBundleUrlType;
 import org.eclipse.equinox.p2.repository.IRepositoryReference;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.Interpolator;
@@ -289,6 +290,11 @@ class ExpandedProduct implements IProductDescriptor {
     @Override
     public String getVM(String os) {
         return defaults.getVM(os);
+    }
+
+    @Override
+    public List<IMacOsBundleUrlType> getMacOsBundleUrlTypes() {
+        return defaults.getMacOsBundleUrlTypes();
     }
 
 }


### PR DESCRIPTION
After #4246, we can now consume the new

org.eclipse.equinox.internal.p2.publisher.eclipse.IProductDescriptor.getMacOsBundleUrlTypes()

API in the Tycho wrapper
org.eclipse.tycho.p2.tools.publisher.ExpandedProduct.

This is necessary to properly support link handler registrations in product's launchers.

See
https://github.com/eclipse-platform/eclipse.platform.ui/issues/1901 https://github.com/eclipse-equinox/p2/pull/533
for more information.