### PR TITLE
buffer file outputs

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/FtpTransportProtocolHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/FtpTransportProtocolHandler.java
@@ -1,14 +1,13 @@
 package org.eclipse.tycho.p2maven.transport;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.net.ftp.*;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
-import org.eclipse.tycho.MavenRepositorySettings.Credentials;
+import static java.lang.String.format;
 
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.net.SocketException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -16,7 +15,18 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static java.lang.String.format;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.net.ftp.FTP;
+import org.apache.commons.net.ftp.FTPClient;
+import org.apache.commons.net.ftp.FTPCmd;
+import org.apache.commons.net.ftp.FTPConnectionClosedException;
+import org.apache.commons.net.ftp.FTPFile;
+import org.apache.commons.net.ftp.FTPReply;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
+import org.eclipse.tycho.MavenRepositorySettings.Credentials;
 
 /**
  * Handles files discovery over the FTP protocol.
@@ -93,7 +103,7 @@ public class FtpTransportProtocolHandler implements TransportProtocolHandler, Di
             final File tempFile = Files.createTempFile(parent.toPath(), "download", ".tmp").toFile();
             tempFile.deleteOnExit();
 
-            try (final OutputStream os = new FileOutputStream(tempFile)) {
+			try (final OutputStream os = new BufferedOutputStream(new FileOutputStream(tempFile))) {
                 if (!client.retrieveFile(remotePath, os)) {
                     final String message = client.getReplyString();
                     throw new IOException(format("Error retrieving file: %s. Message: %s", remotePath, message));

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/SharedHttpCacheStorage.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/SharedHttpCacheStorage.java
@@ -12,11 +12,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2maven.transport;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.text.DateFormat;
@@ -72,7 +74,7 @@ public class SharedHttpCacheStorage implements HttpCache {
 
 	/**
 	 * Fetches the cache entry for this URI
-	 * 
+	 *
 	 * @param uri
 	 * @return
 	 * @throws FileNotFoundException if the URI is know to be not found
@@ -266,7 +268,7 @@ public class SharedHttpCacheStorage implements HttpCache {
 				}
 				response.checkResponseCode();
 				tempFile = File.createTempFile("download", ".tmp", file.getParentFile());
-				try (FileOutputStream os = new FileOutputStream(tempFile)) {
+				try (OutputStream os = new BufferedOutputStream(new FileOutputStream(tempFile))) {
 					response.transferTo(os);
 				} catch (IOException e) {
 					tempFile.delete();
@@ -390,7 +392,7 @@ public class SharedHttpCacheStorage implements HttpCache {
 				}
 			}
 			FileUtils.forceMkdir(file.getParentFile());
-			try (FileOutputStream out = new FileOutputStream(headerFile)) {
+			try (OutputStream out = new BufferedOutputStream(new FileOutputStream(headerFile))) {
 				// we store the header here, this might be a 404 response or (permanent)
 				// redirect we probably need to work with later on
 				header.store(out, null);

--- a/sisu-osgi/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/internal/DefaultEquinoxInstallationFactory.java
+++ b/sisu-osgi/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/internal/DefaultEquinoxInstallationFactory.java
@@ -150,7 +150,7 @@ public class DefaultEquinoxInstallationFactory implements EquinoxInstallationFac
             File configIni = new File(location, TychoConstants.CONFIG_INI_PATH);
             File configurationLocation = configIni.getParentFile();
             configurationLocation.mkdirs();
-            try (FileOutputStream fos = new FileOutputStream(configIni)) {
+            try (OutputStream fos = new BufferedOutputStream(new FileOutputStream(configIni))) {
                 p.store(fos, null);
             }
 
@@ -201,7 +201,7 @@ public class DefaultEquinoxInstallationFactory implements EquinoxInstallationFac
 
     /**
      * See
-     * 
+     *
      * <pre>
      * https://help.eclipse.org/latest/topic/org.eclipse.platform.doc.isv/reference/misc/runtime-options.html#osgidev
      * </pre>

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/EcJLogFileEnhancer.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/EcJLogFileEnhancer.java
@@ -14,11 +14,10 @@ package org.eclipse.tycho.core;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -93,7 +92,7 @@ public class EcJLogFileEnhancer implements AutoCloseable {
             throws IOException, FileNotFoundException {
         for (File file : needsUpdate) {
             Document document = documents.get(file);
-            try (Writer w = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
+            try (Writer w = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8);
                     XMLWriter xw = new XMLWriter(w)) {
                 document.toXML(xw);
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -17,9 +17,8 @@ package org.eclipse.tycho.core.maven;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -129,7 +128,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
         try {
             validate(projects);
 
-            // setting this system property to let EF figure out where the traffic 
+            // setting this system property to let EF figure out where the traffic
             // is coming from (#467418)
             System.setProperty(P2_USER_AGENT_KEY, P2_USER_AGENT_VALUE + TychoVersion.getTychoVersion());
 
@@ -163,8 +162,8 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
                                 Set<MavenProject> visited = new HashSet<>();
                                 modelWriter.write(new File(project.getBasedir(), "pom-model.xml"), Map.of(),
                                         project.getModel());
-                                try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
-                                        new FileOutputStream(new File(project.getBasedir(), "requirements.txt"))))) {
+                                try (BufferedWriter writer = Files.newBufferedWriter(
+                                        new File(project.getBasedir(), "requirements.txt").toPath())) {
                                     writer.write(project.getId() + ":\r\n");
                                     dumpProjectRequirements(project, writer, closure, dependencyProjects, "\t",
                                             visited);
@@ -179,7 +178,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
             }
         } catch (BuildFailureException e) {
             // build failure is not an internal (unexpected) error, so avoid printing a stack
-            // trace by wrapping it in MavenExecutionException   
+            // trace by wrapping it in MavenExecutionException
             throw new MavenExecutionException(e.getMessage(), e);
         }
         buildListeners.notifyBuildStart(session);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/MavenTargetDefinitionContent.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/MavenTargetDefinitionContent.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.resolver;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -368,7 +369,8 @@ public class MavenTargetDefinitionContent implements TargetDefinitionContent {
         attr.putValue(Constants.BUNDLE_NAME, "Source Bundle for " + symbolicName + ":" + bundleVersion);
         attr.putValue(Constants.BUNDLE_SYMBOLICNAME, symbolicName + ".source");
         attr.putValue(Constants.BUNDLE_VERSION, bundleVersion);
-        try (JarOutputStream stream = new JarOutputStream(new FileOutputStream(tempFile), manifest)) {
+        try (JarOutputStream stream = new JarOutputStream(new BufferedOutputStream(new FileOutputStream(tempFile)),
+                manifest)) {
             try (JarFile jar = new JarFile(sourceFile)) {
                 Enumeration<JarEntry> entries = jar.entries();
                 while (entries.hasMoreElements()) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/ArtifactRepositoryBaseImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/ArtifactRepositoryBaseImpl.java
@@ -17,6 +17,7 @@ import static org.eclipse.tycho.p2.repository.ArtifactProviderImplUtilities.canW
 import static org.eclipse.tycho.p2.repository.ArtifactProviderImplUtilities.canWriteToSink;
 import static org.eclipse.tycho.p2.repository.BundleConstants.BUNDLE_ID;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -440,7 +441,7 @@ public abstract class ArtifactRepositoryBaseImpl<ArtifactDescriptorT extends IAr
             artifactFile.getParentFile().mkdirs();
 
             try {
-                currentOutputStream = new FileOutputStream(artifactFile);
+                currentOutputStream = new BufferedOutputStream(new FileOutputStream(artifactFile));
             } catch (FileNotFoundException e) {
                 throw new ArtifactSinkException("I/O error while creating artifact file " + artifactFile, e);
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/FileBasedTychoRepositoryIndex.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/FileBasedTychoRepositoryIndex.java
@@ -110,7 +110,7 @@ public class FileBasedTychoRepositoryIndex implements TychoRepositoryIndex {
             reconcile();
             // minimize time window for corrupting the file by first writing to a temp file, then moving it
             File tempFile = File.createTempFile("index", "tmp", indexFile.getParentFile());
-            write(new FileOutputStream(tempFile));
+            write(new BufferedOutputStream(new FileOutputStream(tempFile)));
             if (indexFile.isFile()) {
                 indexFile.delete();
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/module/ModuleArtifactMap.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/repository/module/ModuleArtifactMap.java
@@ -14,10 +14,12 @@ package org.eclipse.tycho.p2.repository.module;
 
 import static org.eclipse.tycho.p2.repository.BundleConstants.BUNDLE_ID;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -34,7 +36,7 @@ import org.eclipse.tycho.p2.repository.RepositoryReader;
 /**
  * {@link RepositoryReader} that reads the artifact file locations from the
  * "local-artifacts.properties" file.
- * 
+ *
  * @see TychoConstants#FILE_NAME_LOCAL_ARTIFACTS
  */
 class ModuleArtifactMap {
@@ -56,7 +58,7 @@ class ModuleArtifactMap {
     }
 
     private ModuleArtifactMap(File repositoryRoot) {
-        // TODO constant FILE_NAME_LOCAL_ARTIFACTS should only be needed here 
+        // TODO constant FILE_NAME_LOCAL_ARTIFACTS should only be needed here
         this.mapFile = new File(repositoryRoot, TychoConstants.FILE_NAME_LOCAL_ARTIFACTS);
         this.automaticArtifactFolder = new File(repositoryRoot, "extraArtifacts");
     }
@@ -143,7 +145,8 @@ class ModuleArtifactMap {
             if (entry.getKey() == null) {
                 outputProperties.put(TychoConstants.KEY_ARTIFACT_MAIN, entry.getValue().getAbsolutePath());
             } else {
-                outputProperties.put(TychoConstants.KEY_ARTIFACT_ATTACHED + entry.getKey(), entry.getValue().getAbsolutePath());
+                outputProperties.put(TychoConstants.KEY_ARTIFACT_ATTACHED + entry.getKey(),
+                        entry.getValue().getAbsolutePath());
             }
         }
 
@@ -159,7 +162,7 @@ class ModuleArtifactMap {
     }
 
     private static void writeProperties(Properties properties, File outputFile) throws IOException {
-        try (FileOutputStream outputStream = new FileOutputStream(outputFile);) {
+        try (OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(outputFile))) {
             properties.store(outputStream, null);
         }
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/FeatureGenerator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/resolver/FeatureGenerator.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.resolver;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -102,7 +103,7 @@ public class FeatureGenerator {
         }
         File tempFile = File.createTempFile("feature", ".jar");
         tempFile.deleteOnExit();
-        try (JarOutputStream stream = new JarOutputStream(new FileOutputStream(tempFile))) {
+        try (JarOutputStream stream = new JarOutputStream(new BufferedOutputStream(new FileOutputStream(tempFile)))) {
             stream.putNextEntry(new ZipEntry(FEATURE_XML_ENTRY));
             OutputStreamWriter writer = new OutputStreamWriter(stream);
             prettyPrintXml(doc, writer);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -54,7 +56,6 @@ import org.eclipse.equinox.p2.publisher.IPublisherInfo;
 import org.eclipse.equinox.p2.publisher.IPublisherResult;
 import org.eclipse.equinox.p2.publisher.PublisherInfo;
 import org.eclipse.equinox.p2.publisher.actions.IFeatureRootAdvice;
-import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 import org.eclipse.equinox.p2.publisher.eclipse.Feature;
 import org.eclipse.equinox.p2.publisher.eclipse.FeaturesAction;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
@@ -92,6 +93,7 @@ import org.eclipse.tycho.p2.repository.MetadataIO;
 import org.eclipse.tycho.p2maven.actions.CategoryDependenciesAction;
 import org.eclipse.tycho.p2maven.actions.ProductDependenciesAction;
 import org.eclipse.tycho.p2maven.actions.ProductFile2;
+import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 import org.osgi.framework.BundleException;
 
 @Component(role = P2Generator.class)
@@ -485,7 +487,7 @@ public class P2GeneratorImpl extends AbstractMetadataGenerator implements P2Gene
     }
 
     private static void writeProperties(Properties properties, File outputFile) throws IOException {
-        try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
+        try (OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(outputFile))) {
             properties.store(outputStream, null);
         }
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -13,9 +13,11 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2tools;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URLConnection;
@@ -521,7 +523,8 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
         properties.setProperty("version", "1");
         properties.setProperty("artifact.repository.factory.order", "artifacts.xml,!");
         properties.setProperty("metadata.repository.factory.order", "content.xml,!");
-        try (FileOutputStream stream = new FileOutputStream(new File(repositoryDestination, P2_INDEX_FILE))) {
+        try (OutputStream stream = new BufferedOutputStream(
+                new FileOutputStream(new File(repositoryDestination, P2_INDEX_FILE)))) {
             properties.store(stream, null);
         } catch (IOException e) {
             throw new FacadeException("writing index file failed", e);
@@ -531,7 +534,8 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
     private void compressXml(File repositoryDestination, String name) throws FacadeException {
         File jarFile = new File(repositoryDestination, name + ".jar");
         File xmlFile = new File(repositoryDestination, name + ".xml");
-        try (JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(jarFile))) {
+        try (JarOutputStream jarOutputStream = new JarOutputStream(
+                new BufferedOutputStream(new FileOutputStream(jarFile)))) {
             jarOutputStream.putNextEntry(new JarEntry(xmlFile.getName()));
             Files.copy(xmlFile.toPath(), jarOutputStream);
         } catch (IOException e) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/RepositoryReferenceTool.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/RepositoryReferenceTool.java
@@ -12,9 +12,11 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2tools;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -77,7 +79,7 @@ public class RepositoryReferenceTool {
      * <li>The results of the referenced reactor modules,
      * <li>The non-reactor content of the module's target platform.
      * </ol>
-     * 
+     *
      * @param module
      *            The current Maven project
      * @param session
@@ -120,7 +122,8 @@ public class RepositoryReferenceTool {
         try {
             File repositoryLocation = new File(project.getBuild().getDirectory(), "targetPlatformRepository");
             repositoryLocation.mkdirs();
-            try (FileOutputStream stream = new FileOutputStream(new File(repositoryLocation, "content.xml"))) {
+            try (OutputStream stream = new BufferedOutputStream(
+                    new FileOutputStream(new File(repositoryLocation, "content.xml")))) {
 
                 TargetPlatform targetPlatform = projectManager.getTargetPlatform(project)
                         .orElseThrow(() -> new MojoFailureException(TychoConstants.TYCHO_NOT_CONFIGURED + project));

--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/spi/TychoTargetLocationLoader.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/spi/TychoTargetLocationLoader.java
@@ -12,10 +12,9 @@
  *******************************************************************************/
 package org.eclipse.m2e.pde.target.tests.spi;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -75,8 +74,7 @@ public class TychoTargetLocationLoader implements TargetLocationLoader {
     @Override
     public ITargetLocation resolveMavenTarget(String targetXML, File tempDir) throws Exception {
         File targetFile = new File(tempDir, "test.target");
-        try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(targetFile),
-                StandardCharsets.UTF_8)) {
+        try (BufferedWriter writer = Files.newBufferedWriter(targetFile.toPath(), StandardCharsets.UTF_8)) {
             writer.write("<target name=\"test-target-platform\"><locations>");
             writer.write(targetXML);
             writer.write("</locations></target>");

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/locking/LockProcess.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/locking/LockProcess.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.tycho.core.locking;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -95,12 +96,8 @@ public class LockProcess {
             String classNamePath = LockProcess.class.getName().replace('.', '/') + ".class";
             File tmpClassFile = new File(tmpClassDir, classNamePath);
             tmpClassFile.getParentFile().mkdirs();
-            try (OutputStream out = new FileOutputStream(tmpClassFile)) {
-                byte[] buffer = new byte[1024];
-                int read = 0;
-                while ((read = in.read(buffer, 0, buffer.length)) != -1) {
-                    out.write(buffer, 0, read);
-                }
+            try (OutputStream out = new BufferedOutputStream(new FileOutputStream(tmpClassFile))) {
+                in.transferTo(out);
                 in.close();
             }
         } catch (IOException e) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MetadataSerializableImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MetadataSerializableImplTest.java
@@ -14,10 +14,12 @@ package org.eclipse.tycho.p2resolver;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -84,7 +86,7 @@ public class MetadataSerializableImplTest extends TychoPlexusTestCase {
 
     private void serialize(MetadataSerializableImpl subject, Set<IInstallableUnit> units, File tmpDir)
             throws FileNotFoundException, IOException {
-        try (FileOutputStream os = new FileOutputStream(new File(tmpDir, "content.xml"))) {
+        try (OutputStream os = new BufferedOutputStream(new FileOutputStream(new File(tmpDir, "content.xml")))) {
             subject.serialize(os, units);
         }
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleArtifactRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleArtifactRepositoryTest.java
@@ -236,8 +236,7 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
 
     private static void generateBinaryTestFile(File file, int size) throws IOException {
         file.getParentFile().mkdirs();
-        try (FileOutputStream fos = new FileOutputStream(file)) {
-            OutputStream os = new BufferedOutputStream(fos);
+        try (OutputStream os = new BufferedOutputStream(new FileOutputStream(file))) {
             for (int i = 0; i < size; ++i) {
                 os.write(0);
             }

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/runner/ConvertSchemaToHtmlRunner.java
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/runner/ConvertSchemaToHtmlRunner.java
@@ -17,14 +17,13 @@ package org.eclipse.tycho.extras.docbundle.runner;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -146,7 +145,7 @@ public class ConvertSchemaToHtmlRunner implements Callable<ConvertSchemaToHtmlRe
 					}
 					File file = new File(directory, id.replace('.', '_') + ".html"); //$NON-NLS-1$
 					try (PrintWriter out = new PrintWriter(
-							new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8), true)) {
+							Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8), true)) {
 						fTransformer.transform(schema, out, cssURL, SchemaTransformer.BUILD);
 					}
 				} finally {

--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.versionbump;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -47,7 +48,7 @@ import de.pdark.decentxml.XMLWriter;
 /**
  * This allows to update a target file to use newer version of specified items, e.g. IUs from
  * updatesites or maven coordinates. In the simplest form this is called like
- * 
+ *
  * <pre>
  * mvn -f [path to target project] tycho-version-bump:update-target
  * </pre>
@@ -162,7 +163,8 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
         }
         if (changed) {
             String enc = target.getEncoding() != null ? target.getEncoding() : "UTF-8";
-            try (Writer w = new OutputStreamWriter(new FileOutputStream(file), enc); XMLWriter xw = new XMLWriter(w)) {
+            try (Writer w = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(file)), enc);
+                    XMLWriter xw = new XMLWriter(w)) {
                 try {
                     target.toXML(xw);
                 } finally {

--- a/tycho-its/projects/resolver.split/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/StorageUtils.java
+++ b/tycho-its/projects/resolver.split/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/StorageUtils.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -22,13 +22,13 @@ import org.eclipse.equinox.internal.security.auth.nls.SecAuthMessages;
 
 /**
  * PLEASE READ BEFORE CHANGING THIS FILE
- * 
+ *
  * At present most of the methods expect only file URLs. The API methods
  * take URLs for possible future expansion, and there is some code below
  * that would work with some other URL types, but the only supported URL
  * types at this time are file URLs. Also note that URL paths should not
- * be encoded (spaces should be spaces, not "%x20"). 
- *  
+ * be encoded (spaces should be spaces, not "%x20").
+ *
  * On encoding: Java documentation recommends using File.toURI().toURL().
  * However, in this process non-alphanumeric characters (including spaces)
  * get encoded and can not be used with the rest of Eclipse methods that
@@ -73,10 +73,10 @@ public class StorageUtils {
 				if (parent != null && !parent.exists())
 					parent.mkdirs();
 			}
-			return new FileOutputStream(file);
+			return new BufferedOutputStream(new FileOutputStream(file));
 		}
-		// note that code below does not work for File URLs - "by design" Java 
-		// does not support creating output streams on file URLs. Code below should work 
+		// note that code below does not work for File URLs - "by design" Java
+		// does not support creating output streams on file URLs. Code below should work
 		// for HTTP URLs; no idea as to the other types of URLs
 		URLConnection connection = url.openConnection();
 		connection.setDoOutput(true);
@@ -89,7 +89,7 @@ public class StorageUtils {
 		try {
 			return url.openStream();
 		} catch (FileNotFoundException e) {
-			return null; // this is all right, means new file 
+			return null; // this is all right, means new file
 		}
 	}
 
@@ -114,7 +114,7 @@ public class StorageUtils {
 	}
 
 	/**
-	 * The {@link String#getBytes()} truncates non-ASCII chars. As a result 
+	 * The {@link String#getBytes()} truncates non-ASCII chars. As a result
 	 * new String(string.getBytes()) is not the same as the original string. Moreover,
 	 * the default Java encoding can be changed via system variables or startup conditions.
 	 */
@@ -126,10 +126,10 @@ public class StorageUtils {
 
 	/**
 	 * The new String(byte[]) method uses default system encoding which
-	 * might not properly process non-ASCII characters. 
-	 * 
-	 * Pairing {@link #getBytes(String)} and {@link #getString(byte[])} methods allows round trip 
-	 * of non-ASCII characters. 
+	 * might not properly process non-ASCII characters.
+	 *
+	 * Pairing {@link #getBytes(String)} and {@link #getString(byte[])} methods allows round trip
+	 * of non-ASCII characters.
 	 */
 	static public String getString(byte[] bytes) {
 		if (bytes == null)

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/util/TargetDefinitionUtil.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/util/TargetDefinitionUtil.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.util;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -55,7 +57,7 @@ public class TargetDefinitionUtil {
 				repository.setAttribute("location", relocationBasedir.toURI().resolve(repositoryURL).toString());
 			}
 		}
-		try (FileOutputStream output = new FileOutputStream(targetDefinitionFile)) {
+		try (OutputStream output = new BufferedOutputStream(new FileOutputStream(targetDefinitionFile))) {
 			TargetDefinitionFile.writeDocument(platform, output);
 		}
 	}
@@ -83,7 +85,7 @@ public class TargetDefinitionUtil {
 				}
 			}
 		}
-		try (FileOutputStream output = new FileOutputStream(targetDefinitionFile)) {
+		try (OutputStream output = new BufferedOutputStream(new FileOutputStream(targetDefinitionFile))) {
 			TargetDefinitionFile.writeDocument(platform, output);
 		}
 	}
@@ -110,7 +112,7 @@ public class TargetDefinitionUtil {
 				}
 			}
 		}
-		try (FileOutputStream output = new FileOutputStream(targetDefinitionFile)) {
+		try (OutputStream output = new BufferedOutputStream(new FileOutputStream(targetDefinitionFile))) {
 			TargetDefinitionFile.writeDocument(platform, output);
 		}
 	}

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/CategoryP2MetadataMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/CategoryP2MetadataMojo.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.plugins.p2;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -76,7 +77,8 @@ public class CategoryP2MetadataMojo extends AbstractP2MetadataMojo {
             try {
                 if (jar && xmlFile.exists()) {
                     //need to recreate the jar
-                    try (JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(jarFile))) {
+                    try (JarOutputStream jarOutputStream = new JarOutputStream(
+                            new BufferedOutputStream(new FileOutputStream(jarFile)))) {
                         jarOutputStream.putNextEntry(new JarEntry(xmlFile.getName()));
                         Files.copy(xmlFile.toPath(), jarOutputStream);
                     }

--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
@@ -12,15 +12,16 @@
  *******************************************************************************/
 package org.eclipse.tycho.plugins.p2.repository;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -85,7 +86,7 @@ import org.eclipse.tycho.p2maven.tools.TychoFeaturesAndBundlesPublisherApplicati
  * <li>The metadata of the page is attached to the current project with type=zip and
  * classifier=p2site and could be deployed using standard maven techniques</li>
  * </ul>
- * 
+ *
  * <b>Please note:</b> Only valid OSGi bundles are included, there is no way to automatically wrap
  * plain jars and they are silently ignored. This is intentional, as the goal of a p2-maven-site is
  * to use exactly the same artifact that is deployed in the maven repository.
@@ -93,7 +94,7 @@ import org.eclipse.tycho.p2maven.tools.TychoFeaturesAndBundlesPublisherApplicati
  * <p>
  * The produced p2-maven-site can then be consumed by Tycho or PDE targets (m2eclipse is required
  * for this), in the following way: A tycho-repository section:
- * 
+ *
  * <pre>
     &lt;repository>
     &lt;id>my-p2-maven-site</id>
@@ -101,9 +102,9 @@ import org.eclipse.tycho.p2maven.tools.TychoFeaturesAndBundlesPublisherApplicati
         &lt;layout>p2</layout>
     &lt;/repository>
  * </pre>
- * 
+ *
  * A target location of type software-site:
- * 
+ *
  * <pre>
  *  &lt;location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
         &lt;repository location="mvn:[groupId]:[artifactId]:[version]:zip:p2site"/>
@@ -190,7 +191,7 @@ public class MavenP2SiteMojo extends AbstractMojo {
 
     /**
      * The output directory of the jar file
-     * 
+     *
      * By default this is the Maven "target/" directory.
      */
     @Parameter(property = "project.build.directory", required = true)
@@ -271,7 +272,7 @@ public class MavenP2SiteMojo extends AbstractMojo {
             try {
                 File categoryGenFile = File.createTempFile("category", ".xml");
                 try (PrintWriter writer = new PrintWriter(
-                        new OutputStreamWriter(new FileOutputStream(categoryGenFile), StandardCharsets.UTF_8))) {
+                        Files.newBufferedWriter(categoryGenFile.toPath(), StandardCharsets.UTF_8))) {
                     writer.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
                     writer.println("<site>");
                     writer.println("<category-def name=\"bundles\" label=\"" + categoryName + "\"/>");
@@ -344,7 +345,8 @@ public class MavenP2SiteMojo extends AbstractMojo {
                 publicKeysFile = File.createTempFile("publicKeys", ".pgp");
                 publicKeysFile.deleteOnExit();
                 PGPPublicKeyRingCollection collection = new PGPPublicKeyRingCollection(publicKeys.values());
-                try (OutputStream out = new ArmoredOutputStream(new FileOutputStream(publicKeysFile))) {
+                try (OutputStream out = new ArmoredOutputStream(
+                        new BufferedOutputStream(new FileOutputStream(publicKeysFile)))) {
                     collection.encode(out);
                 }
                 arguments.add("-publicKeys");
@@ -468,7 +470,9 @@ public class MavenP2SiteMojo extends AbstractMojo {
             addProvidesAndProperty(properties, TychoConstants.PROP_EXTENSION, artifact.getType(), cnt++);
             addProvidesAndProperty(properties, TychoConstants.PROP_CLASSIFIER, artifact.getClassifier(), cnt++);
             addProvidesAndProperty(properties, "maven-scope", artifact.getScope(), cnt++);
-            properties.store(new FileOutputStream(p2), null);
+            try (OutputStream os = new BufferedOutputStream(new FileOutputStream(p2))) {
+                properties.store(os, null);
+            }
             return p2;
         } catch (IOException e) {
             throw new MojoExecutionException("failed to generate p2.inf", e);

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -10,7 +10,7 @@
  * Contributors:
  *    Sonatype Inc. - initial API and implementation
  *    Christoph Läubrich 	- Issue #177 - Automatically translate maven-pom information to osgi Bundle-Header
- *    						- Issue #572 - Insert dynamic dependencies into the jar included pom 
+ *    						- Issue #572 - Insert dynamic dependencies into the jar included pom
  *******************************************************************************/
 package org.eclipse.tycho.packaging;
 
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -87,7 +88,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 	 * configuration is specified, the default value is <code>true</code>. If the
 	 * maven descriptor should not be added to the artifact, use the following
 	 * configuration:
-	 * 
+	 *
 	 * <pre>
 	 * &lt;plugin&gt;
 	 *   &lt;groupId&gt;org.eclipse.tycho&lt;/groupId&gt;
@@ -110,19 +111,19 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 	 * MANIFEST header. When using this parameter, property ${tycho.scmUrl} must be
 	 * set and be a valid
 	 * <a href="https://maven.apache.org/scm/scm-url-format.html">maven SCM URL</a>.
-	 * 
+	 *
 	 * Example configuration:
-	 * 
+	 *
 	 * <pre>
 	 *         &lt;sourceReferences&gt;
 	 *           &lt;generate&gt;true&lt;/generate&gt;
 	 *         &lt;/sourceReferences&gt;
 	 * </pre>
-	 * 
+	 *
 	 * Note that a {@link SourceReferencesProvider} component must be registered for
 	 * the SCM type being used. You may also override the generated value by
 	 * configuring:
-	 * 
+	 *
 	 * <pre>
 	 *         &lt;sourceReferences&gt;
 	 *           &lt;generate&gt;true&lt;/generate&gt;
@@ -327,7 +328,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
 		if (!parentFile.mkdirs() && !parentFile.exists()) {
 			throw new IOException("creating target directory " + parentFile.getAbsolutePath() + " failed");
 		}
-		try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(output))) {
+		try (OutputStream os = new BufferedOutputStream(new FileOutputStream(output))) {
 			mf.write(os);
 		}
 	}

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/reverseresolve/MavenCentralArtifactCoordinateResolver.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/reverseresolve/MavenCentralArtifactCoordinateResolver.java
@@ -12,11 +12,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.packaging.reverseresolve;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.util.List;
@@ -43,7 +45,7 @@ import kong.unirest.Unirest;
 import kong.unirest.json.JSONObject;
 
 /**
- * 
+ *
  * Use the maven rest API to find an artifact based on its sha1 sum.
  */
 @Component(role = ArtifactCoordinateResolver.class, hint = "central")
@@ -158,7 +160,7 @@ public class MavenCentralArtifactCoordinateResolver implements ArtifactCoordinat
 			properties.setProperty(KEY_ARTIFACT_ID, dependency.getArtifactId());
 			properties.setProperty(KEY_VERSION, dependency.getVersion());
 			properties.setProperty(KEY_TYPE, dependency.getType());
-			try (FileOutputStream stream = new FileOutputStream(cacheFile)) {
+			try (OutputStream stream = new BufferedOutputStream(new FileOutputStream(cacheFile))) {
 				properties.store(stream, null);
 			}
 		} catch (IOException e) {

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
@@ -20,6 +20,7 @@ import static org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME;
 import static org.osgi.framework.Constants.BUNDLE_VENDOR;
 import static org.osgi.framework.Constants.BUNDLE_VERSION;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -137,10 +138,10 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
 
     /**
      * Additional files to be included in the source bundle jar. This can be used when
-     * <code>src.includes</code> in build.properties is not flexible enough , e.g. for files which would
-     * otherwise conflict with files in <code>bin.includes</code><br/>
+     * <code>src.includes</code> in build.properties is not flexible enough , e.g. for files which
+     * would otherwise conflict with files in <code>bin.includes</code><br/>
      * Example:<br/>
-     * 
+     *
      * <pre>
      * &lt;additionalFileSets&gt;
      *  &lt;fileSet&gt;
@@ -148,7 +149,7 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
      *   &lt;includes&gt;
      *    &lt;include&gt;&#42;&#42;/*&lt;/include&gt;
      *   &lt;/includes&gt;
-     *  &lt;/fileSet&gt;     
+     *  &lt;/fileSet&gt;
      * &lt;/additionalFileSets&gt;
      * </pre>
      */
@@ -276,7 +277,7 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
         sourceL10nProps.setProperty(I18N_KEY_BUNDLE_VENDOR, bundleVendor);
         File l10nPropsFile = new File(l10nOutputDir, MANIFEST_BUNDLE_LOCALIZATION_FILENAME);
         l10nPropsFile.getParentFile().mkdirs();
-        try (OutputStream out = new FileOutputStream(l10nPropsFile)) {
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(l10nPropsFile))) {
             sourceL10nProps.store(out, "Source Bundle Localization");
         } catch (IOException e) {
             throw new MojoExecutionException("error while generating source bundle localization file", e);

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
@@ -14,10 +14,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.source;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -348,7 +350,7 @@ public class SourceFeatureMojo extends AbstractMojo {
 
     private static void writeProperties(Properties props, File propertiesFile) throws IOException {
         propertiesFile.getParentFile().mkdirs();
-        try (FileOutputStream out = new FileOutputStream(propertiesFile)) {
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(propertiesFile))) {
             props.store(out, "");
         }
     }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -23,6 +23,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -513,7 +514,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     /**
      * Additional root IUs to install, only relevant if {@link #testRuntime} is
      * <code>p2Installed</code>.
-     * 
+     *
      * <pre>
      * &lt;install&gt;
      *    &lt;iu&gt;
@@ -529,7 +530,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     /**
      * Additional repositories used to install units from, only relevant if {@link #testRuntime} is
      * <code>p2Installed</code>.
-     * 
+     *
      * <pre>
     * &lt;repositories&gt;
     *   &lt;repository&gt;
@@ -537,7 +538,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     *   &lt;/repository&gt;
     * &lt;/repositories&gt;
      * </pre>
-     * 
+     *
      */
     @Parameter(name = "repositories")
     private List<Repository> repositories;
@@ -966,7 +967,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         Properties p = new Properties();
         p.putAll(propertiesMap);
         try {
-            try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
+            try (OutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
                 p.store(out, null);
             }
         } catch (IOException e) {

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/BndTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/BndTestMojo.java
@@ -12,8 +12,10 @@
  ******************************************************************************/
 package org.eclipse.tycho.surefire;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -148,7 +150,7 @@ public class BndTestMojo extends AbstractTestMojo {
 
     /**
      * Configure the tester to use usually one of
-     * 
+     *
      * <ul>
      * <li>{@value #TESTER_DEFAULT}</li>
      * <li>{@value #TESTER_JUNIT_PLATFORM}</li>
@@ -167,7 +169,7 @@ public class BndTestMojo extends AbstractTestMojo {
 
     /**
      * Configure the run framework to use usually one of
-     * 
+     *
      * <ul>
      * <li>{@value #FW_FELIX}</li>
      * <li>{@value #FW_EQUINOX}</li>
@@ -186,7 +188,7 @@ public class BndTestMojo extends AbstractTestMojo {
      * <li>{@value #ENGINE_VINTAGE_ENGINE} - if your test only contains JUnit 3/4</li>
      * <li>{@value #ENGINES_DEFAULT} - if you want to use both engines</li>
      * </ul>
-     * 
+     *
      */
     @Parameter(defaultValue = ENGINES_DEFAULT, required = true)
     private String testEngines;
@@ -230,7 +232,7 @@ public class BndTestMojo extends AbstractTestMojo {
         properties.setProperty(Constants.RUNFW, runfw);
         properties.setProperty(Constants.RUNPROPERTIES, buildRunProperties());
         try {
-            try (FileOutputStream out = new FileOutputStream(runfile)) {
+            try (OutputStream out = new BufferedOutputStream(new FileOutputStream(runfile))) {
                 properties.store(out, null);
             }
             String javaExecutable = getJavaExecutable();

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/TargetFiles.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/TargetFiles.java
@@ -6,12 +6,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
  *******************************************************************************/
 package org.eclipse.tycho.versions.engine;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -52,7 +53,7 @@ public class TargetFiles {
     private void writeTarget(File targetFile, Document document)
             throws IOException, UnsupportedEncodingException, FileNotFoundException {
         String enc = document.getEncoding() != null ? document.getEncoding() : "UTF-8";
-        try (Writer w = new OutputStreamWriter(new FileOutputStream(targetFile), enc);
+        try (Writer w = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(targetFile)), enc);
                 XMLWriter xw = new XMLWriter(w)) {
             try {
                 document.toXML(xw);


### PR DESCRIPTION
This makes "Resolving MavenDependencyRoots..." output somewhat faster on my machine. I started from org.eclipse.tycho.core.resolver.MavenTargetDefinitionContent.generateSourceBundle(String, String, Manifest, File, IArtifactFacade), which took notable time in the profiler, and I then added buffered outputstreams and buffered writers to all FileOutputStreams.

I've run a local build of another project with this snapshot, but I have not run Tycho tests (my company machine fails too much with proxy stuff there and I can't get to my private machine for some days).