### PR TITLE
[tycho-4.0.x] Support version-ranges and no-version for units in IU target locations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,11 @@
 
 This page describes the noteworthy improvements provided by each release of Eclipse Tycho.
 
+## 4.0.10
+
+backports:
+- Support version-ranges and no-version for units in IU target locations
+
 ## 4.0.9
 
 backports:

--- a/tycho-core/src/test/resources/targetresolver/versionRanges.target
+++ b/tycho-core/src/test/resources/targetresolver/versionRanges.target
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="version-ranges">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/eclipse/updates/4.33/R-4.33-202409030240/"/>
+			<unit id="jakarta.activation-api" />
+			<unit id="jakarta.inject.jakarta.inject-api" version="[1.0,2)"/>
+		</location>
+	</locations>
+</target>

--- a/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinitionFile.java
+++ b/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinitionFile.java
@@ -525,6 +525,9 @@ public final class TargetDefinitionFile implements TargetDefinition {
         for (Element unitDom : getChildren(dom, "unit")) {
             String id = unitDom.getAttribute("id");
             String version = unitDom.getAttribute("version");
+			if (version == null || version.isBlank()) {
+				version = "0.0.0";
+			}
             units.add(new Unit(id, version));
         }
         final List<Repository> repositories = new ArrayList<>();


### PR DESCRIPTION
Backport https://github.com/eclipse-tycho/tycho/pull/4361 to tycho-4.0.x

Relates to https://github.com/eclipse-pde/eclipse.pde/pull/1245
