### PR TITLE
Don't write LIBARCHIVE.creationtime attribute in tar.gz archive entries

### DIFF
--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/ProductArchiverMojo.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/ProductArchiverMojo.java
@@ -125,6 +125,15 @@ public final class ProductArchiverMojo extends AbstractProductMojo {
     @Parameter
     private boolean parallel;
 
+    /**
+     * Controls if for {@code .tar.gz} archives the creation-time is stored as
+     * {@code LIBARCHIVE.creationtime } attribute in each entry. Currently {@code GNU tar} does not
+     * support that attributes and emits warnings about the {@code unknown extended header keyword
+     * 'LIBARCHIVE.creationtime'} when extracting such archive.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean storeCreationTime;
+
     @Component
     private MavenProjectHelper helper;
 
@@ -230,6 +239,7 @@ public final class ProductArchiverMojo extends AbstractProductMojo {
 
     private void createCommonsCompressTarGz(File productArchive, File sourceDir) throws IOException {
         TarGzArchiver archiver = new TarGzArchiver();
+        archiver.setStoreCreationTimeAttribute(storeCreationTime);
         archiver.setLog(getLog());
         archiver.addDirectory(sourceDir);
         archiver.setDestFile(productArchive);

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/tar/TarGzArchiver.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/tar/TarGzArchiver.java
@@ -52,6 +52,7 @@ public class TarGzArchiver {
     private File destFile;
     private List<File> sourceDirs = new ArrayList<>();
     private Log log = new SystemStreamLog();
+    private boolean storeCreationTime;
 
     public TarGzArchiver() {
     }
@@ -62,6 +63,10 @@ public class TarGzArchiver {
 
     public void setDestFile(File destFile) {
         this.destFile = destFile;
+    }
+
+    public void setStoreCreationTimeAttribute(boolean storeCreationTime) {
+        this.storeCreationTime = storeCreationTime;
     }
 
     public void addDirectory(File directory) {
@@ -129,6 +134,9 @@ public class TarGzArchiver {
             tarEntry.setMode(FilePermissionHelper.toOctalFileMode(attrs.permissions()));
         }
         tarEntry.setModTime(source.lastModified());
+        if (!storeCreationTime) { // GNU  tar cannot handle 'LIBARCHIVE.creationtime' attributes and emits a lot of warnings on it
+            tarEntry.setCreationTime(null);
+        }
         return tarEntry;
     }
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-tycho/tycho/issues/2586