### PR TITLE
Use the main project to let bnd compute the output file

### DIFF
--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndBuildMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndBuildMojo.java
@@ -49,9 +49,8 @@ public class BndBuildMojo extends AbstractBndProjectMojo {
 				getLog().info(String.format("Building sub bundle '%s'", subProject.getName()));
 				Jar jar = builder.build();
 				checkResult(builder, project.getWorkspace().isFailOk());
-				String jarName = jar.getName();
 				String name = subProject.getName();
-				File file = new File(mavenProject.getBuild().getDirectory(), String.format("%s.jar", jarName));
+				File file = project.getOutputFile(builder.getBsn(), builder.getVersion());
 				file.getParentFile().mkdirs();
 				jar.write(file);
 				helper.attachArtifact(mavenProject, "jar", name, file);

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
@@ -33,6 +33,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
+import aQute.bnd.build.Workspace;
+
 @Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE)
 public class BndInitMojo extends AbstractMojo {
 
@@ -74,6 +76,7 @@ public class BndInitMojo extends AbstractMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
+		Workspace.setDriver("tycho-maven-build");
 		fixupPolyglot();
 		writeConsumerPom();
 	}


### PR DESCRIPTION
Currently we compute the name of the subjar manually, but this can be overridden by the user so it is better to let bnd calculate the file itself.

FYI @chrisrueger 