### PR TITLE
[bp] Upgrade integration test bundles to BREE 17

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,43 @@
 This page describes the noteworthy improvements provided by each release of Eclipse Tycho.
 
 ## 4.0.11
+
+**Important Notice:** There was a bug in previous versions of Tycho that has lead to the situation that projects are resolved
+with a higher bundle required java version even though this was not explicitly allowed. This could also lead to the case that even though
+tests should run with a lower java version as the build, actually the build jvm defined the minimum runtime.
+
+This is now fixed, but might result in build previously working now fail due to the constraints not properly checked before, to fix those builds you have the following opportunities:
+
+1. Update the required execution environment (BREE) of your bundle to those of the dependencies (**recommended**)
+2. If you still want to target older BREE for example because you support older versions of the dependencies, you can set the BREE in your target configuration or target platform file to express the *latest runtime requirements* you are targeting.
+
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>target-platform-configuration</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		<executionEnvironment>JavaSE-17</executionEnvironment>
+	</configuration>
+</plugin>
+```
+
+3. As an alternative you can disable execution environment checks all together  (**not recommended**)
+
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>target-platform-configuration</artifactId>
+	<version>${tycho-version}</version>
+	<configuration>
+		<resolveWithExecutionEnvironmentConstraints>false</resolveWithExecutionEnvironmentConstraints>
+	</configuration>
+</plugin>
+```
+
+**Please note:** This all does not influence the compile-target, that is always derived from the BREE regardless of resolution if not otherwise configured.
+
+
 backports:
 - Support for implicit dependencies in target definitions
 

--- a/demo/bnd-pde-workspace/.mvn/maven.config
+++ b/demo/bnd-pde-workspace/.mvn/maven.config
@@ -1,3 +1,3 @@
--Dtycho-version=4.0.0-SNAPSHOT
--Dtarget-platform=https://download.eclipse.org/releases/2022-12/
+-Dtycho-version=5.0.0-SNAPSHOT
+-Dtarget-platform=https://download.eclipse.org/releases/2024-12/
 -Dtycho.resolver.classic=false

--- a/demo/bnd-pde-workspace/tycho.demo.util/META-INF/MANIFEST.MF
+++ b/demo/bnd-pde-workspace/tycho.demo.util/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: An Eclipse PDE Bundle
 Bundle-SymbolicName: tycho.demo.util
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.tycho.demo.plugin
 Import-Package: org.eclipse.tycho.demo.api

