### PR TITLE
Honor configured profile when determining the execution environment

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -563,6 +563,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
         if (configuredProfile != null) {
             // non standard profile, stick to it
             sink.setProfileConfiguration(configuredProfileName, reason);
+            return;
         }
         StandardExecutionEnvironment currentProfile = ExecutionEnvironmentUtils.getExecutionEnvironment(
                 "JavaSE-" + Runtime.version().feature(), toolchainManager, mavenSession, logger);


### PR DESCRIPTION
When calculating the best matching profile, any explicitly configured profile is effectively overwritten with the one matching the current runtime version.

This makes it impossible to select a profile older than the JRE Tycho is executed with. As a result, properties such as the "useJDK" are ignored if the BREE of the bundle is smaller than the current Java version.