### PR TITLE
Unify access to the Tycho cache directory

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/DefaultTransportCacheConfig.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/DefaultTransportCacheConfig.java
@@ -49,8 +49,12 @@ public class DefaultTransportCacheConfig implements TransportCacheConfig, Initia
 			update = session.getRequest().isUpdateSnapshots();
 			interactive = session.getRequest().isInteractiveMode() && showTransferProgress(session);
 		}
-
-		cacheLocation = new File(repoDir, ".cache/tycho");
+		String property = System.getProperty("tycho.p2.transport.cache");
+		if (property == null || property.isBlank()) {
+			cacheLocation = new File(repoDir, ".cache/tycho");
+		} else {
+			cacheLocation = new File(property);
+		}
 		cacheLocation.mkdirs();
 	}
 

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransport.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransport.java
@@ -226,4 +226,8 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 		}
 	}
 
+	TransportCacheConfig getCacheConfig() {
+		return cacheConfig;
+	}
+
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransportCacheManager.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransportCacheManager.java
@@ -25,18 +25,13 @@ import org.eclipse.equinox.p2.core.ProvisionException;
 
 public class TychoRepositoryTransportCacheManager extends CacheManager {
 
-    public static final String CACHE_RELPATH = ".cache/tycho/p2-repository-metadata";
-
     private static final List<String> EXTENSIONS = List.of(".jar", ".xml");
 
     private TychoRepositoryTransport transport;
 
-	private File localRepositoryRoot;
-
-	public TychoRepositoryTransportCacheManager(TychoRepositoryTransport transport, File localRepositoryRoot) {
+	public TychoRepositoryTransportCacheManager(TychoRepositoryTransport transport) {
         super(null, transport);
         this.transport = transport;
-		this.localRepositoryRoot = localRepositoryRoot;
     }
 
     @Override
@@ -77,7 +72,9 @@ public class TychoRepositoryTransportCacheManager extends CacheManager {
 
     @Override
     protected File getCacheDirectory() {
-		return new File(localRepositoryRoot, CACHE_RELPATH);
+
+		TransportCacheConfig config = transport.getCacheConfig();
+		return new File(config.getCacheLocation(), "p2-repository-metadata");
     }
 
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransportCacheManagerAgentFactory.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransportCacheManagerAgentFactory.java
@@ -12,44 +12,22 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2maven.transport;
 
-import java.io.File;
-
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.LegacySupport;
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 import org.eclipse.equinox.internal.p2.repository.CacheManagerComponent;
 import org.eclipse.equinox.internal.p2.repository.Transport;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
-import org.eclipse.tycho.TychoConstants;
 
 @Component(role = IAgentServiceFactory.class, hint = "org.eclipse.equinox.internal.p2.repository.CacheManager")
-public class TychoRepositoryTransportCacheManagerAgentFactory implements IAgentServiceFactory, Initializable {
-
-    @Requirement
-	private LegacySupport legacySupport;
-	private File repoDir;
+public class TychoRepositoryTransportCacheManagerAgentFactory implements IAgentServiceFactory {
 
     @Override
     public Object createService(IProvisioningAgent agent) {
         Object transport = agent.getService(Transport.SERVICE_NAME);
         if (transport instanceof TychoRepositoryTransport tychoRepositoryTransport) {
-			return new TychoRepositoryTransportCacheManager(tychoRepositoryTransport, repoDir);
+			return new TychoRepositoryTransportCacheManager(tychoRepositoryTransport);
         }
         return new CacheManagerComponent().createService(agent);
     }
-
-	@Override
-	public void initialize() throws InitializationException {
-		MavenSession session = legacySupport.getSession();
-		if (session == null) {
-			repoDir = TychoConstants.DEFAULT_USER_LOCALREPOSITORY;
-		} else {
-			repoDir = new File(session.getLocalRepository().getBasedir());
-		}
-	}
 
 }

--- a/src/site/markdown/SystemProperties.md
+++ b/src/site/markdown/SystemProperties.md
@@ -29,10 +29,20 @@ tycho.comparator.threshold | bytes | 5242880 (~5MB) | gives the number of bytes 
 
 ## P2
 
-These properties control the behaviour of P2 used by Tycho
+These properties control the behavior of P2 used by Tycho
 
 Name | Value | Default | Documentation
 --- | --- | --- | ---
 eclipse.p2.mirrors | true / false | true | Each p2 site can define a list of artifact repository mirrors, this controls if P2 mirrors should be used. This is independent from configuring mirrors in the maven configuration to be used by Tycho!
 eclipse.p2.maxDownloadAttempts | _any positive integer_ | 3 | Describes how often Tycho attempts to re-download an artifact from a p2 repository in case e.g. a bad mirror was used. One can think of this value as the maximum number of mirrors Tycho/p2 will check. 
 
+### Tycho P2 Transport
+
+These properties control how Tycho downloads artifacts from P2 servers
+
+Name | Value | Default | Documentation
+--- | --- | --- | ---
+tycho.p2.transport.cache | file path | local maven repository | Specify the location where Tycho stores certain cache files to speed up successive builds
+tycho.p2.transport.debug | true/false | false | enable debugging of the Tycho Transport
+tycho.p2.transport.max-download-threads | number | 4 | maximum number of threads that should be used to download artifacts in parallel
+tycho.p2.transport.min-cache-minutes | number | 60 | Number of minutes that a cache entry is assumed to be fresh and is not fetched again from the server

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -63,6 +63,7 @@ import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.DefaultBundleReader;
 import org.eclipse.tycho.p2maven.MavenProjectDependencyProcessor;
 import org.eclipse.tycho.p2maven.MavenProjectDependencyProcessor.ProjectDependencyClosure;
+import org.eclipse.tycho.p2maven.transport.TransportCacheConfig;
 import org.eclipse.tycho.resolver.TychoResolver;
 import org.eclipse.tycho.version.TychoVersion;
 
@@ -102,6 +103,9 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
     @Requirement
     TychoProjectManager projectManager;
+
+    @Requirement
+    TransportCacheConfig transportCacheConfig;
 
     public TychoMavenLifecycleParticipant() {
         // needed for plexus
@@ -374,8 +378,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
     private void configureComponents(MavenSession session) {
         // TODO why does the bundle reader need to cache stuff in the local maven repository?
-        File localRepository = new File(session.getLocalRepository().getBasedir());
-        ((DefaultBundleReader) bundleReader).setLocationRepository(localRepository);
+        ((DefaultBundleReader) bundleReader).setCacheLocation(transportCacheConfig.getCacheLocation());
     }
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultBundleReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultBundleReader.java
@@ -42,7 +42,6 @@ import org.eclipse.tycho.TychoConstants;
 public class DefaultBundleReader extends AbstractLogEnabled implements BundleReader {
 
     private static final long LOCK_TIMEOUT = Long.getLong("tycho.bundlereader.lock.timeout", 5 * 60 * 1000L);
-    public static final String CACHE_PATH = ".cache/tycho";
     private final Map<String, OsgiManifest> manifestCache = new HashMap<>();
 
     private File cacheDir;
@@ -160,8 +159,8 @@ public class DefaultBundleReader extends AbstractLogEnabled implements BundleRea
         return OsgiManifest.parse(new FileInputStream(manifestFile), manifestFile.getAbsolutePath());
     }
 
-    public void setLocationRepository(File basedir) {
-        this.cacheDir = new File(basedir, CACHE_PATH);
+    public void setCacheLocation(File basedir) {
+        this.cacheDir = basedir;
     }
 
     @Override

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/test/DefaultBundleReaderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/test/DefaultBundleReaderTest.java
@@ -42,7 +42,7 @@ public class DefaultBundleReaderTest extends TychoPlexusTestCase {
         cacheDir.delete();
         cacheDir.mkdirs();
         bundleReader = (DefaultBundleReader) lookup(BundleReader.class);
-        bundleReader.setLocationRepository(cacheDir);
+        bundleReader.setCacheLocation(cacheDir);
     }
 
     @After
@@ -106,7 +106,7 @@ public class DefaultBundleReaderTest extends TychoPlexusTestCase {
     public void testGetEntryExternalJar() throws Exception {
         File bundleJar = getTestJar();
         // 370958 IOException will only occur if extraction dir exists already
-        new File(new File(cacheDir, DefaultBundleReader.CACHE_PATH), bundleJar.getName()).mkdirs();
+        new File(cacheDir, bundleJar.getName()).mkdirs();
         File externalLib = bundleReader.getEntry(bundleJar, "external:$user.home$/external-lib.jar");
         assertNull(externalLib);
     }

--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
@@ -310,7 +310,7 @@ public class MavenP2SiteMojo extends AbstractMojo {
                                 List<Exception> errors = new ArrayList<>();
                                 for (String keyServer : keyServers) {
                                     try {
-                                        PGPPublicKeyRing publicKey = pgpService.getPublicKey(keyID, keyServer, session,
+                                        PGPPublicKeyRing publicKey = pgpService.getPublicKey(keyID, keyServer,
                                                 keyServerRetry);
                                         if (publicKey != null) {
                                             publicKeys.put(keyID, publicKey);


### PR DESCRIPTION
Currently Tycho caches data in the local maven repository but the access to that directory is spread over several places.

This unifies the way to get the base directory and adds a new property 'tycho.p2.transport.cache' to allow specify an alternative location.