### PR TITLE
tycho-versions-plugin: PomUtil.expandProperties(): Quote replacements

### DIFF
--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/pom/PomUtil.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/pom/PomUtil.java
@@ -48,8 +48,8 @@ public class PomUtil {
                 String unexpandedProperty = m.group();
                 String propertyName = m.group(1);
                 m.appendReplacement(resolvedVersionBuilder,
-                        properties.stream().filter(p -> p.getName().equals(propertyName)).map(p -> p.getValue())
-                                .findFirst().orElse(unexpandedProperty));
+                        Matcher.quoteReplacement(properties.stream().filter(p -> p.getName().equals(propertyName))
+                                .map(p -> p.getValue()).findFirst().orElse(unexpandedProperty)));
             }
             m.appendTail(resolvedVersionBuilder);
             return resolvedVersionBuilder.toString();

--- a/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/pom/tests/PomUtilTest.java
+++ b/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/pom/tests/PomUtilTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.versions.pom.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.tycho.versions.pom.PomFile;
+import org.eclipse.tycho.versions.pom.PomUtil;
+import org.junit.Test;
+
+public class PomUtilTest {
+
+    @Test
+    public void expandProperties() throws Exception {
+        String pom = """
+                <project>
+                  <properties>
+                    <foo>    fooValue   </foo>
+                    <bar>barValue</bar>
+                  </properties>
+                </project>
+                """;
+        PomFile pomFile = PomFile.read(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)), true);
+
+        String expanded = PomUtil.expandProperties("${foo}-${bar}-${notFound}", pomFile.getProperties());
+
+        assertEquals("fooValue-barValue-${notFound}", expanded);
+    }
+}


### PR DESCRIPTION
The replacement strings passed to

  `java.util.regex.Matcher.appendReplacement(StringBuilder, String)`

are to be treated literally, no regex capture groups are to be evaluated if the replacement string happens to contains '${...}'.

So they must be quoted using

  `java.util.regex.Matcher.quoteReplacement(String)`


Fixes the regression introduced in #3900.