### PR TITLE
Add support for setting an API baseline in EclipseBuildMojos

### DIFF
--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisMojo.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisMojo.java
@@ -403,7 +403,7 @@ public class ApiAnalysisMojo extends AbstractMojo {
 	private Collection<Path> getBaselineBundles() throws MojoFailureException {
 		long start = System.currentTimeMillis();
 		try {
-			Collection<TargetEnvironment> targetEnvironments = getBaselineEnvironments();
+			Collection<TargetEnvironment> targetEnvironments = projectManager.getBaselineEnvironments(project);
 			Optional<ArtifactKey> artifactKey = projectManager.getArtifactKey(project);
 			getLog().info("Resolve API baseline for " + project.getId() + " with "
 					+ targetEnvironments.stream().map(String::valueOf).collect(Collectors.joining(", ")));
@@ -425,25 +425,6 @@ public class ApiAnalysisMojo extends AbstractMojo {
 				return List.of();
 			}
 		}
-	}
-
-	/**
-	 * This method selected the a target environment best suited for the current
-	 * baseline, if it is a valid choice the running target is used (e.g. linux on
-	 * linux host, windows on windows hosts and so on), if such environment is not
-	 * available it is using the configured ones form the project as is.
-	 * 
-	 * @return the chosen {@link TargetEnvironment}s
-	 */
-	private Collection<TargetEnvironment> getBaselineEnvironments() {
-		Collection<TargetEnvironment> targetEnvironments = projectManager.getTargetEnvironments(project);
-		TargetEnvironment runningEnvironment = TargetEnvironment.getRunningEnvironment();
-		for (TargetEnvironment targetEnvironment : targetEnvironments) {
-			if (targetEnvironment.equals(runningEnvironment)) {
-				return List.of(targetEnvironment);
-			}
-		}
-		return targetEnvironments;
 	}
 
 	private String time(long start) {

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiApplicationResolver.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiApplicationResolver.java
@@ -13,23 +13,16 @@
 package org.eclipse.tycho.apitools;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.eclipse.tycho.ArtifactKey;
-import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.IllegalArtifactReferenceException;
 import org.eclipse.tycho.MavenRepositoryLocation;
 import org.eclipse.tycho.TargetEnvironment;
-import org.eclipse.tycho.TargetPlatform;
-import org.eclipse.tycho.core.resolver.P2ResolutionResult;
-import org.eclipse.tycho.core.resolver.P2ResolutionResult.Entry;
-import org.eclipse.tycho.core.resolver.P2Resolver;
 import org.eclipse.tycho.osgi.framework.Bundles;
 import org.eclipse.tycho.osgi.framework.EclipseApplication;
 import org.eclipse.tycho.osgi.framework.EclipseApplicationFactory;
@@ -56,19 +49,7 @@ public class ApiApplicationResolver {
 	public Collection<Path> getApiBaselineBundles(Collection<MavenRepositoryLocation> baselineRepoLocations,
 			ArtifactKey artifactKey, Collection<TargetEnvironment> environment)
 			throws IllegalArtifactReferenceException {
-		P2Resolver resolver = applicationFactory.createResolver(environment);
-		resolver.addDependency(ArtifactType.TYPE_INSTALLABLE_UNIT, artifactKey.getId(), "0.0.0");
-		List<Path> resolvedBundles = new ArrayList<>();
-		TargetPlatform targetPlatform = applicationFactory.createTargetPlatform(baselineRepoLocations);
-		for (P2ResolutionResult result : resolver.resolveTargetDependencies(targetPlatform, null).values()) {
-			for (Entry entry : result.getArtifacts()) {
-				if (ArtifactType.TYPE_ECLIPSE_PLUGIN.equals(entry.getType())
-						&& !"org.eclipse.osgi".equals(entry.getId())) {
-					resolvedBundles.add(entry.getLocation(true).toPath());
-				}
-			}
-		}
-		return resolvedBundles;
+		return applicationFactory.getApiBaselineBundles(baselineRepoLocations, artifactKey, environment);
 	}
 
 	public EclipseApplication getApiApplication(MavenRepositoryLocation apiToolsRepo) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
@@ -379,4 +379,25 @@ public class TychoProjectManager {
         return Arrays.stream(manifestBREEs);
     }
 
+    /**
+     * This method selected the a target environment best suited for the current baseline, if it is
+     * a valid choice the running target is used (e.g. linux on linux host, windows on windows hosts
+     * and so on), if such environment is not available it is using the configured ones form the
+     * project as is.
+     * 
+     * @param project
+     * 
+     * @return the chosen {@link TargetEnvironment}s
+     */
+    public Collection<TargetEnvironment> getBaselineEnvironments(MavenProject project) {
+        Collection<TargetEnvironment> targetEnvironments = getTargetEnvironments(project);
+        TargetEnvironment runningEnvironment = TargetEnvironment.getRunningEnvironment();
+        for (TargetEnvironment targetEnvironment : targetEnvironments) {
+            if (targetEnvironment.equals(runningEnvironment)) {
+                return List.of(targetEnvironment);
+            }
+        }
+        return targetEnvironments;
+    }
+
 }

--- a/tycho-eclipse-plugin/pom.xml
+++ b/tycho-eclipse-plugin/pom.xml
@@ -49,6 +49,18 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+		    <groupId>org.eclipse.pde</groupId>
+		    <artifactId>org.eclipse.pde.api.tools</artifactId>
+		    <version>1.3.600</version>
+		    <type>jar</type>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>sisu-equinox-launching</artifactId>
 			<version>${project.version}</version>

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/SetApiBaseline.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/SetApiBaseline.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.eclipsebuild;
+
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILogListener;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.pde.api.tools.internal.ApiBaselineManager;
+import org.eclipse.pde.api.tools.internal.model.ApiModelFactory;
+import org.eclipse.pde.api.tools.internal.provisional.model.IApiBaseline;
+import org.eclipse.pde.api.tools.internal.provisional.model.IApiComponent;
+
+public class SetApiBaseline implements Callable<Serializable>, Serializable {
+
+	private boolean debug;
+	private List<String> baselineBundles;
+	private String name;
+
+	SetApiBaseline(String name, Collection<Path> baselineBundles, boolean debug) {
+		this.name = name;
+		this.debug = debug;
+		this.baselineBundles = baselineBundles.stream().map(EclipseProjectBuild::pathAsString).toList();
+	}
+
+	@Override
+	public Serializable call() throws Exception {
+		ILogListener listener = (status, plugin) -> debug(status.toString());
+		Platform.addLogListener(listener);
+		EclipseProjectBuild.disableAutoBuild();
+
+		debug("Setting API baseline:");
+		IApiBaseline baseline = ApiModelFactory.newApiBaseline(name);
+		IApiComponent[] components = baselineBundles.stream().peek(this::debug).map(absoluteFile -> {
+			try {
+				return ApiModelFactory.newApiComponent(baseline, absoluteFile);
+			} catch (CoreException e) {
+				return null;
+			}
+		}).filter(Objects::nonNull).toArray(IApiComponent[]::new);
+		baseline.addApiComponents(components);
+		ApiBaselineManager.getManager().removeApiBaseline(baseline.getName());
+		ApiBaselineManager.getManager().addApiBaseline(baseline);
+		ApiBaselineManager.getManager().setDefaultApiBaseline(baseline.getName());
+		return null;
+	}
+
+	private void debug(String string) {
+		if (debug) {
+			System.out.println(string);
+		}
+	}
+
+}


### PR DESCRIPTION
Currently only setting a target platform is supported, this now also adds support for setting the API Baseline if the projects has api nature enabled.