### PR TITLE
Add support for building sub-bundle with tycho-bnd-extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin/
 *.iml
 .idea/
 .tycho-consumer-pom.xml
+.polyglot.*
 ## Eclipse metadata files
 org.eclipse.core.resources.prefs
 org.eclipse.m2e.core.prefs
@@ -21,3 +22,4 @@ pom-model-classic.xml
 project-dependencies.xml
 project-units.xml
 requirements.txt
+.DS_Store

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/maven/BndMavenProject.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/maven/BndMavenProject.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bnd.maven;
+
+import org.apache.maven.project.MavenProject;
+
+import aQute.bnd.build.Project;
+
+record BndMavenProject(MavenProject mavenProject, Project project, String classifier) {
+
+}

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/AbstractBndProjectMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/AbstractBndProjectMojo.java
@@ -59,7 +59,7 @@ public abstract class AbstractBndProjectMojo extends AbstractMojo {
 
 	}
 
-	private void checkResult(Report report, boolean errorOk) throws MojoFailureException {
+	protected void checkResult(Report report, boolean errorOk) throws MojoFailureException {
 		List<String> warnings = report.getWarnings();
 		for (String warning : warnings) {
 			getLog().warn(warning);

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndBuildMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndBuildMojo.java
@@ -13,24 +13,51 @@
 package org.eclipse.tycho.bnd.mojos;
 
 import java.io.File;
+import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProjectHelper;
 
 import aQute.bnd.build.Project;
+import aQute.bnd.build.ProjectBuilder;
+import aQute.bnd.build.SubProject;
+import aQute.bnd.osgi.Jar;
 
 @Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class BndBuildMojo extends AbstractBndProjectMojo {
 
+	@Component
+	MavenProjectHelper helper;
+
 	@Override
 	protected void execute(Project project) throws Exception {
-		File[] files = project.build();
-		if (files != null && files.length > 0) {
-			Artifact artifact = mavenProject.getArtifact();
-			artifact.setFile(files[0]);
+		List<SubProject> subProjects = project.getSubProjects();
+		if (subProjects.isEmpty()) {
+			getLog().info(String.format("Building bundle '%s'", project.getName()));
+			File[] files = project.build();
+			if (files != null && files.length > 0) {
+				Artifact artifact = mavenProject.getArtifact();
+				artifact.setFile(files[0]);
+			}
+		} else {
+			for (SubProject subProject : subProjects) {
+				ProjectBuilder builder = subProject.getProjectBuilder();
+				getLog().info(String.format("Building sub bundle '%s'", subProject.getName()));
+				Jar jar = builder.build();
+				checkResult(builder, project.getWorkspace().isFailOk());
+				String jarName = jar.getName();
+				String name = subProject.getName();
+				File file = new File(mavenProject.getBuild().getDirectory(), String.format("%s.jar", jarName));
+				file.getParentFile().mkdirs();
+				jar.write(file);
+				helper.attachArtifact(mavenProject, "jar", name, file);
+			}
 		}
+
 	}
 
 }

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bnd.mojos;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.ModelReader;
+import org.apache.maven.model.io.ModelWriter;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+@Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE)
+public class BndInitMojo extends AbstractMojo {
+
+	@Parameter(property = "project", readonly = true)
+	protected MavenProject mavenProject;
+
+	/**
+	 * The filename of the tycho generated POM file.
+	 */
+	@Parameter(defaultValue = ".tycho-consumer-pom.xml", property = "tycho.bnd.consumerpom.file")
+	protected String tychoPomFilename;
+
+	/**
+	 * If deleteOnExit is true the file will be marked for deletion on JVM exit
+	 */
+	@Parameter(defaultValue = "true", property = "tycho.bnd.consumerpom.delete")
+	protected boolean deleteOnExit = true;
+
+	/**
+	 * Indicate if the generated tycho POM should become the new project.
+	 */
+	@Parameter(defaultValue = "true", property = "tycho.bnd.consumerpom.update")
+	protected boolean updatePomFile = true;
+
+	@Parameter(defaultValue = "false", property = "tycho.bnd.consumerpom.skip")
+	protected boolean skipPomGeneration;
+
+	/**
+	 * The directory where the tycho generated POM file will be written to.
+	 */
+	@Parameter(defaultValue = "${project.basedir}", property = "tycho.bnd.consumerpom.directory")
+	protected File outputDirectory;
+
+	@Component(role = ModelWriter.class)
+	protected ModelWriter modelWriter;
+
+	@Component(role = ModelReader.class)
+	protected ModelReader modelReader;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		fixupPolyglot();
+		writeConsumerPom();
+	}
+
+	private void writeConsumerPom() throws MojoExecutionException {
+		if (skipPomGeneration) {
+			return;
+		}
+		Model projectModel;
+		try {
+			projectModel = modelReader.read(mavenProject.getFile(), Map.of());
+		} catch (IOException e) {
+			throw new MojoExecutionException("reading the model failed!", e);
+		}
+		projectModel.setVersion(mavenProject.getVersion());
+		projectModel.setGroupId(mavenProject.getGroupId());
+		projectModel.setParent(null);
+		List<Dependency> dependencies = projectModel.getDependencies();
+		dependencies.clear();
+		dependencies.addAll(Objects.requireNonNullElse(mavenProject.getDependencies(), Collections.emptyList()));
+		File output = new File(outputDirectory, tychoPomFilename);
+		if (deleteOnExit) {
+			output.deleteOnExit();
+		}
+		try {
+			modelWriter.write(output, Map.of(), projectModel);
+		} catch (IOException e) {
+			throw new MojoExecutionException("writing the model failed!", e);
+		}
+		if (updatePomFile) {
+			mavenProject.setFile(output);
+		}
+	}
+
+	private void fixupPolyglot() {
+		/*
+		 * bnd instructions might include wildcards (e.g. -sub *.bnd) these commands get
+		 * confused if the automatic polyglot file named after the bnd file
+		 * (.polyglot.bnd.bnd) is present and goes wild. We simply rename it here to xml
+		 * to avoid any confusion.
+		 */
+		File basedir = mavenProject.getBasedir();
+		File[] files = basedir.listFiles(new FileFilter() {
+
+			@Override
+			public boolean accept(File pathname) {
+				return pathname.getName().startsWith(".polyglot.") && pathname.getName().endsWith(".bnd");
+			}
+
+		});
+		for (File file : files) {
+			File moved = new File(file.getParentFile(), ".polyglot.xml");
+			if (file.renameTo(moved)) {
+				mavenProject.setFile(moved);
+			}
+		}
+	}
+
+}

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
@@ -80,6 +80,11 @@ public class BndProjectMapping extends AbstractTychoMapping {
 	protected void initModel(Model model, Reader artifactReader, Path artifactFile) throws IOException {
 		try {
 			Project project = Workspace.getProject(artifactFile.getParent().toFile());
+			if (project.getSubProjects().isEmpty()) {
+				model.setPackaging(getPackaging());
+			} else {
+				model.setPackaging("pom");
+			}
 			String g = project.getProperty(TychoConstants.PROP_GROUP_ID);
 			String a = project.getProperty(TychoConstants.PROP_ARTIFACT_ID);
 			String v = project.getProperty(TychoConstants.PROP_VERSION);
@@ -101,6 +106,10 @@ public class BndProjectMapping extends AbstractTychoMapping {
 			Plugin bndPlugin = getPlugin(model, TYCHO_GROUP_ID, TYCHO_BND_PLUGIN);
 			bndPlugin.setExtensions(true);
 			bndPlugin.setVersion(TychoVersion.getTychoVersion());
+			addPluginExecution(bndPlugin, execution -> {
+				execution.setId("initialize");
+				execution.addGoal("initialize");
+			});
 			addPluginExecution(bndPlugin, execution -> {
 				execution.setId("clean");
 				execution.addGoal("clean");


### PR DESCRIPTION
Currently the tycho-build bnd extension do not correctly handle subbundles in the following way:

1. they are not build
2. they are not reflected in the maven metadata

this also revealed some confusion with the generated polyglot files.

Now there is a new initialize mojo that cleanup and creates a consumer pom, sub bundles are build and represented as attached artifacts to have multiple ones and are correctly reflected now.