### PR TITLE
[bp] Add support for version patterns in URLs to update IU locations

### DIFF
--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
@@ -53,14 +53,15 @@ import de.pdark.decentxml.XMLWriter;
  * mvn -f [path to target project] tycho-version-bump:update-target
  * </pre>
  * <p>
- * For updating <b>maven target locations</b> the mojo support
+ * For updating <b>maven target locations</b> the mojo supports
  * <a href="https://www.mojohaus.org/versions/versions-maven-plugin/version-rules.html">Version
  * number comparison rule-sets</a> similar to the
  * <a href="https://www.mojohaus.org/versions/versions-maven-plugin">Versions Maven Plugin</a>
  * please check the documentation there for further information about ruleset files.
  * </p>
  * <p>
- * For updating <b>installable unit locations</b> (also known as update sites)
+ * For updating <b>installable unit locations</b> (also known as update sites) you can configure
+ * different strategies (see {@link #getUpdateSiteDiscovery()}) to discover updates.
  * </p>
  */
 @Mojo(name = "update-target")
@@ -100,15 +101,20 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
     private boolean allowSubIncrementalUpdates;
 
     /**
-     * A comma separated list of update site discovery strategies, the following is currently
-     * supported:
+     * A list of update site discovery strategies, the following is currently supported:
      * <ul>
-     * <li>parent - search the parent path for a composite that can be used to find newer
-     * versions</li>
+     * <li><code>parent</code> - search the parent path for a composite that can be used to find
+     * newer versions</li>
+     * <li><code>versionPattern[:pattern]</code> - specifies a pattern to match in the URL (defaults
+     * to <code>(\d+)\.(\d+)</code> where it increments each numeric part beginning at the last
+     * group, if no repository is found using the next group setting the previous to zero. Any non
+     * numeric pattern will be replaced by the empty string</li>
      * </ul>
+     * If used on the CLI, individual values must be separated by a comma see <a href=
+     * "https://maven.apache.org/guides/mini/guide-configuring-plugins.html#Mapping_Collections_and_Arrays">here</a>
      */
     @Parameter(property = "discovery")
-    private String updateSiteDiscovery;
+    private List<String> updateSiteDiscovery;
 
     /**
      * <p>
@@ -239,8 +245,11 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
         return mojoExecution;
     }
 
-    String getUpdateSiteDiscovery() {
-        return updateSiteDiscovery;
+    List<String> getUpdateSiteDiscovery() {
+        if (updateSiteDiscovery == null) {
+            return List.of();
+        }
+        return updateSiteDiscovery.stream().map(String::trim).toList();
     }
 
     Set<String> getMavenIgnoredVersions() {

--- a/tycho-maven-plugin/src/main/resources/META-INF/maven/extension.xml
+++ b/tycho-maven-plugin/src/main/resources/META-INF/maven/extension.xml
@@ -18,6 +18,8 @@
     <exportedPackage>org.eclipse.equinox.p2.publisher</exportedPackage>
     <exportedPackage>org.eclipse.equinox.p2.publisher.eclipse</exportedPackage>
     <exportedPackage>org.eclipse.equinox.p2.query</exportedPackage>
+<!--     This currently produces problems with the PGP signing mojo failing to load org.bouncycastle.openpgp.PGPPublicKey (we need to probably export this as well) -->
+<!--    <exportedPackage>org.eclipse.equinox.p2.repository</exportedPackage> -->
     <exportedPackage>org.eclipse.equinox.p2.repository.artifact</exportedPackage>
     <exportedPackage>org.eclipse.equinox.p2.repository.metadata</exportedPackage>
     <exportedPackage>org.eclipse.equinox.internal.p2.metadata</exportedPackage>


### PR DESCRIPTION
Some sites just use a given version scheme that is incremented on each release but don'T offer a composite at the parent.

This now adds a new detector called 'versionPattern' that allows to match a pattern and let the version be incremented as long as there is a valid repo at that URL.

(cherry picked from commit 0f2b5c31b5a1129f61eac842d5f3a8e7f887ca78)