### PR TITLE
Cache temporary redirections in the original location (#4459)

### DIFF
--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho2938/ContentJarTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho2938/ContentJarTest.java
@@ -86,7 +86,7 @@ public class ContentJarTest extends AbstractTychoIntegrationTest {
 		String redirectedUrl = server.addRedirect("repoB", originalPath -> mainRepoUrl + originalPath + "_invalid");
 		configureRepositoryInTargetDefinition(redirectedUrl);
 		Assert.assertThrows(VerificationException.class, () -> verifier.executeGoal("package"));
-		verifier.verifyTextInLog("No repository found at " + redirectedUrl);
+		verifier.verifyTextInLog("Unable to read repository at " + redirectedUrl);
 		assertVisited("/content.jar_invalid");
 	}
 


### PR DESCRIPTION
Some p2 sites can temporarily redirect to another location. In the case of JFrog Artifactory, these redirection URLs are too long to make as a file path, so the build would fail in this case. For temporary redirects, we save the artifact in the original location instead, since it's likely the redirection might change in the future. Permanent redirects will get their own cache entry as before.