### PR TITLE
[backport] avoid annotation processor warnings on Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,28 @@
 				</plugins>
 			</build>
 		</profile>
+        <profile>
+            <!-- allow annotation processing on JDK 21+ -->
+            <id>avoid-maven-compiler-warnings</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<configuration>
+								<!-- avoid annotation processor warning on JDK 21+.
+								The flag must be set explicitly there. -->
+								<proc>full</proc>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+        </profile>
 	</profiles>
 	<distributionManagement>
 		<site>

--- a/tycho-lib-detector/pom.xml
+++ b/tycho-lib-detector/pom.xml
@@ -26,7 +26,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<configuration>
+					<configuration combine.self="override">
 						<!-- make sure we use minimum source/target level as this code will be run in old JVMs -->
 						<source>1.3</source>
 						<target>1.1</target>


### PR DESCRIPTION
Looks like this fix of a warning actually has fixed the lib detector as well:
```
[INFO] Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation
processing
  unless at least one processor is specified by name (-processor), or a
search
  path is specified (--processor-path, --processor-module-path), or
annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
```

Fixes https://github.com/eclipse-tycho/tycho/issues/4533

FYI @Bananeweizen 