### PR TITLE
Add reproducible timestamps in archives

### DIFF
--- a/tycho-extras/tycho-custom-bundle-plugin/src/main/java/org/eclipse/tycho/extras/custombundle/CustomBundleMojo.java
+++ b/tycho-extras/tycho-custom-bundle-plugin/src/main/java/org/eclipse/tycho/extras/custombundle/CustomBundleMojo.java
@@ -86,6 +86,16 @@ public class CustomBundleMojo extends AbstractMojo {
 	@Parameter
 	private MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
 
+	/**
+	 * Timestamp for reproducible output archive entries, either formatted as ISO
+	 * 8601 extended offset date-time (e.g. in UTC such as '2011-12-03T10:15:30Z' or
+	 * with an offset '2019-10-05T20:37:42+06:00'), or as an int representing
+	 * seconds since the epoch (like <a href=
+	 * "https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+	 */
+	@Parameter(defaultValue = "${project.build.outputTimestamp}")
+	private String outputTimestamp;
+
 	@Component(role = Archiver.class, hint = "jar")
 	private JarArchiver jarArchiver;
 
@@ -99,6 +109,9 @@ public class CustomBundleMojo extends AbstractMojo {
 		MavenArchiver archiver = new MavenArchiver();
 		archiver.setArchiver(jarArchiver);
 		archiver.setOutputFile(outputJarFile);
+
+		// configure for Reproducible Builds based on outputTimestamp value
+		archiver.configureReproducibleBuild(outputTimestamp);
 
 		try {
 			archiver.getArchiver().setManifest(updateManifest());

--- a/tycho-gpg-plugin/pom.xml
+++ b/tycho-gpg-plugin/pom.xml
@@ -64,6 +64,11 @@
 			<artifactId>tycho-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-archiver</artifactId>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/tycho-its/projects/reproducible-archive-timestamps/pom.xml
+++ b/tycho-its/projects/reproducible-archive-timestamps/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>reproducible.archive.timestamps</groupId>
+	<artifactId>reproducible.archive.timestamps.parent</artifactId>
+	<version>1.0.0</version>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>reproducible.bundle</module>
+		<module>reproducible.bundle.feature</module>
+		<module>reproducible.iu</module>
+		<module>reproducible.repository</module>
+	</modules>
+
+	<properties>
+		<project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
+		<target-platform>http://download.eclipse.org/releases/latest</target-platform>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>repo</id>
+			<layout>p2</layout>
+			<url>${target-platform}</url>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<environments>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86</arch>
+						</environment>
+					</environments>
+				</configuration>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-packaging-plugin</artifactId>
+				<version>${tycho-version}</version>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>plugin-source</id>
+						<goals>
+							<goal>plugin-source</goal>
+							<goal>feature-source</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>attach-p2-metadata</id>
+						<phase>package</phase>
+						<goals>
+							<goal>p2-metadata</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	
+</project>

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle.feature/build.properties
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle.feature/feature.xml
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle.feature/feature.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="reproducible.bundle.feature"
+      label="Feature"
+      version="1.0.0">
+
+   <plugin
+         id="reproducible.bundle"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle.feature/pom.xml
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle.feature/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>reproducible.archive.timestamps</groupId>
+		<artifactId>reproducible.archive.timestamps.parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>reproducible.bundle.feature</artifactId>
+	<packaging>eclipse-feature</packaging>
+</project>

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Reproducible-bundle
+Bundle-SymbolicName: reproducible.bundle
+Bundle-Version: 1.0.0

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/build.properties
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/custom/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/custom/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Reproducible-bundle
+Bundle-SymbolicName: reproducible.bundle.attached
+Bundle-Version: 1.0.0

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/pom.xml
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>reproducible.archive.timestamps</groupId>
+		<artifactId>reproducible.archive.timestamps.parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>reproducible.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-custom-bundle-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>attached</id>
+						<phase>package</phase>
+						<goals>
+							<goal>custom-bundle</goal>
+						</goals>
+						<configuration>
+							<bundleLocation>${project.basedir}/custom</bundleLocation>
+							<classifier>attached</classifier>
+							<fileSets>
+								<fileSet>
+									<directory>${project.build.outputDirectory}</directory>
+									<includes>
+										<include>**/*.class</include>
+									</includes>
+								</fileSet>
+							</fileSets>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/src/reproducible/bundle/PublicClass.java
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.bundle/src/reproducible/bundle/PublicClass.java
@@ -1,0 +1,6 @@
+package reproducible.bundle;
+
+public class PublicClass
+{
+
+}

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.iu/p2iu.xml
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.iu/p2iu.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<unit id='reproducible.iu' version='1.0.0' singleton='false'>
+  <update id='reproducible.iu' range='[0.0.0,1.0.0)' severity='0'/>
+  <properties>
+    <property name='org.eclipse.equinox.p2.name' value='Root files for my product'/>
+  </properties>
+  <touchpoint id='org.eclipse.equinox.p2.native' version='1.0.0'/>
+    <touchpointData>
+    <instructions>
+      <instruction key='install'>
+        unzip(source:@artifact, target:${installFolder});
+      </instruction>
+      <instruction key='uninstall'>
+        cleanupzip(source:@artifact, target:${installFolder});
+      </instruction>
+    </instructions>
+  </touchpointData>
+</unit>

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.iu/pom.xml
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.iu/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>reproducible.archive.timestamps</groupId>
+		<artifactId>reproducible.archive.timestamps.parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>reproducible.iu</artifactId>
+	<packaging>p2-installable-unit</packaging>
+</project>

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.repository/main.p2.inf
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.repository/main.p2.inf
@@ -1,0 +1,3 @@
+requires.0.namespace=org.eclipse.equinox.p2.iu
+requires.0.name=reproducible.iu
+requires.0.range=[$version$,$version$]

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.repository/main.product
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.repository/main.product
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Main Product" uid="main.product.id" id="product.branding" application="product.bundle.application" version="1.0.0" useFeatures="false" includeLaunchers="false">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="org.eclipse.core.runtime"/>
+   </plugins>
+
+
+</product>

--- a/tycho-its/projects/reproducible-archive-timestamps/reproducible.repository/pom.xml
+++ b/tycho-its/projects/reproducible-archive-timestamps/reproducible.repository/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>reproducible.archive.timestamps</groupId>
+		<artifactId>reproducible.archive.timestamps.parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>reproducible.repository</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>assemble-maven-repository</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>assemble-maven-repository</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>materialize-products</id>
+						<goals>
+							<goal>materialize-products</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>archive-products</id>
+						<goals>
+							<goal>archive-products</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<formats>
+						<linux>zip</linux>
+						<mac>zip</mac>
+						<windows>zip</windows>
+					</formats>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/reproducible/ReproducibleArchiveTimestampsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/reproducible/ReproducibleArchiveTimestampsTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.test.reproducible;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ReproducibleArchiveTimestampsTest extends AbstractTychoIntegrationTest {
+	// The ZipEntry.getLastModifiedTime() method uses the default timezone to
+	// convert date and time fields to Instant, so we also use the default timezone
+	// for the expected timestamp here.
+	private static final String EXPECTED_TIMESTAMP_STRING = "2023-01-01T00:00:00";
+	private static final Instant EXPECTED_TIMESTAMP_INSTANT = LocalDateTime.parse(EXPECTED_TIMESTAMP_STRING)
+			.toInstant(OffsetDateTime.now().getOffset());
+
+	/**
+	 * Check that the timestamp of the files inside the produced archives is equal
+	 * to the one specified in the "project.build.outputTimestamp" property of the
+	 * pom file.
+	 */
+	@Test
+	public void test() throws Exception {
+		Verifier verifier = getVerifier("reproducible-archive-timestamps");
+		verifier.executeGoals(List.of("clean", "verify"));
+		verifier.verifyErrorFreeLog();
+
+		// Check timestamps of files in archives
+		checkTimestamps(verifier.getBasedir() + "/reproducible.bundle/target/reproducible.bundle-1.0.0.jar");
+		checkTimestamps(verifier.getBasedir() + "/reproducible.bundle/target/reproducible.bundle-1.0.0-attached.jar");
+		checkTimestamps(verifier.getBasedir() + "/reproducible.bundle/target/reproducible.bundle-1.0.0-sources.jar");
+		checkTimestamps(
+				verifier.getBasedir() + "/reproducible.bundle.feature/target/reproducible.bundle.feature-1.0.0.jar");
+		checkTimestamps(verifier.getBasedir()
+				+ "/reproducible.bundle.feature/target/reproducible.bundle.feature-1.0.0-sources-feature.jar");
+		checkTimestamps(verifier.getBasedir() + "/reproducible.iu/target/reproducible.iu-1.0.0.zip");
+		checkTimestamps(verifier.getBasedir() + "/reproducible.repository/target/reproducible.repository-1.0.0.zip");
+		checkTimestamps(verifier.getBasedir() + "/reproducible.repository/target/p2-site.zip");
+	}
+
+	private void checkTimestamps(String file) throws IOException {
+		try (ZipFile zip = new ZipFile(file)) {
+			final var entries = zip.entries();
+			while (entries.hasMoreElements()) {
+				final ZipEntry entry = entries.nextElement();
+				Assert.assertEquals(EXPECTED_TIMESTAMP_INSTANT, entry.getLastModifiedTime().toInstant());
+			}
+		}
+	}
+}

--- a/tycho-p2-director-plugin/pom.xml
+++ b/tycho-p2-director-plugin/pom.xml
@@ -96,6 +96,11 @@
 			<artifactId>tycho-p2-plugin</artifactId>
 			<version>${project.version}</version>	
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-archiver</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/ProductArchiverMojo.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/ProductArchiverMojo.java
@@ -255,6 +255,9 @@ public final class ProductArchiverMojo extends AbstractProductMojo {
         TarGzArchiver archiver = new TarGzArchiver();
         archiver.setStoreCreationTimeAttribute(storeCreationTime);
         archiver.setLog(getLog());
+        // configure for Reproducible Builds based on outputTimestamp value
+        MavenArchiver.parseBuildOutputTimestamp(outputTimestamp).map(FileTime::from)
+                .ifPresent(modifiedTime -> archiver.configureReproducibleBuild(modifiedTime));
         archiver.addDirectory(sourceDir);
         archiver.setDestFile(productArchive);
         archiver.createArchive();

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/ProductArchiverMojo.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/ProductArchiverMojo.java
@@ -16,12 +16,14 @@ package org.eclipse.tycho.plugins.p2.director;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.attribute.FileTime;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -134,6 +136,15 @@ public final class ProductArchiverMojo extends AbstractProductMojo {
     @Parameter(defaultValue = "false")
     private boolean storeCreationTime;
 
+    /**
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601 extended
+     * offset date-time (e.g. in UTC such as '2011-12-03T10:15:30Z' or with an offset
+     * '2019-10-05T20:37:42+06:00'), or as an int representing seconds since the epoch (like
+     * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     */
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
     @Component
     private MavenProjectHelper helper;
 
@@ -223,6 +234,9 @@ public final class ProductArchiverMojo extends AbstractProductMojo {
                 createCommonsCompressTarGz(productArchive, sourceDir);
             } else {
                 Archiver archiver = productArchiver.get();
+                // configure for Reproducible Builds based on outputTimestamp value
+                MavenArchiver.parseBuildOutputTimestamp(outputTimestamp).map(FileTime::from)
+                        .ifPresent(modifiedTime -> archiver.configureReproducibleBuild(modifiedTime));
                 archiver.setDestFile(productArchive);
                 DefaultFileSet fileSet = new DefaultFileSet(sourceDir);
                 fileSet.setUsingDefaultExcludes(false);

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/tar/TarGzArchiver.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/tar/TarGzArchiver.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.util.ArrayList;
@@ -53,6 +54,7 @@ public class TarGzArchiver {
     private List<File> sourceDirs = new ArrayList<>();
     private Log log = new SystemStreamLog();
     private boolean storeCreationTime;
+    private FileTime outputTimestamp = null;
 
     public TarGzArchiver() {
     }
@@ -67,6 +69,10 @@ public class TarGzArchiver {
 
     public void setStoreCreationTimeAttribute(boolean storeCreationTime) {
         this.storeCreationTime = storeCreationTime;
+    }
+
+    public void configureReproducibleBuild(FileTime timestamp) {
+        this.outputTimestamp = timestamp;
     }
 
     public void addDirectory(File directory) {
@@ -133,9 +139,15 @@ public class TarGzArchiver {
         if (attrs != null) {
             tarEntry.setMode(FilePermissionHelper.toOctalFileMode(attrs.permissions()));
         }
-        tarEntry.setModTime(source.lastModified());
+        if (outputTimestamp == null) {
+            tarEntry.setModTime(source.lastModified());
+        } else {
+            tarEntry.setModTime(outputTimestamp);
+        }
         if (!storeCreationTime) { // GNU  tar cannot handle 'LIBARCHIVE.creationtime' attributes and emits a lot of warnings on it
             tarEntry.setCreationTime(null);
+        } else if (outputTimestamp != null) {
+            tarEntry.setCreationTime(outputTimestamp);
         }
         return tarEntry;
     }

--- a/tycho-p2-repository-plugin/pom.xml
+++ b/tycho-p2-repository-plugin/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>tycho-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-archiver</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
@@ -105,6 +105,16 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
     @Parameter(defaultValue = "${project.build.directory}/site")
     private File target;
 
+    /**
+     * Timestamp for reproducible output archive entries, either formatted as ISO
+     * 8601 extended offset date-time (e.g. in UTC such as '2011-12-03T10:15:30Z' or
+     * with an offset '2019-10-05T20:37:42+06:00'), or as an int representing
+     * seconds since the epoch (like <a href=
+     * "https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     */
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
     @Component
     private FeatureXmlTransformer featureXmlTransformer;
 
@@ -161,6 +171,8 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
             MavenArchiver archiver = new MavenArchiver();
             JarArchiver jarArchiver = getJarArchiver();
             archiver.setArchiver(jarArchiver);
+            // configure for Reproducible Builds based on outputTimestamp value
+            archiver.configureReproducibleBuild(outputTimestamp);
             archiver.setOutputFile(outputJar);
             jarArchiver.setDestFile(outputJar);
 

--- a/tycho-repository-plugin/pom.xml
+++ b/tycho-repository-plugin/pom.xml
@@ -62,6 +62,11 @@
 			<artifactId>tycho-spi</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-archiver</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
@@ -194,6 +194,15 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
     @Parameter(property = "source.forceCreation", defaultValue = "false")
     private boolean forceCreation;
 
+    /**
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601 extended
+     * offset date-time (e.g. in UTC such as '2011-12-03T10:15:30Z' or with an offset
+     * '2019-10-05T20:37:42+06:00'), or as an int representing seconds since the epoch (like
+     * <a href= "https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     */
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
     // ----------------------------------------------------------------------
     // Public methods
     // ----------------------------------------------------------------------
@@ -348,6 +357,9 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
     protected MavenArchiver createArchiver() throws MojoExecutionException {
         MavenArchiver archiver = new MavenArchiver();
         archiver.setArchiver(jarArchiver);
+
+        // configure for Reproducible Builds based on outputTimestamp value
+        archiver.configureReproducibleBuild(outputTimestamp);
 
         if (project.getBuild() != null) {
             List<Resource> resources = project.getBuild().getResources();

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
@@ -193,6 +193,15 @@ public class SourceFeatureMojo extends AbstractMojo {
     @Parameter(property = "session", readonly = true)
     private MavenSession session;
 
+    /**
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601 extended
+     * offset date-time (e.g. in UTC such as '2011-12-03T10:15:30Z' or with an offset
+     * '2019-10-05T20:37:42+06:00'), or as an int representing seconds since the epoch (like
+     * <a href= "https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     */
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
     private final Set<String> excludedPlugins = new HashSet<>();
 
     private final Set<String> excludedFeatures = new HashSet<>();
@@ -243,6 +252,8 @@ public class SourceFeatureMojo extends AbstractMojo {
                 writeProperties(mergedSourceFeatureProps, getMergedSourceFeaturePropertiesFile());
                 MavenArchiver archiver = new MavenArchiver();
                 archiver.setArchiver(jarArchiver);
+                // configure for Reproducible Builds based on outputTimestamp value
+                archiver.configureReproducibleBuild(outputTimestamp);
                 File outputJarFile = getOutputJarFile();
                 archiver.setOutputFile(outputJarFile);
                 File template = new File(project.getBasedir(), FEATURE_TEMPLATE_DIR);


### PR DESCRIPTION
Use the standard "project.build.outputTimestamp" maven property to enable reproducible timestamps in archives (cf. https://maven.apache.org/guides/mini/guide-reproducible-builds.html).