--- a/tycho-api/src/main/java/org/eclipse/tycho/ExecutionEnvironmentConfiguration.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/ExecutionEnvironmentConfiguration.java
@@ -86,6 +86,10 @@ public interface ExecutionEnvironmentConfiguration {
 
     public boolean isIgnoredByResolver();
 
+    default boolean isResolveWithEEConstraints() {
+        return !isIgnoredByResolver();
+    }
+
     /**
      * @return all known Execution Environments accessible for the same scope
      */

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -599,18 +599,22 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
             MavenSession mavenSession, ExecutionEnvironmentConfiguration sink) {
         StandardExecutionEnvironment configuredProfile = ExecutionEnvironmentUtils
                 .getExecutionEnvironment(configuredProfileName, toolchainManager, mavenSession, logger);
-        if (configuredProfile != null) {
-            // non standard profile, stick to it
-            sink.setProfileConfiguration(configuredProfileName, reason);
+        if (configuredProfile == null) {
+            //should never be the case as Tycho delegates to other profiles, but if we need to stick to the defaults...
+            return;
         }
-        StandardExecutionEnvironment currentProfile = ExecutionEnvironmentUtils.getExecutionEnvironment(
-                "JavaSE-" + Runtime.version().feature(), toolchainManager, mavenSession, logger);
-        if (currentProfile.compareTo(configuredProfile) > 0) {
-            sink.setProfileConfiguration(currentProfile.getProfileName(),
-                    "Currently running profile, newer than configured profile (" + configuredProfileName + ") from ["
-                            + reason + "]");
-        } else {
+        if (sink.isResolveWithEEConstraints()) {
             sink.setProfileConfiguration(configuredProfileName, reason);
+        } else {
+            StandardExecutionEnvironment currentProfile = ExecutionEnvironmentUtils.getExecutionEnvironment(
+                    "JavaSE-" + Runtime.version().feature(), toolchainManager, mavenSession, logger);
+            if (currentProfile != null && currentProfile.compareTo(configuredProfile) > 0) {
+                sink.setProfileConfiguration(currentProfile.getProfileName(),
+                        "Currently running profile, newer than configured profile (" + configuredProfileName
+                                + ") from [" + reason + "]");
+            } else {
+                sink.setProfileConfiguration(configuredProfileName, reason);
+            }
         }
     }
 

--- a/tycho-extras/tycho-extras-its/src/test/resources/dependencyList/dependency-with-nested-jar/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/dependencyList/dependency-with-nested-jar/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: dependent-on-bundle-with-nested-jar
 Bundle-Version: 0.1.0.qualifier
 Require-Bundle: org.junit
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-extras/tycho-extras-its/src/test/resources/dependencyList/multi-modules/dependency/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/dependencyList/multi-modules/dependency/META-INF/MANIFEST.MF
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: dependency
 Bundle-Version: 0.1.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-extras/tycho-extras-its/src/test/resources/dependencyList/multi-modules/dependent/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/dependencyList/multi-modules/dependent/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: dependent
 Bundle-Version: 0.1.0.qualifier
 Require-Bundle: dependency
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless-flat/bundle1.tests/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless-flat/bundle1.tests/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: pomless.bundle.tests
 Bundle-Version: 1.0.1
 Require-Bundle: org.junit;bundle-version="4.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless-flat/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless-flat/bundle1/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: pomless.bundle;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless-structured/bundles/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless-structured/bundles/bundle1/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: pomless.bundle;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless-structured/tests/bundle1.tests/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless-structured/tests/bundle1.tests/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: pomless.bundle.tests
 Bundle-Version: 1.0.1
 Require-Bundle: org.junit;bundle-version="4.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless/bundle1.tests/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless/bundle1.tests/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: pomless.bundle.tests
 Bundle-Version: 1.0.1
 Require-Bundle: org.junit;bundle-version="4.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless/bundle1/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: pomless.bundle;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 

--- a/tycho-its/projects/api-tools/api-break/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/api-tools/api-break/bundle1/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin with API
 Bundle-SymbolicName: api-bundle-1
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: bundle
 Automatic-Module-Name: bundle

--- a/tycho-its/projects/api-tools/missing-dependency/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/api-tools/missing-dependency/bundle1/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Plugin with API
 Bundle-SymbolicName: api-bundle-1
 Bundle-Version: 0.0.1.qualifier
 Require-Bundle: org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: bundle
 Automatic-Module-Name: bundle

--- a/tycho-its/projects/ci-friendly/buildqualifier/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/ci-friendly/buildqualifier/bundle/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: bundle Plug-in
 Bundle-SymbolicName: bundle
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: bundle
 Automatic-Module-Name: bundle

--- a/tycho-its/projects/ci-friendly/buildqualifier/bundle2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/ci-friendly/buildqualifier/bundle2/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: bundle2
 Bundle-SymbolicName: bundle2;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Require-Bundle: bundle;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: bundle2

--- a/tycho-its/projects/compiler.additional.bundles/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.additional.bundles/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: Bundles
 Bundle-SymbolicName: compiler.additional.bundles
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: compiler.additional.bundles
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/compiler.additional.bundles2/a/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.additional.bundles2/a/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Vendor: My Company
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: a; singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/compiler.additional.bundles2/b/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.additional.bundles2/b/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Vendor: My Company
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: b; singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/compiler.annotations/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.annotations/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Annotations
 Bundle-SymbolicName: compiler.annotations
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: test.osgi.annotations
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: test.osgi.annotations;version="1.5.10"    
 X-Test: MyValue
 X-Test2: MyValue2

--- a/tycho-its/projects/compiler.exclude/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.exclude/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: compilerExclude
 Bundle-Version: 1.0.0
 Bundle-Activator: exclude.Activator
 Require-Bundle: org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: mycodelib.jar

--- a/tycho-its/projects/compiler.javaxAnnotationImport/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.javaxAnnotationImport/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: TestAnnotation
 Bundle-SymbolicName: testAnnotationImport
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation

--- a/tycho-its/projects/compiler.junitcontainer/junit4-in-bundle-with-dependencies/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.junitcontainer/junit4-in-bundle-with-dependencies/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: junit4-in-bundle-with-dependencies
 Bundle-SymbolicName: junit4.in.bundle.with.dependencies
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation,
  org.osgi.framework
 Export-Package: bundle.test

--- a/tycho-its/projects/compiler.junitcontainer/junit4-in-bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.junitcontainer/junit4-in-bundle/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: junit4-in-bundle
 Bundle-SymbolicName: junit4.in.bundle
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation,
  org.osgi.framework
 Export-Package: bundle.test

--- a/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-with-linked-resources/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: junit5-with-linked-resources
 Bundle-SymbolicName: junit5.with.linked.resources
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: bundle.test

--- a/tycho-its/projects/compiler.junitcontainer/junit5-without-target/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.junitcontainer/junit5-without-target/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: junit5-without-target
 Bundle-SymbolicName: junit5.without.target
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: bundle.test

--- a/tycho-its/projects/compiler.libentry/my.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.libentry/my.bundle/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: My Bundle
 Bundle-SymbolicName: my.bundle
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: my.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: my.bundle;version="1.0.0"

--- a/tycho-its/projects/compiler.limit.modules/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.limit.modules/bundle/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle Plug-in
 Bundle-SymbolicName: bundle.jre.modules
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.w3c.dom
 Automatic-Module-Name: bundle

--- a/tycho-its/projects/compiler.pomdependencies/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/compiler.pomdependencies/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Exclude
 Bundle-SymbolicName: compiler-pomdependencies
 Bundle-Version: 1.0.0
 Bundle-Activator: guardian.Activator
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/tycho-its/projects/document-bundle-plugin/additionalDepsTest/doc.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/document-bundle-plugin/additionalDepsTest/doc.bundle/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: Doc Bundle
 Bundle-SymbolicName: doc.bundle
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: my.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/document-bundle-plugin/additionalDepsTest/my.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/document-bundle-plugin/additionalDepsTest/my.bundle/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: My Bundle
 Bundle-SymbolicName: my.bundle
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: my.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: my.bundle;version="1.0.0"

--- a/tycho-its/projects/eeProfile.resolution.fragments.unmatchinginp2/compiler.fragments.unmatchinginp2.gtk.linux.x86/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/eeProfile.resolution.fragments.unmatchinginp2/compiler.fragments.unmatchinginp2.gtk.linux.x86/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: org.eclipse.swt.graphics
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=x86))
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/eeProfile.resolution.fragments.unmatchinginp2/compiler.fragments.unmatchinginp2.unmatching/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/eeProfile.resolution.fragments.unmatchinginp2/compiler.fragments.unmatchinginp2.unmatching/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: org.eclipse.swt.graphics
 Eclipse-PlatformFilter: (& (osgi.ws=unknown) (osgi.os=unknown) (osgi.arch=unknown))
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/eeProfile.resolution.fragments.unmatchinginp2/compiler.fragments.unmatchinginp2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/eeProfile.resolution.fragments.unmatchinginp2/compiler.fragments.unmatchinginp2/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Eclipse-ExtensibleAPI: true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/eeProfile/dependencyHigherBREE/pom.xml
+++ b/tycho-its/projects/eeProfile/dependencyHigherBREE/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -7,6 +8,10 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<artifactId>parent</artifactId>
 	<packaging>pom</packaging>
