### PR TITLE
Let QuickFix run in UI, save editor, rebuild on error and wait for jobs

### DIFF
--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanUpMojo.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanUpMojo.java
@@ -62,10 +62,12 @@ public class CleanUpMojo extends AbstractEclipseBuildMojo<CleanupResult> {
 			return;
 		}
 		MarkdownBuilder builder = new MarkdownBuilder(reportFileName);
-		builder.add("The following cleanups where applied:");
+		builder.h3("The following cleanups where applied:");
 		result.cleanups().forEach(cleanup -> {
 			builder.addListItem(cleanup);
 		});
+		builder.newLine();
+		builder.newLine();
 		builder.write();
 	}
 

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFixMojo.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFixMojo.java
@@ -52,9 +52,15 @@ public class QuickFixMojo extends AbstractEclipseBuildMojo<QuickFixResult> {
 		}
 		MarkdownBuilder builder = new MarkdownBuilder(reportFileName);
 		List<String> fixes = result.fixes().toList();
-		builder.add("The following " + (fixes.size() > 0 ? "warnings" : "warning") + " has been resolved:");
+		builder.h3("The following " + (fixes.size() > 0 ? "warnings" : "warning") + " has been resolved:");
+		builder.newLine();
 		fixes.forEach(fix -> builder.addListItem(fix));
+		builder.newLine();
+		builder.newLine();
 		builder.write();
+		for (String fix : fixes) {
+			getLog().info("Fixed: " + fix);
+		}
 	}
 
 	@Override

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFixResult.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/QuickFixResult.java
@@ -13,13 +13,18 @@
 package org.eclipse.tycho.cleancode;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.tycho.eclipsebuild.EclipseBuildResult;
 
 public class QuickFixResult extends EclipseBuildResult {
 
+	private Set<String> tried = new HashSet<String>();
 	private List<String> fixed = new ArrayList<>();
 	private int markers;
 
@@ -31,16 +36,22 @@ public class QuickFixResult extends EclipseBuildResult {
 		fixed.add(fix);
 	}
 
-	public void setNumberOfMarker(int markers) {
-		this.markers = markers;
-	}
-
-	public int getMarkers() {
-		return markers;
-	}
-
 	public boolean isEmpty() {
 		return fixed.isEmpty();
+	}
+
+	public boolean tryFix(IMarker marker) {
+		String msg = marker.getAttribute(IMarker.MESSAGE, "");
+		String resource = marker.getResource().toString();
+		int line = marker.getAttribute(IMarker.LINE_NUMBER, -1);
+		String type;
+		try {
+			type = marker.getType();
+		} catch (CoreException e) {
+			type = "";
+		}
+		String key = type + " " + resource + ":" + line + " " + msg;
+		return tried.add(key);
 	}
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/MarkdownBuilder.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/MarkdownBuilder.java
@@ -57,4 +57,23 @@ public class MarkdownBuilder {
         }
     }
 
+    public void newLine() {
+        lines.add("");
+    }
+
+    public void h1(String string) {
+        lines.add("# " + string);
+        lines.add("");
+    }
+
+    public void h2(String string) {
+        lines.add("## " + string);
+        lines.add("");
+    }
+
+    public void h3(String string) {
+        lines.add("### " + string);
+        lines.add("");
+    }
+
 }

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuildMojo.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuildMojo.java
@@ -81,7 +81,7 @@ public abstract class AbstractEclipseBuildMojo<Result extends EclipseBuildResult
 	@Parameter(defaultValue = "false")
 	private boolean failOnResolutionError;
 
-	@Parameter
+	@Parameter(property = "tycho.eclipsebuild.application")
 	private String application;
 	/**
 	 * Controls if the local target platform of the project should be used to
@@ -142,7 +142,7 @@ public abstract class AbstractEclipseBuildMojo<Result extends EclipseBuildResult
 		}
 		List<String> arguments;
 		String applicationName = this.application;
-		boolean useApplication = applicationName != null;
+		boolean useApplication = applicationName != null && !applicationName.isBlank();
 		if (useApplication) {
 			arguments = List.of(EclipseApplication.ARG_APPLICATION, applicationName);
 		} else {


### PR DESCRIPTION
Fixing one warning might make the resulting markers either invalid or no longer apply. Also quickfixes are often written to be run in the UI thread and might schedule jobs during execution.

This now rebuilds the project when one marker was fixed and run them in the UI while waiting for any jobs scheduled in the meantime.