### PR TITLE
[Backport Tycho 4.0] Don't write LIBARCHIVE.creationtime attribute in tar.gz archive entries

### DIFF
--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/ProductArchiverMojo.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/ProductArchiverMojo.java
@@ -125,6 +125,15 @@ public final class ProductArchiverMojo extends AbstractProductMojo {
     @Parameter
     private boolean parallel;
 
+    /**
+     * Controls if for {@code .tar.gz} archives the creation-time is stored as
+     * {@code LIBARCHIVE.creationtime } attribute in each entry. Currently {@code GNU tar} does not
+     * support that attributes and emits warnings about the {@code unknown extended header keyword
+     * 'LIBARCHIVE.creationtime'} when extracting such archive.
+     */
+    @Parameter(defaultValue = "true")
+    private boolean storeCreationTime;
+
     @Component
     private MavenProjectHelper helper;
 
@@ -230,6 +239,7 @@ public final class ProductArchiverMojo extends AbstractProductMojo {
 
     private void createCommonsCompressTarGz(File productArchive, File sourceDir) throws IOException {
         TarGzArchiver archiver = new TarGzArchiver();
+        archiver.setStoreCreationTimeAttribute(storeCreationTime);
         archiver.setLog(getLog());
         archiver.addDirectory(sourceDir);
         archiver.setDestFile(productArchive);


### PR DESCRIPTION
Back-port of https://github.com/eclipse-tycho/tycho/pull/4427

Fixes https://github.com/eclipse-tycho/tycho/issues/2586