+	
+	<properties>
+		<resolveWithConstraints>false</resolveWithConstraints>
+	</properties>
 
 	<modules>
 		<module>bundleHigherBREE</module>
@@ -20,6 +25,13 @@
 				<artifactId>tycho-maven-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<configuration>
+					<resolveWithExecutionEnvironmentConstraints>${resolveWithConstraints}</resolveWithExecutionEnvironmentConstraints>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-its/projects/issue23/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/issue23/bundle/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: bundle Plug-in
 Bundle-SymbolicName: bundle
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: bundle
 Automatic-Module-Name: bundle
 Require-Bundle: org.eclipse.core.runtime

--- a/tycho-its/projects/issue23/bundle2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/issue23/bundle2/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: bundle2
 Bundle-SymbolicName: bundle2;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Require-Bundle: bundle;bundle-version="0.0.1"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: bundle2

--- a/tycho-its/projects/issue2937/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/issue2937/bundle/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: bundle
 Bundle-SymbolicName: bundle
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: bundle
 Require-Bundle: org.python.pydev

--- a/tycho-its/projects/issue697/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/issue697/bundle1/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: bundle
 Bundle-SymbolicName: bundle
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: bundle
 Require-Bundle: wrapped.de.monticore.monticore-runtime;bundle-version="7.2.0"

--- a/tycho-its/projects/issue697/bundle2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/issue697/bundle2/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: bundle2
 Bundle-SymbolicName: bundle2
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: bundle2
 Require-Bundle: dsltool-api;bundle-version="0.0.1"

--- a/tycho-its/projects/mixed.reactor/tycho.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/mixed.reactor/tycho.bundle/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Tycho Bundle
 Bundle-SymbolicName: tycho.bundle
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: tycho.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: felix.bundle.exported

--- a/tycho-its/projects/multiPlatform.product/tycho.demo.application/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/multiPlatform.product/tycho.demo.application/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Activator: tycho.demo.application.Activator
 Require-Bundle: org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: tycho.demo.application

--- a/tycho-its/projects/multiple-gson/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/multiple-gson/bundle/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Import-Package: com.google.gson;version="[2.9.1,2.10.0)",
  org.eclipse.osgi.container;version="1.6.0"
 Automatic-Module-Name: org.example.gson
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 

--- a/tycho-its/projects/p2Repository.duplicateDownload/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2Repository.duplicateDownload/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Plugin 1
 Bundle-SymbolicName: issue-670
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: plugin.1
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: com.google.guava,
   org.eclipse.swt

