### PR TITLE
Add abstraction support for the code executed inside the OSGi Framework

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/framework/Bundles.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/framework/Bundles.java
@@ -19,6 +19,8 @@ public record Bundles(Set<String> bundles) {
     public static final String BUNDLE_API_TOOLS = "org.eclipse.pde.api.tools";
     public static final String BUNDLE_ECLIPSE_HELP_BASE = "org.eclipse.help.base";
     public static final String BUNDLE_PDE_CORE = "org.eclipse.pde.core";
+    public static final String BUNDLE_JDT_CORE = "org.eclipse.jdt.core";
+
     static final String BUNDLE_LAUNCHING_MACOS = "org.eclipse.jdt.launching.macosx";
     static final String BUNDLE_APP = "org.eclipse.equinox.app";
     static final String BUNDLE_SCR = "org.apache.felix.scr";

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/EclipseBuildProjectMojo.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/EclipseBuildProjectMojo.java
@@ -38,10 +38,9 @@ public class EclipseBuildProjectMojo extends AbstractEclipseBuildMojo<EclipseBui
 		return "Eclipse Project Build";
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	protected EclipseBuild createExecutable() {
-		return new EclipseBuild(project.getBasedir().toPath(), debug);
+	protected EclipseProjectBuild createExecutable() {
+		return new EclipseProjectBuild(project.getBasedir().toPath(), debug);
 	}
 
 	@Override

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/EclipseProjectBuild.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/EclipseProjectBuild.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.eclipsebuild;
+
+import java.nio.file.Path;
+
+import org.eclipse.core.resources.IProject;
+
+public class EclipseProjectBuild extends AbstractEclipseBuild<EclipseBuildResult> {
+
+	EclipseProjectBuild(Path projectDir, boolean debug) {
+		super(projectDir, debug);
+	}
+
+	@Override
+	protected EclipseBuildResult createResult(IProject project) {
+		return new EclipseBuildResult();
+	}
+
+}

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/SetTargetPlatform.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/SetTargetPlatform.java
@@ -38,14 +38,14 @@ public class SetTargetPlatform implements Callable<Serializable>, Serializable {
 
 	SetTargetPlatform(Collection<Path> dependencyBundles, boolean debug) {
 		this.debug = debug;
-		this.targetBundles = dependencyBundles.stream().map(EclipseBuild::pathAsString).toList();
+		this.targetBundles = dependencyBundles.stream().map(EclipseProjectBuild::pathAsString).toList();
 	}
 
 	@Override
 	public Serializable call() throws Exception {
 		ILogListener listener = (status, plugin) -> debug(status.toString());
 		Platform.addLogListener(listener);
-		EclipseBuild.disableAutoBuild();
+		EclipseProjectBuild.disableAutoBuild();
 		ITargetPlatformService service = TargetPlatformService.getDefault();
 		ITargetDefinition target = service.newTarget();
 		target.setName("buildpath");


### PR DESCRIPTION
Currently the code for executing a build in the embedded framework is non trivial as well.

This now uses an abstract class here as well and add support for the EclipseFramework to use such one level indirection as well.