### PR TITLE
Extend demo bnd-workspace with subbundles

### DIFF
--- a/demo/bnd-workspace/.mvn/maven.config
+++ b/demo/bnd-workspace/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dtycho-version=4.0.0-SNAPSHOT
+-Dtycho-version=4.0.11

--- a/demo/bnd-workspace/cnf/ext/central.mvn
+++ b/demo/bnd-workspace/cnf/ext/central.mvn
@@ -1,4 +1,8 @@
 # Contains all bundles to consume from maven central
 
+org.osgi:osgi.core:8.0.0
 org.osgi:osgi.annotation:8.1.0
 org.osgi:org.osgi.service.component.annotations:1.5.1
+org.osgi:org.osgi.service.component:1.5.1
+org.commonmark:commonmark:0.22.0
+org.commonmark:commonmark-ext-gfm-tables:0.22.0

--- a/demo/bnd-workspace/tycho.demo.impl/bnd.bnd
+++ b/demo/bnd-workspace/tycho.demo.impl/bnd.bnd
@@ -1,3 +1,4 @@
 -buildpath:  osgi.annotation, \
 				tycho.demo.api, \
+				tycho.demo.markdown.api,\
 				org.osgi.service.component.annotations

--- a/demo/bnd-workspace/tycho.demo.impl/src/main/java/org/eclipse/tycho/demo/impl/HelloWorldService.java
+++ b/demo/bnd-workspace/tycho.demo.impl/src/main/java/org/eclipse/tycho/demo/impl/HelloWorldService.java
@@ -14,10 +14,18 @@ package org.eclipse.tycho.demo.impl;
 
 import org.eclipse.tycho.demo.api.HelloWorld;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import tycho.demo.utils.markdown.api.MarkdownRenderer;
 
 @Component
 public class HelloWorldService implements HelloWorld {
+
+	@Reference
+    private MarkdownRenderer markdown;
+
 	public void sayHello() {
 		System.out.println("Hello BND Workspace!");
+		
+		System.out.println("Render some markdown to HTML: " + markdown.render("## H2 Headline"));
 	}
 }

--- a/demo/bnd-workspace/tycho.demo.markdown/api.bnd
+++ b/demo/bnd-workspace/tycho.demo.markdown/api.bnd
@@ -1,0 +1,1 @@
+Export-Package: tycho.demo.utils.markdown.api

--- a/demo/bnd-workspace/tycho.demo.markdown/bnd.bnd
+++ b/demo/bnd-workspace/tycho.demo.markdown/bnd.bnd
@@ -1,0 +1,8 @@
+-sub: *.bnd
+
+-buildpath: \
+	osgi.core;version=latest,\
+	osgi.annotation;version=latest,\
+	org.osgi.service.component.annotations;version=latest,\
+	org.commonmark:commonmark;version=latest,\
+	org.commonmark:commonmark-ext-gfm-tables;version=latest

--- a/demo/bnd-workspace/tycho.demo.markdown/impl.bnd
+++ b/demo/bnd-workspace/tycho.demo.markdown/impl.bnd
@@ -1,0 +1,8 @@
+-privatepackage: tycho.demo.utils.markdown.impl
+
+
+
+-includeresource: \
+	${repo;org.commonmark:commonmark;latest}; lib:=true,\
+	${repo;org.commonmark:commonmark-ext-gfm-tables;latest}; lib:=true,\
+	

--- a/demo/bnd-workspace/tycho.demo.markdown/src/main/java/tycho/demo/utils/markdown/api/MarkdownRenderer.java
+++ b/demo/bnd-workspace/tycho.demo.markdown/src/main/java/tycho/demo/utils/markdown/api/MarkdownRenderer.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Rüger and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Rüger - extend example to use bnd -sub instruction
+ *******************************************************************************/
+package tycho.demo.utils.markdown.api;
+
+public interface MarkdownRenderer {
+
+    /**
+     * Renders markdown string to html.
+     * 
+     * @param markdown
+     * @return
+     */
+    String render(String markdown);
+
+}

--- a/demo/bnd-workspace/tycho.demo.markdown/src/main/java/tycho/demo/utils/markdown/impl/MarkdownRendererImpl.java
+++ b/demo/bnd-workspace/tycho.demo.markdown/src/main/java/tycho/demo/utils/markdown/impl/MarkdownRendererImpl.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Rüger and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Rüger - extend example to use bnd -sub instruction
+ *******************************************************************************/
+package tycho.demo.utils.markdown.impl;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.osgi.service.component.annotations.Component;
+
+import tycho.demo.utils.markdown.api.MarkdownRenderer;
+
+@Component
+public class MarkdownRendererImpl implements MarkdownRenderer {
+
+    private Parser       parser;
+    private HtmlRenderer renderer;
+
+    public MarkdownRendererImpl() {
+        List<Extension> extensions = Arrays.asList(TablesExtension.create());
+
+        this.parser   = Parser.builder().extensions(extensions).build();
+        this.renderer = HtmlRenderer.builder().extensions(extensions).build();
+    }
+
+    @Override
+    public String render(String markdown) {
+
+        Node document = parser.parse(markdown);
+        return renderer.render(document);
+    }
+
+}


### PR DESCRIPTION
see the `bnd.bnd` of the new `tycho.demo.markdown` bundle.
it uses the `-sub: *.bnd` instruction to create 2 jar files based on the other .bnd files (api.bnd and impl.bnd)

- https://bnd.discourse.group/t/generating-multiple-bundles-per-project/84
- https://bnd.discourse.group/t/sub-bundles-buildpath-vs-classpath/482
- https://bnd.bndtools.org/instructions/sub.html

this build **currently fails** (which is intentional) and we want to use that to fix tycho to make it compile.
It seems that tycho currently does not recognize the 2 (sub) jars so it cannot find them as dependencies for the HelloWorldService

```
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-bnd-plugin:4.0.10:compile (compile) on project tycho.demo.impl: javac failed /bnd-workspace/tycho.demo.impl/src/main/java/org/eclipse/tycho/demo/impl/HelloWorldService.java:18: error: package tycho.demo.utils.markdown.api does not exist
[ERROR] import tycho.demo.utils.markdown.api.MarkdownRenderer;
[ERROR]                                     ^
[ERROR] /bnd-workspace/tycho.demo.impl/src/main/java/org/eclipse/tycho/demo/impl/HelloWorldService.java:24: error: cannot find symbol
[ERROR]     private MarkdownRenderer markdown;
[ERROR]             ^
[ERROR]   symbol:   class MarkdownRenderer
[ERROR]   location: class HelloWorldService
[ERROR] 2 errors
```


## Expected result

The build should have produced two jars in `tycho.demo.markdown`

- tycho.demo.markdown.api.jar
- tycho.demo.markdown.impl.jar

And those should be recognized as dependency as required by the `-buildpath` of the `tycho.demo.impl/bnd.bnd`, so that `tycho.demo.impl` compiles successfully.