### PR TITLE
Build project after clean

### DIFF
--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanUp.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/CleanUp.java
@@ -65,6 +65,7 @@ public class CleanUp extends AbstractEclipseBuild<CleanupResult> {
 				applyCleanups(project, cleanups, units);
 			}
 		}
+		buildProject(project);
 		return result;
 	}
 


### PR DESCRIPTION
Currently the mojo reports probably old warnings, because of this we need to rebuild the project after cleanups are applied to get a more up-to-date state to report.