### PR TITLE
[backport] Add a tycho-wrap mojo

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 backports:
 - Support version-ranges and no-version for units in IU target locations
+- Add new `tycho-wrap:wrap`
 
 ## 4.0.9
 

--- a/pom.xml
+++ b/pom.xml
@@ -577,6 +577,7 @@
 		<module>tycho-bnd-plugin</module>
 		<module>tycho-repository-plugin</module>
 		<module>tycho-eclipse-plugin</module>
+		<module>tycho-wrap-plugin</module>
 	</modules>
 	<profiles>
 		<profile>

--- a/tycho-wrap-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-wrap-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/tycho-wrap-plugin/pom.xml
+++ b/tycho-wrap-plugin/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho</artifactId>
+		<version>4.0.10-SNAPSHOT</version>
+	</parent>
+	<artifactId>tycho-wrap-plugin</artifactId>
+	<name>Tycho Wrap Plugin</name>
+	<description>Support wrapping of plain jars into OSGi bundles</description>
+	<packaging>maven-plugin</packaging>
+	<prerequisites>
+		<maven>${minimal-maven-version}</maven>
+	</prerequisites>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.bndlib</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.bnd.maven</artifactId>
+			<version>7.0.0</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<!-- workaround for
+				https://issues.apache.org/jira/browse/MPLUGIN-504 -->
+				<configuration>
+					<goalPrefix>tycho-wrap</goalPrefix>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-wrap-plugin/src/main/java/org/eclipse/tycho/wrap/WrapMojo.java
+++ b/tycho-wrap-plugin/src/main/java/org/eclipse/tycho/wrap/WrapMojo.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.tycho.wrap;
+
+import java.io.File;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.regex.Pattern;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.settings.Settings;
+import org.osgi.framework.Constants;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.maven.lib.configuration.BndConfiguration;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.print.JarPrinter;
+import aQute.bnd.version.MavenVersion;
+import aQute.bnd.version.Version;
+
+@Mojo(name = "wrap", requiresProject = true, threadSafe = true, defaultPhase = LifecyclePhase.PACKAGE)
+public class WrapMojo extends AbstractMojo {
+
+	private static final String[] HEADERS = { Constants.BUNDLE_SYMBOLICNAME, Constants.BUNDLE_VERSION };
+
+	@Component
+	private MavenProject project;
+
+	@Parameter(defaultValue = "${settings}", readonly = true)
+	Settings settings;
+
+	@Component
+	private MojoExecution mojoExecution;
+
+	@Component
+	private MavenProjectHelper helper;
+
+	/**
+	 * File path to a bnd file containing bnd instructions for this project.
+	 * Defaults to {@code bnd.bnd}. The file path can be an absolute or relative to
+	 * the project directory.
+	 * <p>
+	 * The bnd instructions for this project are merged with the bnd instructions,
+	 * if any, for the parent project.
+	 */
+	// This is not used and is for doc only; see
+	// BndConfiguration#loadProperties and
+	// AbstractBndMavenPlugin for reference
+	@Parameter(defaultValue = Project.BNDFILE)
+	String bndfile;
+
+	/**
+	 * Bnd instructions for this project specified directly in the pom file. This is
+	 * generally be done using a {@code <![CDATA[]]>} section. If the project has a
+	 * {@link #bndfile}, then this configuration element is ignored.
+	 * <p>
+	 * The bnd instructions for this project are merged with the bnd instructions,
+	 * if any, for the parent project.
+	 */
+	// This is not used and is for doc only; see
+	// BndConfiguration#loadProperties and
+	// AbstractBndMavenPlugin for reference
+	@Parameter
+	String bnd;
+
+	@Parameter(required = true, property = "input", defaultValue = "${project.build.directory}/${project.build.finalName}.${project.packaging}")
+	private File input;
+
+	@Parameter(required = true, property = "output", defaultValue = "${project.build.directory}/${project.build.finalName}-bundle.${project.packaging}")
+	private File output;
+
+	/**
+	 * If enabled attach the generated file as an artifact to the project
+	 */
+	@Parameter(required = false, defaultValue = "true", property = "attach")
+	private boolean attach;
+
+	/**
+	 * The classifier to use when attach this to the project
+	 */
+	@Parameter(defaultValue = "bundle", property = "classifier")
+	private String classifier;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		BndConfiguration configuration = new BndConfiguration(project, mojoExecution);
+
+		try (Jar jar = new Jar(output.getName(), input, Pattern.compile(JarFile.MANIFEST_NAME));
+				Analyzer analyzer = new Analyzer(jar)) {
+			configuration.loadProperties(analyzer);
+			if (analyzer.getProperty(Constants.BUNDLE_VERSION) == null) {
+				Version version = new MavenVersion(project.getVersion()).getOSGiVersion();
+				analyzer.setProperty(Constants.BUNDLE_VERSION, version.toString());
+			}
+			if (analyzer.getProperty(Constants.BUNDLE_SYMBOLICNAME) == null) {
+				analyzer.setProperty(Constants.BUNDLE_SYMBOLICNAME, project.getArtifactId());
+			}
+			if (analyzer.getProperty(Constants.BUNDLE_NAME) == null) {
+				analyzer.setProperty(Constants.BUNDLE_NAME, project.getName());
+			}
+			Set<Artifact> artifacts = project.getArtifacts();
+			for (Artifact artifact : artifacts) {
+				File cpe = artifact.getFile();
+				try {
+					analyzer.addClasspath(cpe);
+				} catch (Exception e) {
+					// just go on... it might be not a jar or something else not usable
+				}
+			}
+			Manifest manifest = analyzer.calcManifest();
+			jar.setManifest(manifest);
+			jar.write(output);
+			analyzer.getWarnings().forEach(getLog()::warn);
+			analyzer.getErrors().forEach(getLog()::error);
+			Attributes mainAttributes = manifest.getMainAttributes();
+			for (String header : HEADERS) {
+				getLog().info(header + ": " + mainAttributes.getValue(header));
+			}
+			try (JarPrinter jarPrinter = new JarPrinter()) {
+				jarPrinter.doPrint(jar, JarPrinter.IMPEXP, false, false);
+				getLog().info(jarPrinter.toString());
+			}
+		} catch (MojoFailureException e) {
+			throw e;
+		} catch (MojoExecutionException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new MojoFailureException("wrapping input " + input + " failed: " + e, e);
+		}
+		if (attach) {
+			helper.attachArtifact(project, output, classifier);
+		}
+	}
+
+}


### PR DESCRIPTION
in maven jars/artifacts can be build in numerous ways, not all include the maven-jar-plugin (e.g. maven-assembly-plugin) and not all are easily combined with maven-bundle or bnd-maven plugin.

This adds a new tycho-wrap-plugin that closes this gap by allowing to specify an arbitrary input and output, some bnd instructions and an option to attach the result to the project.

This has also the advantage that projects are able to publish two "flavors" of their artifact a plain one and an OSGi-fied one that could help to convince projects to provide such things as it has zero influence to their build and ways how they build artifacts.