--- a/tycho-its/projects/p2mavensite.reactor/deployme/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2mavensite.reactor/deployme/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Test-mvn-updatesite-reactor-deployme
 Bundle-SymbolicName: test.mvn.updatesite.reactor.deployme
 Bundle-Version: 1.0.0
 Automatic-Module-Name: test.mvn.updatesite.reactor.deployme
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jetty.http

--- a/tycho-its/projects/p2mavensite.reactor/ignoreme-property/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2mavensite.reactor/ignoreme-property/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Test-mvn-updatesite-reactor-ignoreme-property
 Bundle-SymbolicName: test.mvn.updatesite.reactor.ignoreme.property
 Bundle-Version: 1.0.0
 Automatic-Module-Name: test.mvn.updatesite.reactor.ignoreme.property
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jetty.http

--- a/tycho-its/projects/p2mavensite.reactor/ignoreme/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2mavensite.reactor/ignoreme/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Test-mvn-updatesite-reactor-ignoreme
 Bundle-SymbolicName: test.mvn.updatesite.reactor.ignoreme
 Bundle-Version: 1.0.0
 Automatic-Module-Name: test.mvn.updatesite.reactor.ignoreme
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jetty.http

--- a/tycho-its/projects/p2mavensite/consumer/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2mavensite/consumer/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Test-mvn-updatesite
 Bundle-SymbolicName: test.mvn.updatesite
 Bundle-Version: 1.0.0
 Automatic-Module-Name: test.mvn.updatesite
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jetty.http

--- a/tycho-its/projects/packaging.consumer.pom/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/packaging.consumer.pom/bundle/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin with API
 Bundle-SymbolicName: api-bundle
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime
 Automatic-Module-Name: bundle

--- a/tycho-its/projects/packaging.manifestAndFeature/plugin1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/packaging.manifestAndFeature/plugin1/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Example Plugin
 Bundle-SymbolicName: plugin1;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: ${vendorName}
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: packaging.manifestAndFeature.plugin1

--- a/tycho-its/projects/pomless-model/bundles-2/foo.bar.bundle-5/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles-2/foo.bar.bundle-5/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.bundle-5
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-3/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-3/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.bundle-3
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-4/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-4/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.bundle-4
 Bundle-Version: 1.0.0
 Automatic-Module-Name: foo.bar.plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/pomless-model/bundles/foo.bar.bundle-2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles/foo.bar.bundle-2/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.bundle-2
 Bundle-Version: 1.0.0
 Automatic-Module-Name: foo.bar.plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/pomless-model/bundles/foo.bar.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles/foo.bar.bundle/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.bundle
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/pomless-model/foo.bar.plugin-2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/foo.bar.plugin-2/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.plugin-2
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/pomless-model/foo.bar.plugin/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/foo.bar.plugin/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.plugin
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/pomless/bnd/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless/bnd/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: This Bundle uses BND to generate some metadata
 Bundle-SymbolicName: plugin.project.using.bnd
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: plugin.project.using.bnd
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/pomless/sourcefolder/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless/sourcefolder/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: This Bundle uses the classpath to define source folders
 Bundle-SymbolicName: plugin.project.using.classpath
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/product.types/foo.bar.plugin.in.feature/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/product.types/foo.bar.plugin.in.feature/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.plugin.in.feature
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/product.types/foo.bar.plugin/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/product.types/foo.bar.plugin/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plugin
 Bundle-SymbolicName: foo.bar.plugin
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/resolver.cycles/plugin1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.cycles/plugin1/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Plugin1
 Bundle-SymbolicName: plugin1
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: plugin1
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: plugin2

--- a/tycho-its/projects/resolver.cycles/plugin2.tests/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.cycles/plugin2.tests/META-INF/MANIFEST.MF
@@ -5,5 +5,5 @@ Bundle-SymbolicName: plugin2.tests
 Bundle-Version: 0.0.1.qualifier
 Fragment-Host: plugin2
 Automatic-Module-Name: plugin2.tests
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: plugin1

--- a/tycho-its/projects/resolver.cycles/plugin2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.cycles/plugin2/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: Plugin2
 Bundle-SymbolicName: plugin2
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: plugin2
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/resolver.generateSources/a/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.generateSources/a/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Vendor: My Company
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: a; singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/resolver.generateSources/b/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.generateSources/b/META-INF/MANIFEST.MF
@@ -7,4 +7,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: b; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: a
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/resolver.multipleDownloads/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.multipleDownloads/bundle1/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle 1
 Bundle-SymbolicName: bundle1;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.swt;bundle-version="3.119.0"

--- a/tycho-its/projects/resolver.pomDependencies/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.pomDependencies/test.bundle/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/resolver.reexportBundle/org.eclipse.core.expressions/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.reexportBundle/org.eclipse.core.expressions/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.core.expressions
 Bundle-Version: 3.7.100.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.3.0,4.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.w3c.dom

