### PR TITLE
Skip packages without a version

### DIFF
--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/DependencyCheckMojo.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/DependencyCheckMojo.java
@@ -165,6 +165,12 @@ public class DependencyCheckMojo extends AbstractMojo {
 				IInstallableUnit unit = packageProvidingUnit.get();
 				Optional<org.eclipse.equinox.p2.metadata.Version> matchedPackageVersion = ArtifactMatcher
 						.getPackageVersion(unit, packageName);
+				if (matchedPackageVersion.isEmpty()
+						|| matchedPackageVersion.get().equals(org.eclipse.equinox.p2.metadata.Version.emptyVersion)) {
+					log.warn("Package " + packageName
+							+ " has no version exported and can not be checked for compatibility");
+					continue;
+				}
 				matchedPackageVersion.filter(v -> v.isOSGiCompatible()).ifPresent(v -> {
 					Version current = new Version(v.toString());
 					allPackageVersion.computeIfAbsent(packageName, nil -> new TreeSet<>()).add(current);


### PR DESCRIPTION
If the current matched dependency has no version on the package export we can't really do anything useful in checking a package version range as it will result in a minimal import version of [0,1).

This now skip packages that have no version range currently present.