### PR TITLE
Set Toolchan JDKs as JDT JVM installations

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/framework/Bundles.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/framework/Bundles.java
@@ -20,6 +20,7 @@ public record Bundles(Set<String> bundles) {
     public static final String BUNDLE_ECLIPSE_HELP_BASE = "org.eclipse.help.base";
     public static final String BUNDLE_PDE_CORE = "org.eclipse.pde.core";
     public static final String BUNDLE_JDT_CORE = "org.eclipse.jdt.core";
+    public static final String BUNDLE_JDT_LAUNCHING = "org.eclipse.jdt.launching";
 
     static final String BUNDLE_LAUNCHING_MACOS = "org.eclipse.jdt.launching.macosx";
     static final String BUNDLE_APP = "org.eclipse.equinox.app";

--- a/tycho-eclipse-plugin/pom.xml
+++ b/tycho-eclipse-plugin/pom.xml
@@ -61,6 +61,17 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.jdt</groupId>
+			<artifactId>org.eclipse.jdt.launching</artifactId>
+			<version>3.23.100</version>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>sisu-equinox-launching</artifactId>
 			<version>${project.version}</version>

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/SetJVMs.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/SetJVMs.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.eclipsebuild;
+
+import java.io.File;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+import org.eclipse.jdt.internal.launching.StandardVMType;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstall2;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.VMStandin;
+
+public class SetJVMs implements Callable<Serializable>, Serializable {
+
+	private static final long serialVersionUID = 1L;
+	private boolean debug;
+	private Collection<String> jvms;
+
+	public SetJVMs(Collection<Path> jvms, boolean debug) {
+		this.debug = debug;
+		this.jvms = jvms.stream().map(EclipseProjectBuild::pathAsString).toList();
+	}
+
+	@Override
+	public Serializable call() throws Exception {
+		StandardVMType standardType = (StandardVMType) JavaRuntime.getVMInstallType(StandardVMType.ID_STANDARD_VM_TYPE);
+		for (String entry : jvms) {
+			debug("Adding JVM " + entry + "...");
+			VMStandin workingCopy = new VMStandin(standardType, entry);
+			workingCopy.setInstallLocation(new File(entry));
+			workingCopy.setName(entry);
+			IVMInstall install = workingCopy.convertToRealVM();
+			if (!isValid(install)) {
+				standardType.disposeVMInstall(install.getId());
+			}
+		}
+		return null;
+	}
+
+	private static boolean isValid(IVMInstall install) {
+		return install instanceof IVMInstall2 vm && vm.getJavaVersion() != null;
+	}
+
+	private void debug(String string) {
+		if (debug) {
+			System.out.println(string);
+		}
+	}
+
+}


### PR DESCRIPTION
Currently only the default java is used but this can cause issues if a more specific jvm is required.

This now reads all jdk toolchains from the maven config and configure those as JVMs in JDT.