--- a/tycho-its/projects/resolver.reexportBundle/transitively.require.org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.reexportBundle/transitively.require.org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: transitively.require.org.eclipse.osgi
 Bundle-Version: 0.0.1.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.3.0,4.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: transitively.require.org.eclipse.osgi

--- a/tycho-its/projects/resolver.split/org.eclipse.equinox.security/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.split/org.eclipse.equinox.security/META-INF/MANIFEST.MF
@@ -37,7 +37,7 @@ Import-Package: javax.crypto,
  org.osgi.framework;version="[1.4.0,2.0.0)",
  org.osgi.service.prefs;version="[1.1.0,2.0.0)",
  org.osgi.util.tracker;version="[1.3.3,2.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Eclipse-BuddyPolicy: registered
 Automatic-Module-Name: org.eclipse.equinox.security

--- a/tycho-its/projects/resolver.tycho1127_addjars_issue/a/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.tycho1127_addjars_issue/a/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Vendor: My Company
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: a; singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/resolver.tycho1127_addjars_issue/b/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.tycho1127_addjars_issue/b/META-INF/MANIFEST.MF
@@ -7,4 +7,4 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: b; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: a
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle with w3c depdencies
 Bundle-SymbolicName: bundle.test.w3c
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime,
  org.apache.batik.dom;bundle-version="1.14.0"

--- a/tycho-its/projects/sameAbsoluteTarget/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/sameAbsoluteTarget/bundle1/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: bundle
 Bundle-SymbolicName: bundle
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: bundle
 Require-Bundle: org.apache.commons.lang3

--- a/tycho-its/projects/sameAbsoluteTarget/bundle2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/sameAbsoluteTarget/bundle2/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: bundle2
 Bundle-SymbolicName: bundle2
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: bundle2
 Require-Bundle: org.apache.commons.lang3

--- a/tycho-its/projects/surefire.appArgs/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.appArgs/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: TYCHO0290appArgs
 Bundle-SymbolicName: TYCHO0290appArgs
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit,
  org.eclipse.core.runtime

--- a/tycho-its/projects/surefire.bundleStart/explicit/explicit.start.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.bundleStart/explicit/explicit.start.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: explicit.start.test;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: system.bundle,
  org.junit;bundle-version="4.0.0",
  explicit.start;bundle-version="1.0.0"

--- a/tycho-its/projects/surefire.bundleStart/explicit/explicit.start/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.bundleStart/explicit/explicit.start/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Start
 Bundle-SymbolicName: explicit.start;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Activator: explicit.start.Activator
 Require-Bundle: system.bundle
 Export-Package: explicit.start

--- a/tycho-its/projects/surefire.bundleStart/implicit/ds.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.bundleStart/implicit/ds.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle
 Bundle-SymbolicName: ds.test;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Service-Component: OSGI-INF/component.xml
 Require-Bundle: org.junit;bundle-version="4.5.0",
  system.bundle

--- a/tycho-its/projects/surefire.bundleUnpack/tycho340.plugin/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.bundleUnpack/tycho340.plugin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle01 Plug-in
 Bundle-SymbolicName: org.codehaus.tycho.tychoits.tycho0340.plugin
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: bundle01
 Require-Bundle: org.eclipse.osgi;bundle-version="3.2.0"
 Bundle-Activator: bundle01.Bundle01Activator

--- a/tycho-its/projects/surefire.bundleUnpack/tycho340.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.bundleUnpack/tycho340.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle02 Plug-in
 Bundle-SymbolicName: org.codehaus.tycho.tychoits.tycho0340.test
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="3.8.2",
  org.apache.ant;bundle-version="1.7.0",
  org.codehaus.tycho.tychoits.tycho0340.plugin,

--- a/tycho-its/projects/surefire.combinedtests/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.combinedtests/bundle.test/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Test Plug-in
 Bundle-SymbolicName: bundle.test
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation,
  org.osgi.framework

--- a/tycho-its/projects/surefire.combinedtests/bundle5.no.vintage.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.combinedtests/bundle5.no.vintage.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.0.0
 Import-Package: javax.annotation,
  org.osgi.framework
 Automatic-Module-Name: bundle.test5
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.combinedtests/bundle5.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.combinedtests/bundle5.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.0.0
 Import-Package: javax.annotation,
  org.osgi.framework
 Automatic-Module-Name: bundle.test5
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.enableAssertions/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.enableAssertions/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: tycho.surefire.enableAssertions
 Bundle-Version: 0.0.1.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.envVars/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.envVars/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: tycho.431793
 Bundle-Version: 0.0.1.qualifier
 Require-Bundle: org.junit;bundle-version="4.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.frameworkExtensions/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.frameworkExtensions/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: TYCHO351testSystemProperties
 Bundle-SymbolicName: TYCHO351testSystemProperties
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit,
  org.eclipse.core.runtime

--- a/tycho-its/projects/surefire.junit4/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit4/bundle.test/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Test Plug-in
 Bundle-SymbolicName: bundle.test
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.0.0"

