### PR TITLE
Catch OsgiManifestParserException in maven artifact provider

### DIFF
--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/provider/MavenArtifactVersionProvider.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/provider/MavenArtifactVersionProvider.java
@@ -45,6 +45,7 @@ import org.eclipse.tycho.artifacts.ArtifactVersion;
 import org.eclipse.tycho.artifacts.ArtifactVersionProvider;
 import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.OsgiManifest;
+import org.eclipse.tycho.core.osgitools.OsgiManifestParserException;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.VersionRange;
 import org.osgi.framework.namespace.PackageNamespace;
@@ -165,10 +166,10 @@ public class MavenArtifactVersionProvider implements ArtifactVersionProvider {
 
 	private ModuleRevisionBuilder readOSGiInfo(Path path) {
 		if (path != null) {
-			OsgiManifest manifest = bundleReader.loadManifest(path.toFile());
 			try {
+				OsgiManifest manifest = bundleReader.loadManifest(path.toFile());
 				return OSGiManifestBuilderFactory.createBuilder(manifest.getHeaders());
-			} catch (BundleException e) {
+			} catch (BundleException | OsgiManifestParserException e) {
 			}
 		}
 		return null;


### PR DESCRIPTION
Maven artifacts are not required to be valid bundles, in such case a OsgiManifestParserException can be thrown when query for the package version that then fails the build.

This now catches OsgiManifestParserException to prevent the issue from happening.