### PR TITLE
Don't await a StackOverflowError on a redirection loop

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/HttpCache.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/HttpCache.java
@@ -24,9 +24,9 @@ public interface HttpCache {
 	 * 
 	 * @param uri
 	 * @return
-	 * @throws FileNotFoundException
-	 *             if the URI is know to be not found
+	 * @throws FileNotFoundException    if the URI is know to be not found
+	 * @throws RedirectionLoopException if the URI redirects to itself
 	 */
-	CacheEntry getCacheEntry(URI uri, Logger logger) throws FileNotFoundException;
+	CacheEntry getCacheEntry(URI uri, Logger logger) throws FileNotFoundException, RedirectionLoopException;
 
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/RedirectionLoopException.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/RedirectionLoopException.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Tobias Hahnen and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Tobias Hahnen - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.transport;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when a URI would be redirecting to itself. This will cause a
+ * loop and therefore might lead to a StackOverflowError.
+ */
+public class RedirectionLoopException extends IOException {
+	public RedirectionLoopException(String uri) {
+		super(uri);
+	}
+}


### PR DESCRIPTION
In case of a redirection loop for URI of a p2 repository, fail fast on a redirection loop. In this case provide a warning to the user and let the rest be handled by Tycho. Otherwise there might be a StackOverflowError due to the recursion used and no check for whether the base URI is the same as the redirected URI.

This links to #4451 but does not fix it, only raising visibility for such cases.