--- a/tycho-its/projects/surefire.junit47/categories/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit47/categories/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: tychoits.categories.testbundle
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.8.0"

--- a/tycho-its/projects/surefire.junit47/parallel/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit47/parallel/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.tychoits.junit47
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.7.0"

--- a/tycho-its/projects/surefire.junit4and54/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit4and54/bundle.test/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JUnit4and5 Test Plug-in
 Bundle-SymbolicName: bundle.test.junit4and54
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit;version="4.12",
  org.junit.jupiter.api;version="5.4.0"

--- a/tycho-its/projects/surefire.junit5/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit5/bundle.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JUnit5 Test Plug-in
 Bundle-SymbolicName: bundle.test.junit5
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit;version="4.12",
  org.junit.jupiter.api;version="5.0",
  org.junit.jupiter.params;version="5.0",

--- a/tycho-its/projects/surefire.junit54/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit54/bundle.test/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JUnit54 Test Plug-in
 Bundle-SymbolicName: bundle.test.junit54
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit.jupiter.api;version="5.4.0"

--- a/tycho-its/projects/surefire.junit56/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit56/bundle.test/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JUnit56 Test Plug-in
 Bundle-SymbolicName: bundle.test.junit56
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit.jupiter.api;version="5.6.0"

--- a/tycho-its/projects/surefire.junit59/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit59/bundle.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JUnit59 Test Plug-in
 Bundle-SymbolicName: bundle.test.junit59
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit.jupiter.api;version="5.9.0",
  org.junit.jupiter.params;version="5.9.0",
  org.junit.jupiter.params.provider;version="5.9.0"

--- a/tycho-its/projects/surefire.junit59suite/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit59suite/bundle.test/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JUnit5 Suite Test Plug-in
 Bundle-SymbolicName: bundle.test.junit59suite
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit.jupiter.api;version="5.9.0",
  org.junit.platform.suite.api;version="1.9.0"

--- a/tycho-its/projects/surefire.junit5tempdir/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit5tempdir/bundle.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JUnit5 @TempDir Test Plug-in
 Bundle-SymbolicName: bundle.test.junit5tempdir
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit;version="4.12",
  org.junit.jupiter.api;version="5.5",
  org.junit.jupiter.api.io;version="5.5"

--- a/tycho-its/projects/surefire.jvmArgs/bundle.tests/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.jvmArgs/bundle.tests/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: build.tests
 Bundle-Version: 0.0.1.qualifier
 Require-Bundle: org.junit;bundle-version="4.12.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.noTests/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.noTests/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle
 Bundle-SymbolicName: TYCHO0432configurableFailIfNoTests;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.0.0"
 Bundle-ActivationPolicy: lazy

--- a/tycho-its/projects/surefire.opentest4j/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.opentest4j/bundle.test/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: OpenTest4J Usage Test Plug-in
 Bundle-SymbolicName: bundle.test.opentest4j
 Bundle-Version: 1.0.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.junit.jupiter.api;version="5.5",
  org.opentest4j;version="1.2.0"

--- a/tycho-its/projects/surefire.p2InstalledRuntime/extProductTest/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.p2InstalledRuntime/extProductTest/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-SymbolicName: spir.extProductTest
 Bundle-Version: 1.0.0
 Require-Bundle: org.junit,
  org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.p2InstalledRuntime/extProductTestDirector/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.p2InstalledRuntime/extProductTestDirector/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-SymbolicName: spir.extProductTest
 Bundle-Version: 1.0.0
 Require-Bundle: org.junit,
  org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.p2InstalledRuntime/productTest/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.p2InstalledRuntime/productTest/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-SymbolicName: spir.productTest
 Bundle-Version: 1.0.0
 Require-Bundle: org.junit,
  org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.requireBundle.multipleVersions/surefire.requireBundle.bundletest/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.requireBundle.multipleVersions/surefire.requireBundle.bundletest/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundletest
 Bundle-SymbolicName: surefire.requireBundle.coretest
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.junit.jupiter.api
 Require-Bundle: surefire.requireBundle.core;bundle-version="[1,2)";resolution:=optional,

--- a/tycho-its/projects/surefire.requireBundle/surefire.requireBundle.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.requireBundle/surefire.requireBundle.bundle/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: surefire.requireBundle.core;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: STEGMANNSYSTEMS
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.tycho.debugtychosurefire.bundle
 Require-Bundle: org.junit,

--- a/tycho-its/projects/surefire.requireBundle/surefire.requireBundle.bundletest/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.requireBundle/surefire.requireBundle.bundletest/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundletest
 Bundle-SymbolicName: surefire.requireBundle.coretest
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit,
  surefire.requireBundle.core;bundle-version="0.0.1"

