### PR TITLE
Propagate configured folders from bnd to maven model

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -155,4 +155,5 @@ public interface TychoConstants {
 
     String SUFFIX_SNAPSHOT = "-SNAPSHOT";
     String PROP_DOWNLOAD_CHECKSUM_PREFIX = IArtifactDescriptor.DOWNLOAD_CHECKSUM + ".";
+    public String DRIVER_NAME = "tycho-maven-build";
 }

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/maven/BndMavenLifecycleParticipant.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/maven/BndMavenLifecycleParticipant.java
@@ -34,6 +34,7 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.bnd.BndPluginManager;
 
 import aQute.bnd.build.Project;
@@ -70,6 +71,7 @@ public class BndMavenLifecycleParticipant extends AbstractMavenLifecycleParticip
 
 	@Override
 	public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
+		Workspace.setDriver(TychoConstants.DRIVER_NAME);
 		Map<MavenProject, Project> bndProjects = getProjects(session);
 		Map<String, BndMavenProject> manifestFirstProjects = getManifestFirstProjects(session, bndProjects.keySet());
 		Map<String, BndMavenProject> bndWorkspaceProjects = new HashMap<>();

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndCleanMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndCleanMojo.java
@@ -12,8 +12,11 @@
  *******************************************************************************/
 package org.eclipse.tycho.bnd.mojos;
 
+import java.io.File;
+
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import aQute.bnd.build.Project;
@@ -21,8 +24,22 @@ import aQute.bnd.build.Project;
 @Mojo(name = "clean", defaultPhase = LifecyclePhase.CLEAN, requiresDependencyResolution = ResolutionScope.NONE, threadSafe = true)
 public class BndCleanMojo extends AbstractBndProjectMojo {
 
+	/**
+	 * The filename of the tycho generated POM file.
+	 */
+	@Parameter(defaultValue = ".tycho-consumer-pom.xml", property = "tycho.bnd.consumerpom.file")
+	protected String tychoPomFilename;
+
+	/**
+	 * The directory where the tycho generated POM file will be written to.
+	 */
+	@Parameter(defaultValue = "${project.basedir}", property = "tycho.bnd.consumerpom.directory")
+	protected File outputDirectory;
+
 	@Override
 	protected void execute(Project project) throws Exception {
+		File consumerPom = new File(outputDirectory, tychoPomFilename);
+		consumerPom.delete();
 		project.clean();
 	}
 

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
@@ -33,8 +33,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import aQute.bnd.build.Workspace;
-
 @Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE)
 public class BndInitMojo extends AbstractMojo {
 
@@ -76,7 +74,6 @@ public class BndInitMojo extends AbstractMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		Workspace.setDriver("tycho-maven-build");
 		fixupPolyglot();
 		writeConsumerPom();
 	}
@@ -91,6 +88,7 @@ public class BndInitMojo extends AbstractMojo {
 		} catch (IOException e) {
 			throw new MojoExecutionException("reading the model failed!", e);
 		}
+		projectModel.setBuild(null);
 		projectModel.setVersion(mavenProject.getVersion());
 		projectModel.setGroupId(mavenProject.getGroupId());
 		projectModel.setParent(null);
@@ -131,6 +129,7 @@ public class BndInitMojo extends AbstractMojo {
 			File moved = new File(file.getParentFile(), ".polyglot.xml");
 			if (file.renameTo(moved)) {
 				mavenProject.setFile(moved);
+				moved.deleteOnExit();
 			}
 		}
 	}

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import org.apache.maven.lifecycle.Lifecycle;
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.component.annotations.Component;
@@ -79,6 +80,7 @@ public class BndProjectMapping extends AbstractTychoMapping {
 	@Override
 	protected void initModel(Model model, Reader artifactReader, Path artifactFile) throws IOException {
 		try {
+			Workspace.setDriver(TychoConstants.DRIVER_NAME);
 			Project project = Workspace.getProject(artifactFile.getParent().toFile());
 			if (project.getSubProjects().isEmpty()) {
 				model.setPackaging(getPackaging());
@@ -101,7 +103,14 @@ public class BndProjectMapping extends AbstractTychoMapping {
 			} else {
 				model.setVersion(v);
 			}
-
+			Build build = getBuild(model);
+			build.setDirectory(path(project.getTarget()));
+			build.setOutputDirectory(path(project.getSrcOutput()));
+			build.setTestOutputDirectory(path(project.getTestOutput()));
+			@SuppressWarnings("deprecation")
+			File src = project.getSrc();
+			build.setSourceDirectory(path(src));
+			build.setTestSourceDirectory(path(project.getTestSrc()));
 			model.setVersion(project.getBundleVersion());
 			Plugin bndPlugin = getPlugin(model, TYCHO_GROUP_ID, TYCHO_BND_PLUGIN);
 			bndPlugin.setExtensions(true);
@@ -140,6 +149,13 @@ public class BndProjectMapping extends AbstractTychoMapping {
 			throw new IOException(e);
 		}
 
+	}
+
+	private static String path(File file) throws Exception {
+		if (file != null) {
+			return file.getAbsolutePath();
+		}
+		return null;
 	}
 
 }


### PR DESCRIPTION
The user can define custom folders for output and sources, these are now propagated from the bnd config to the maven model.

FYI @chrisrueger 