### PR TITLE
[bp] Create new tycho-cleancode plugin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,8 @@ This is now fixed, but might result in build previously working now fail due to 
 backports:
 - Support for implicit dependencies in target definitions
 - Add tycho-baseline:check-dependencies mojo
+- Add tycho-cleancode plugin
+
 
 ## 4.0.10
 

--- a/pom.xml
+++ b/pom.xml
@@ -595,6 +595,7 @@
 		<module>tycho-repository-plugin</module>
 		<module>tycho-eclipse-plugin</module>
 		<module>tycho-wrap-plugin</module>
+		<module>tycho-cleancode-plugin</module>
 	</modules>
 	<profiles>
 		<profile>

--- a/tycho-cleancode-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-cleancode-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/tycho-cleancode-plugin/pom.xml
+++ b/tycho-cleancode-plugin/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho</artifactId>
+		<version>4.0.11-SNAPSHOT</version>
+	</parent>
+	<artifactId>tycho-cleancode-plugin</artifactId>
+	<name>Tycho Eclipse Plugin</name>
+	<packaging>maven-plugin</packaging>
+	<prerequisites>
+		<maven>${minimal-maven-version}</maven>
+	</prerequisites>
+	<description>Maven Plugins for performing automatic code clean options</description>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>tycho-eclipse-plugin</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jdt</groupId>
+			<artifactId>org.eclipse.jdt.ui</artifactId>
+			<version>3.33.200</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jdt</groupId>
+			<artifactId>org.eclipse.jdt.core.manipulation</artifactId>
+			<version>1.21.300</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-component-metadata</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<!-- workaround for
+				https://issues.apache.org/jira/browse/MPLUGIN-450 -->
+				<configuration>
+					<goalPrefix>tycho-cleancode</goalPrefix>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanUp.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanUp.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.corext.fix.CleanUpPreferenceUtil;
+import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoring;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.fix.MapCleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.ICleanUp;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.tycho.eclipsebuild.AbstractEclipseBuild;
+
+public class CleanUp extends AbstractEclipseBuild<CleanupResult> {
+
+	private Map<String, String> customProfile;
+
+	CleanUp(Path projectDir, boolean debug, Map<String, String> customProfile) {
+		super(projectDir, debug);
+		this.customProfile = customProfile;
+	}
+
+	@Override
+	protected CleanupResult createResult(IProject project) throws Exception {
+		CleanupResult result = new CleanupResult();
+		CleanUpOptions options = getOptions(project);
+		ICleanUp[] cleanups = getCleanups(result, options);
+		if (cleanups.length > 0) {
+			List<ICompilationUnit> units = getCompilationUnits(project);
+			final CleanUpRefactoring refactoring = new CleanUpRefactoring(project.getName());
+			for (ICompilationUnit cu : units) {
+				refactoring.addCompilationUnit(cu);
+			}
+			refactoring.setUseOptionsFromProfile(false);
+			for (ICleanUp cleanUp : cleanups) {
+				refactoring.addCleanUp(cleanUp);
+			}
+			final RefactoringStatus status = refactoring.checkAllConditions(this);
+			if (status.isOK()) {
+				Change change = refactoring.createChange(this);
+				change.initializeValidationData(this);
+				PerformChangeOperation performChangeOperation = new PerformChangeOperation(change);
+				performChangeOperation.run(this);
+			} else if (status.hasError()) {
+				throw new RuntimeException("Refactoring failed: " + status);
+			}
+		}
+		return result;
+	}
+
+	private List<ICompilationUnit> getCompilationUnits(IProject project) throws JavaModelException {
+		IJavaProject javaProject = JavaCore.create(project);
+		List<ICompilationUnit> units = new ArrayList<ICompilationUnit>();
+		IPackageFragmentRoot[] packages = javaProject.getPackageFragmentRoots();
+		for (IPackageFragmentRoot root : packages) {
+			if (root.getKind() == IPackageFragmentRoot.K_SOURCE) {
+				for (IJavaElement javaElement : root.getChildren()) {
+					if (javaElement.getElementType() == IJavaElement.PACKAGE_FRAGMENT) {
+						IPackageFragment pf = (IPackageFragment) javaElement;
+						ICompilationUnit[] compilationUnits = pf.getCompilationUnits();
+						for (ICompilationUnit compilationUnit : compilationUnits) {
+							units.add(compilationUnit);
+						}
+					}
+				}
+			}
+		}
+		return units;
+	}
+
+	private ICleanUp[] getCleanups(CleanupResult result, CleanUpOptions options) {
+		ICleanUp[] cleanUps = JavaPlugin.getDefault().getCleanUpRegistry().createCleanUps();
+		for (ICleanUp cleanUp : cleanUps) {
+			try {
+				cleanUp.setOptions(options);
+				String[] descriptions = cleanUp.getStepDescriptions();
+				if (descriptions != null) {
+					for (String description : descriptions) {
+						result.addCleanup(description);
+					}
+				}
+			} catch (Exception e) {
+				debug("Ignore cleanup '" + cleanUp + "' because of initialization error.", e);
+			}
+		}
+		return cleanUps;
+	}
+
+	private CleanUpOptions getOptions(IProject project) {
+		Map<String, String> options;
+		if (customProfile == null || customProfile.isEmpty()) {
+			options = CleanUpPreferenceUtil.loadOptions(new ProjectScope(project));
+		} else {
+			options = customProfile;
+		}
+		debug("Cleanup Profile: " + options.entrySet().stream().map(e -> e.getKey() + " = " + e.getValue())
+				.collect(Collectors.joining(System.lineSeparator())));
+		return new MapCleanUpOptions(options);
+	}
+
+}

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanUpMojo.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanUpMojo.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.tycho.eclipsebuild.AbstractEclipseBuildMojo;
+import org.eclipse.tycho.model.project.EclipseProject;
+
+/**
+ * This mojo allows to perform eclipse cleanup action
+ */
+@Mojo(name = "cleanup", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class CleanUpMojo extends AbstractEclipseBuildMojo<CleanupResult> {
+
+	@Parameter(defaultValue = "${project.build.directory}/cleanups.md", property = "tycho.cleanup.report")
+	private File reportFileName;
+
+	/**
+	 * Defines key value pairs of a cleanup profile, if not defined will use the
+	 * project defaults
+	 */
+	@Parameter
+	private Map<String, String> cleanUpProfile;
+
+	@Override
+	protected String[] getRequireBundles() {
+		return new String[] { "org.eclipse.jdt.ui" };
+	}
+
+	@Override
+	protected String getName() {
+		return "Perform Cleanup";
+	}
+
+	@Override
+	protected CleanUp createExecutable() {
+		return new CleanUp(project.getBasedir().toPath(), debug, cleanUpProfile);
+	}
+
+	@Override
+	protected void handleResult(CleanupResult result)
+			throws MojoFailureException {
+		List<String> results = new ArrayList<>();
+		results.add("The following cleanups where applied:");
+		result.cleanups().forEach(cleanup -> {
+			results.add("- " + cleanup);
+		});
+		try {
+			Files.writeString(reportFileName.toPath(),
+					results.stream().collect(Collectors.joining(System.lineSeparator())));
+		} catch (IOException e) {
+			throw new MojoFailureException(e);
+		}
+	}
+
+	@Override
+	protected boolean isValid(EclipseProject eclipseProject) {
+		// Cleanups can only be applied to java projects
+		return eclipseProject.hasNature("org.eclipse.jdt.core.javanature");
+	}
+
+}

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanupResult.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanupResult.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.eclipse.tycho.eclipsebuild.EclipseBuildResult;
+
+public class CleanupResult extends EclipseBuildResult {
+
+	private Set<String> cleanups = new TreeSet<String>();
+
+	public void addCleanup(String cleanup) {
+		cleanups.add(cleanup);
+	}
+
+	public Stream<String> cleanups() {
+		return this.cleanups.stream();
+	}
+
+}

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFix.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFix.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.tycho.eclipsebuild.AbstractEclipseBuild;
+import org.eclipse.ui.IMarkerResolution;
+import org.eclipse.ui.IMarkerResolution2;
+import org.eclipse.ui.IMarkerResolutionRelevance;
+import org.eclipse.ui.ide.IDE;
+
+/**
+ * Applies the QuickFix with the highest relevance to a warning, because
+ * QuickFixes are not really optimized to run in a CI build we need to be very
+ * forgiving here and handle errors gracefully.
+ */
+public class QuickFix extends AbstractEclipseBuild<QuickFixResult> {
+
+	QuickFix(Path projectDir, boolean debug) {
+		super(projectDir, debug);
+	}
+
+	@Override
+	protected QuickFixResult createResult(IProject project) throws Exception {
+		QuickFixResult result = new QuickFixResult();
+		IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+		result.setNumberOfMarker(markers.length);
+		for (IMarker marker : markers) {
+			debug("Marker: " + marker);
+			try {
+				IMarkerResolution[] resolutions = IDE.getMarkerHelpRegistry().getResolutions(marker);
+				debug("Marker has " + resolutions.length + " resolutions");
+				IMarkerResolution resolution = Arrays.stream(resolutions)
+						.max(Comparator.comparingInt(r -> getRelevance(r))).orElse(null);
+				if (resolution != null) {
+					debug("Apply best resolution to marker: " + getInfo(resolution));
+					// must use an own thread to make sure it is not called as a job
+					AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+					Thread thread = new Thread(new Runnable() {
+
+						@Override
+						public void run() {
+							try {
+								resolution.run(marker);
+							} catch (Throwable t) {
+								error.set(t);
+							}
+						}
+					});
+					thread.start();
+					thread.join();
+					Throwable t = error.get();
+					if (t == null) {
+						result.addFix(buildFixMessage(marker));
+					} else {
+						debug("Marker could not be applied!", t);
+					}
+				}
+			} catch (Throwable t) {
+				debug("Marker resolutions could not be computed!", t);
+			}
+		}
+		return result;
+	}
+
+	private String buildFixMessage(IMarker marker) {
+		StringBuilder sb = new StringBuilder(marker.getAttribute(IMarker.MESSAGE, "Unknown Problem"));
+		IResource resource = marker.getResource();
+		if (resource != null) {
+			sb.append(" in ");
+			sb.append(resource.getFullPath());
+			int line = marker.getAttribute(IMarker.LINE_NUMBER, -1);
+			if (line > 0) {
+				sb.append(" at line ");
+				sb.append(line);
+			}
+		}
+		return sb.toString();
+	}
+
+	private String getInfo(IMarkerResolution resolution) {
+		if (resolution instanceof IMarkerResolution2 res2) {
+			return resolution.getClass().getName() + ": " + getLabel(resolution) + " // " + getDescription(res2);
+		} else {
+			return resolution.getClass().getName() + ": " + getLabel(resolution);
+		}
+	}
+
+	private int getRelevance(IMarkerResolution resolution) {
+		try {
+			if (resolution instanceof IMarkerResolutionRelevance relevance) {
+				return relevance.getRelevanceForResolution();
+			}
+		} catch (RuntimeException e) {
+		}
+		return -1;
+	}
+
+	private String getDescription(IMarkerResolution2 markerResolution) {
+		try {
+			return markerResolution.getDescription();
+		} catch (RuntimeException e) {
+			return null;
+		}
+	}
+
+	private String getLabel(IMarkerResolution resolution) {
+		try {
+			return resolution.getLabel();
+		} catch (RuntimeException e) {
+			return resolution.getClass().getName();
+		}
+	}
+
+}

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFixMojo.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFixMojo.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.tycho.eclipsebuild.AbstractEclipseBuildMojo;
+
+@Mojo(name = "quickfix", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class QuickFixMojo extends AbstractEclipseBuildMojo<QuickFixResult> {
+
+	@Parameter(defaultValue = "${project.build.directory}/quickfix.md", property = "tycho.quickfix.report")
+	private File reportFileName;
+
+	@Override
+	protected void handleResult(QuickFixResult result) throws MojoFailureException {
+		List<String> results = new ArrayList<>();
+		if (result.getMarkers() == 0) {
+			results.add("Project is clean!");
+		} else {
+			List<String> fixes = result.fixes().toList();
+			if (fixes.isEmpty()) {
+				results.add("Nothing has been resolved in this project.");
+			} else {
+				results.add("The following " + (fixes.size() > 0 ? "warnings" : "warning") + " has been resolved:");
+				fixes.forEach(fix -> {
+					results.add("- " + fix);
+				});
+			}
+		}
+		try {
+			Files.writeString(reportFileName.toPath(),
+					results.stream().collect(Collectors.joining(System.lineSeparator())));
+		} catch (IOException e) {
+			throw new MojoFailureException(e);
+		}
+	}
+
+	@Override
+	protected String[] getRequireBundles() {
+		return new String[] { "org.eclipse.ui.ide", "org.eclipse.jdt.ui" };
+	}
+
+	@Override
+	protected QuickFix createExecutable() {
+		return new QuickFix(project.getBasedir().toPath(), debug);
+	}
+
+	@Override
+	protected String getName() {
+		return "Quick Fix";
+	}
+
+}

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFixResult.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFixResult.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.tycho.eclipsebuild.EclipseBuildResult;
+
+public class QuickFixResult extends EclipseBuildResult {
+
+	private List<String> fixed = new ArrayList<>();
+	private int markers;
+
+	public Stream<String> fixes() {
+		return fixed.stream();
+	}
+
+	public void addFix(String fix) {
+		fixed.add(fix);
+	}
+
+	public void setNumberOfMarker(int markers) {
+		this.markers = markers;
+	}
+
+	public int getMarkers() {
+		return markers;
+	}
+
+}

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuild.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuild.java
@@ -1,7 +1,9 @@
 package org.eclipse.tycho.eclipsebuild;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.Serializable;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
@@ -80,6 +82,14 @@ public abstract class AbstractEclipseBuild<Result extends EclipseBuildResult>
 	protected void debug(String string) {
 		if (debug) {
 			System.out.println(string);
+		}
+	}
+
+	protected void debug(String string, Throwable t) {
+		if (debug) {
+			StringWriter writer = new StringWriter();
+			t.printStackTrace(new PrintWriter(writer));
+			debug(string + System.lineSeparator() + writer);
 		}
 	}
 

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuildMojo.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuildMojo.java
@@ -96,6 +96,9 @@ public abstract class AbstractEclipseBuildMojo<Result extends EclipseBuildResult
 			return;
 		}
 		EclipseProject eclipseProject = eclipseProjectValue.get();
+		if (!isValid(eclipseProject)) {
+			return;
+		}
 		Collection<Path> projectDependencies;
 		try {
 			projectDependencies = projectManager.getProjectDependencies(project);
@@ -143,6 +146,10 @@ public abstract class AbstractEclipseBuildMojo<Result extends EclipseBuildResult
 			}
 			throw new MojoExecutionException(cause);
 		}
+	}
+
+	protected boolean isValid(EclipseProject eclipseProject) {
+		return true;
 	}
 
 	protected abstract void handleResult(Result result) throws MojoFailureException;


### PR DESCRIPTION
Currently there are two categories in the IDE that allows automatic code changes:

1) QuickFix that allows to resolve an error/warning automatically 
2) CleanUp that allows to modernize or fix a more generic form of problem

Tycho now has support to apply these automatically to a given project codebase to automate this process especially when the code evolves or new warnings occur due to changed dependencies.