### PR TITLE
reduce file access

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultArtifactDescriptor.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultArtifactDescriptor.java
@@ -68,10 +68,13 @@ public class DefaultArtifactDescriptor implements ArtifactDescriptor {
         if (projectLocation != null) {
             return projectLocation;
         }
-        if (fetch && locationSupplier != null && (location == null || !location.exists())) {
+        if (fetch && locationSupplier != null && location == null) {
             File file = locationSupplier.apply(this);
             if (file != null) {
                 location = ArtifactCollection.normalizeLocation(file);
+                if (!location.exists()) {
+                    location = null;
+                }
             }
         }
         return location;


### PR DESCRIPTION
At least on Windows the repeated invocation of file.exists takes a huge amount of time. The change removes several _minutes_ of runtime from a 1 hour product build: 
![image](https://github.com/user-attachments/assets/6c5e92b1-ad71-4843-a815-f3bed610777a)