--- a/tycho-its/projects/surefire.systemProperties/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.systemProperties/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: TYCHO351testSystemProperties
 Bundle-SymbolicName: TYCHO351testSystemProperties
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit,
  org.eclipse.core.runtime

--- a/tycho-its/projects/surefire.testSelection/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.testSelection/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle
 Bundle-SymbolicName: TYCHO0356runSingleTest;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.0.0",
  system.bundle
 Bundle-ActivationPolicy: lazy

--- a/tycho-its/projects/surefire.toolchains/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.toolchains/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: toolchains
 Bundle-SymbolicName: toolchains
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit,
  org.eclipse.core.runtime

--- a/tycho-its/projects/surefire.trimstacktrace/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.trimstacktrace/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: surefire.trimstacktrace
 Bundle-Version: 1.0.0.qualifier
 Import-Package: org.junit;version="4.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.twoJunitVersions/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.twoJunitVersions/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: bundle.test
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="3.8.0"

--- a/tycho-its/projects/target.artifact.caching/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.artifact.caching/test.bundle/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: tycho.test.package

--- a/tycho-its/projects/target.directory/test.directory.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.directory/test.directory.bundle/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.directory.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: directory.bundle;bundle-version="0.0.1"

--- a/tycho-its/projects/target.maven-scopes/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven-scopes/test.bundle/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: net.bytebuddy.byte-buddy;bundle-version="1.12.1",
  net.bytebuddy.byte-buddy-agent;bundle-version="1.12.1",
  org.mockito.mockito-core;bundle-version="4.1.0",

--- a/tycho-its/projects/target.maven.autofeature/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven.autofeature/test.bundle/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/target.maven.httpAuthentication/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven.httpAuthentication/test.bundle/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle Plug-in
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: bundle

--- a/tycho-its/projects/target.maven.pom/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven.pom/test.bundle/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: jakarta.xml.bind-api;bundle-version="[3.0.1,4.0.0)"

--- a/tycho-its/projects/target.maven.wrapAsBundle/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven.wrapAsBundle/bundle/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-Version: 0.0.1.qualifier
 Require-Bundle: org.apache.commons.lang3;resolution:=optional
 Import-Package: okhttp3;resolution:=optional
 Automatic-Module-Name: bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/target.maven/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven/test.bundle/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: wrapped.oro.oro;bundle-version="2.0.8",
  custom.name.test;bundle-version="3.141.59",
  org.apache.commons.lang;bundle-version="2.4.0"

--- a/tycho-its/projects/target.mavenMulti/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.mavenMulti/test.bundle/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jetty.http;bundle-version="11.0.6",
  slf4j.api;bundle-version="2.0.0"

--- a/tycho-its/projects/target.mavenRepos/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.mavenRepos/test.bundle/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 0.0.1.qualifier
 Require-Bundle: wrapped.edu.ucar.cdm;bundle-version="5.0.0",
  wrapped.edu.ucar.udunits;bundle-version="5.0.0"
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/target.offlineModeCompositeRepo/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.offlineModeCompositeRepo/bundle/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle
 Bundle-SymbolicName: offlinemode.compositerepo.bundle
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: offlinemode.compositerepo.child1.bundle, offlinemode.compositerepo.child2.bundle

--- a/tycho-its/projects/target.offlineModeXZRepo/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.offlineModeXZRepo/bundle/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bundle
 Bundle-SymbolicName: offlinemode.xzrepo.bundle
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: offlinemode.xzrepo.bundlefromrepo

--- a/tycho-its/projects/target.plannerWithDependenciesInDifferentTargetLocation/pom.xml
+++ b/tycho-its/projects/target.plannerWithDependenciesInDifferentTargetLocation/pom.xml
@@ -24,9 +24,7 @@
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho-version}</version>
                 <configuration>
-                    <resolver>p2</resolver>
                     <pomDependencies>consider</pomDependencies>
-                    <executionEnvironment>JavaSE-11</executionEnvironment>
                     <target>
                         <artifact>
                             <groupId>tycho-its-project.p2Repository.slicerDependencies</groupId>

--- a/tycho-its/projects/target.plannerWithDependenciesInDifferentTargetLocation/project/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.plannerWithDependenciesInDifferentTargetLocation/project/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: project
 Bundle-Version: 1.0.0
 Automatic-Module-Name: bundle3
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: bundle2

--- a/tycho-its/projects/target.plannerWithMissingDependencies/project/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.plannerWithMissingDependencies/project/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: project
 Bundle-Version: 1.0.0
 Automatic-Module-Name: bundle3
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: bundle2

--- a/tycho-its/projects/target.references/test.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.references/test.bundle/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Bundle
 Bundle-SymbolicName: test.bundle
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: test.bundle
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.commons.cli;bundle-version="1.4.0"

--- a/tycho-its/projects/target.slicerWithDependenciesInDifferentTargetLocation/pom.xml
+++ b/tycho-its/projects/target.slicerWithDependenciesInDifferentTargetLocation/pom.xml
@@ -24,9 +24,7 @@
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho-version}</version>
                 <configuration>
