### PR TITLE
[bpt] Prepare for using new Transport#downloadArtifact

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransport.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TychoRepositoryTransport.java
@@ -43,6 +43,7 @@ import org.eclipse.equinox.internal.p2.repository.DownloadStatus;
 import org.eclipse.equinox.internal.provisional.p2.repository.IStateful;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
 
 @Component(role = org.eclipse.equinox.internal.p2.repository.Transport.class, hint = "tycho")
 public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.repository.Transport
@@ -85,47 +86,30 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 	}
 
 	@Override
-	public IStatus download(URI toDownload, OutputStream target, long startPos, IProgressMonitor monitor) {
-		if (startPos > 0) {
-			return new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"range downloads are not implemented");
-		}
-		return download(toDownload, target, monitor);
-	}
-
-	@Override
-	public IStatus download(URI toDownload, OutputStream target, IProgressMonitor monitor) {
+	public IStatus downloadArtifact(URI source, OutputStream target, IArtifactDescriptor descriptor,
+			IProgressMonitor monitor) {
 		String id = "p2"; // TODO we might compute the id from the IRepositoryIdManager based on the URI?
 		if (cacheConfig.isInteractive()) {
-			logger.info("Downloading from " + id + ": " + toDownload);
+			logger.info("Downloading from " + id + ": " + source);
 		}
 		try {
 			DownloadStatusOutputStream statusOutputStream = new DownloadStatusOutputStream(target,
-					"Download of " + toDownload);
-			stream(toDownload, monitor).transferTo(statusOutputStream);
+					"Download of " + source);
+			stream(source, monitor).transferTo(statusOutputStream);
 			DownloadStatus downloadStatus = statusOutputStream.getStatus();
 			if (cacheConfig.isInteractive()) {
-				logger.info("Downloaded from " + id + ": " + toDownload + " ("
+				logger.info("Downloaded from " + id + ": " + source + " ("
 						+ FileUtils.byteCountToDisplaySize(downloadStatus.getFileSize()) + " at "
 						+ FileUtils.byteCountToDisplaySize(downloadStatus.getTransferRate()) + "/s)");
 			}
 			return reportStatus(downloadStatus, target);
 		} catch (AuthenticationFailedException e) {
-			return new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"authentication failed for " + toDownload, e);
+			return Status.error("authentication failed for " + source, e);
 		} catch (IOException e) {
-			return reportStatus(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"download from " + toDownload + " failed", e), target);
+			return reportStatus(Status.error("download from " + source + " failed", e), target);
 		} catch (CoreException e) {
 			return reportStatus(e.getStatus(), target);
 		}
-	}
-
-	private IStatus reportStatus(IStatus status, OutputStream target) {
-		if (target instanceof IStateful stateful) {
-			stateful.setStatus(status);
-		}
-		return status;
 	}
 
 	@Override
@@ -162,14 +146,26 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 			if (DEBUG_REQUESTS) {
 				logger.debug(" --> generic error: " + e);
 			}
-			throw new CoreException(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"download from " + toDownload + " failed", e));
+			throw new CoreException(Status.error("download from " + toDownload + " failed", e));
 		} finally {
 			if (DEBUG_REQUESTS) {
 				logger.debug("Total number of requests: " + requests.longValue() + " (" + indexRequests.longValue()
 						+ " for p2.index)");
 			}
 		}
+	}
+
+	@Override
+	public IStatus download(URI toDownload, OutputStream target, IProgressMonitor monitor) {
+		return downloadArtifact(toDownload, target, null, monitor);
+	}
+
+	@Override
+	public IStatus download(URI toDownload, OutputStream target, long startPos, IProgressMonitor monitor) {
+		if (startPos > 0) {
+			return Status.error("range downloads are not implemented");
+		}
+		return downloadArtifact(toDownload, target, null, monitor);
 	}
 
 	TransportProtocolHandler getHandler(URI uri) {
@@ -199,8 +195,7 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 		} catch (FileNotFoundException e) {
 			throw e;
 		} catch (IOException e) {
-			throw new CoreException(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
-					"download from " + toDownload + " failed", e));
+			throw new CoreException(Status.error("download from " + toDownload + " failed", e));
 		}
 	}
 
@@ -233,6 +228,13 @@ public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.re
 
 	TransportCacheConfig getCacheConfig() {
 		return cacheConfig;
+	}
+
+	private static IStatus reportStatus(IStatus status, OutputStream target) {
+		if (target instanceof IStateful stateful) {
+			stateful.setStatus(status);
+		}
+		return status;
 	}
 
 }


### PR DESCRIPTION
P2 has a new way to download an actual P2 artifact by passing the IArtifactDescriptor to the transport so it can use additional information for caching.

This simply prepares the TychoRepositoryTransport for usages by overriding the new method and delegate calls from the old one.