### PR TITLE
Revert "Add a flag to skip the service-component file check in packaging-plugin"

### DIFF
--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -155,13 +155,6 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 	@Parameter(defaultValue = "true")
 	private boolean deriveHeaderFromSource;
 
-	/**
-	 * If {@code true}, it is checked that the explicitly declared OSGi service
-	 * component files exist.
-	 */
-	@Parameter(defaultValue = "true")
-	private boolean checkServiceComponentFilesExist = true;
-
 	@Component
 	private SourceReferenceComputer soureReferenceComputer;
 
@@ -269,7 +262,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 			checkBinIncludesExist(buildProperties, binIncludesIgnoredForValidation.toArray(new String[0]));
 			// 4. check DS files exits...
 			TychoProject facet = getTychoProjectFacet();
-			if (checkServiceComponentFilesExist && facet instanceof OsgiBundleProject bundleProject) {
+			if (facet instanceof OsgiBundleProject bundleProject) {
 				String components = bundleProject.getManifestValue("Service-Component", project);
 				if (components != null) {
 					if (components.contains("*")) {


### PR DESCRIPTION
Reverts eclipse-tycho/tycho#4280

For the intended use-case this is not necessary anymore and seems to be too specific for a general usage.

For the tycho 4.0.x-line I suggest to deprecate this for removal.

@laeubi Should we do the same for https://github.com/eclipse-tycho/tycho/pull/4279? It's also not necessary anymore for the intended use-case, but seems to be more general and might be useful as such?