### PR TITLE
Add support for version patterns in URLs to update IU locations

### DIFF
--- a/tycho-maven-plugin/src/main/resources/META-INF/maven/extension.xml
+++ b/tycho-maven-plugin/src/main/resources/META-INF/maven/extension.xml
@@ -18,6 +18,8 @@
     <exportedPackage>org.eclipse.equinox.p2.publisher</exportedPackage>
     <exportedPackage>org.eclipse.equinox.p2.publisher.eclipse</exportedPackage>
     <exportedPackage>org.eclipse.equinox.p2.query</exportedPackage>
+<!--     This currently produces problems with the PGP signing mojo failing to load org.bouncycastle.openpgp.PGPPublicKey (we need to probably export this as well) -->
+<!--    <exportedPackage>org.eclipse.equinox.p2.repository</exportedPackage> -->
     <exportedPackage>org.eclipse.equinox.p2.repository.artifact</exportedPackage>
     <exportedPackage>org.eclipse.equinox.p2.repository.metadata</exportedPackage>
     <exportedPackage>org.eclipse.equinox.internal.p2.metadata</exportedPackage>


### PR DESCRIPTION
Some sites just use a given version scheme that is incremented on each release but don'T offer a composite at the parent.

This now adds a new detector called 'versionPattern' that allows to match a pattern and let the version be incremented as long as there is a valid repo at that URL.