-                    <resolver>p2</resolver>
                     <pomDependencies>consider</pomDependencies>
-                    <executionEnvironment>JavaSE-11</executionEnvironment>
                     <target>
                         <artifact>
                             <groupId>tycho-its-project.p2Repository.slicerDependencies</groupId>

--- a/tycho-its/projects/target.slicerWithDependenciesInDifferentTargetLocation/project/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.slicerWithDependenciesInDifferentTargetLocation/project/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: project
 Bundle-Version: 1.0.0
 Automatic-Module-Name: bundle3
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: bundle2

--- a/tycho-its/projects/target.slicerWithMissingDependencies/project/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.slicerWithMissingDependencies/project/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: project
 Bundle-Version: 1.0.0
 Automatic-Module-Name: bundle3
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: bundle2

--- a/tycho-its/projects/target.variables/env/pom.xml
+++ b/tycho-its/projects/target.variables/env/pom.xml
@@ -24,9 +24,7 @@
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho-version}</version>
                 <configuration>
-                    <resolver>p2</resolver>
                     <pomDependencies>consider</pomDependencies>
-                    <executionEnvironment>JavaSE-11</executionEnvironment>
                     <target>
                         <artifact>
                             <groupId>tycho-its-project.variables.env</groupId>

--- a/tycho-its/projects/target.variables/env/project/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.variables/env/project/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: project
 Bundle-Version: 1.0.0
 Automatic-Module-Name: project
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: javax.xml

--- a/tycho-its/projects/target.variables/sysprop/pom.xml
+++ b/tycho-its/projects/target.variables/sysprop/pom.xml
@@ -24,9 +24,7 @@
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho-version}</version>
                 <configuration>
-                    <resolver>p2</resolver>
                     <pomDependencies>consider</pomDependencies>
-                    <executionEnvironment>JavaSE-11</executionEnvironment>
                     <target>
                         <artifact>
                             <groupId>tycho-its-project.variables.sysprop</groupId>

--- a/tycho-its/projects/target.variables/sysprop/project/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.variables/sysprop/project/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: project
 Bundle-Version: 1.0.0
 Automatic-Module-Name: project
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: javax.xml

--- a/tycho-its/projects/tycho-ds/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-ds/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tycho DS
 Bundle-SymbolicName: tycho.ds
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: tycho.ds
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Service-Component: OSGI-INF/tycho.ds.TestComponent.xml,
  OSGI-INF/tycho.ds.TestComponent2.xml
 Bundle-ActivationPolicy: lazy

--- a/tycho-its/projects/tycho.xtend/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho.xtend/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: tycho.xtend
 Bundle-SymbolicName: tycho.xtend
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: tycho.xtend
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.25.0"

--- a/tycho-its/projects/tycho154/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho154/bundle/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: bundle
 Bundle-Version: 0.0.1.qualifier
 Bundle-ClassPath: simple.jar
 Export-Package: simple.jar
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/tycho937/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho937/bundle/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Bundle-ManifestVersion: 2
 Bundle-Name: ExecutionEnvironments Test
 Bundle-SymbolicName: tycho937
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/workspaceReader/dependencyFromMavenRepo/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/workspaceReader/dependencyFromMavenRepo/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Plugin 1
 Bundle-SymbolicName: issue1043
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: plugin.1
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.osgi.util.promise

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/DependencyResolverEETest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/DependencyResolverEETest.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.eeProfile;
 
+import static org.junit.Assert.assertThrows;
+
+import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil;
@@ -39,8 +42,18 @@ public class DependencyResolverEETest extends AbstractTychoIntegrationTest {
 	@Test
 	public void breeForDependencyHigherThanCurrentBREE() throws Exception {
 		Verifier verifier = getVerifier("/eeProfile/dependencyHigherBREE", false);
+		verifier.setSystemProperty("resolveWithConstraints", "false");
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
+	}
+
+	@Test
+	public void breeForDependencyHigherThanCurrentBREEAndConstraints() throws Exception {
+		Verifier verifier = getVerifier("/eeProfile/dependencyHigherBREE", false);
+		verifier.setSystemProperty("resolveWithConstraints", "true");
+		assertThrows(VerificationException.class, () -> verifier.executeGoal("verify"));
+		verifier.verifyTextInLog(
+				"requires Execution Environment that matches (&(osgi.ee=JavaSE)(version=1.8)) but the current resolution context uses [a.jre.javase 1.6.0]");
 	}
 
 }


### PR DESCRIPTION
Currently we have a lot of old integration tests that require different BREEs due to historical reasons even though we already depend on much newer dependencies.

This update the BREE of all test that do not explicitly test a specific feature related to the BREE to Java 17 to reflect the things we actually use.