### PR TITLE
Add support for exporting bndruns in bndworkspace projects

### DIFF
--- a/tycho-bnd-plugin/pom.xml
+++ b/tycho-bnd-plugin/pom.xml
@@ -48,6 +48,11 @@
 			<artifactId>biz.aQute.bnd.embedded-repo</artifactId>
 			<version>${bnd.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.resolve</artifactId>
+			<version>${bnd.version}</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/MavenReactorRepository.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/MavenReactorRepository.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bnd;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+
+import aQute.bnd.osgi.repository.ResourcesRepository;
+import aQute.bnd.osgi.resource.ResourceBuilder;
+import aQute.bnd.service.RepositoryPlugin;
+import aQute.bnd.service.resource.SupportingResource;
+import aQute.bnd.version.Version;
+
+@Component(role = MavenReactorRepository.class)
+public class MavenReactorRepository extends ResourcesRepository implements RepositoryPlugin {
+
+	@Override
+	public PutResult put(InputStream stream, PutOptions options) throws Exception {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public File get(String bsn, Version version, Map<String, String> properties, DownloadListener... listeners)
+			throws Exception {
+		return null;
+	}
+
+	@Override
+	public boolean canWrite() {
+		return false;
+	}
+
+	@Override
+	public List<String> list(String pattern) throws Exception {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public SortedSet<Version> versions(String bsn) throws Exception {
+		return Collections.emptySortedSet();
+	}
+
+	@Override
+	public String getName() {
+		return "Maven Reactor";
+	}
+
+	@Override
+	public String getLocation() {
+		return "reactor";
+	}
+
+	public void addProject(MavenProject project) {
+		addArtifact(project.getArtifact());
+		project.getAttachedArtifacts().forEach(this::addArtifact);
+	}
+
+	private void addArtifact(Artifact artifact) {
+		File file = artifact.getFile();
+		if (file == null || !file.getName().endsWith(".jar") || !file.isFile()) {
+			return;
+		}
+		try {
+			SupportingResource resource = ResourceBuilder.parse(file, file.toURI());
+			add(resource);
+		} catch (RuntimeException e) {
+
+		}
+	}
+
+}

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/maven/BndProjectExecutionListener.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/maven/BndProjectExecutionListener.java
@@ -20,9 +20,15 @@ import org.apache.maven.execution.ProjectExecutionListener;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.plugin.MojoExecution;
 import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.tycho.bnd.MavenReactorRepository;
 
 @Component(role = ProjectExecutionListener.class)
 public class BndProjectExecutionListener implements ProjectExecutionListener {
+
+
+	@Requirement
+	private MavenReactorRepository mavenReactorRepository;
 
 	@Override
 	public void beforeProjectExecution(ProjectExecutionEvent event) throws LifecycleExecutionException {
@@ -74,7 +80,7 @@ public class BndProjectExecutionListener implements ProjectExecutionListener {
 
 	@Override
 	public void afterProjectExecutionSuccess(ProjectExecutionEvent event) throws LifecycleExecutionException {
-
+		mavenReactorRepository.addProject(event.getProject());
 	}
 
 	@Override

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/AbstractBndMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/AbstractBndMojo.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bnd.mojos;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.tycho.bnd.MavenReactorRepository;
+
+import aQute.bnd.build.Workspace;
+import aQute.service.reporter.Report;
+
+public abstract class AbstractBndMojo extends AbstractMojo {
+
+	@Parameter(property = "project", readonly = true)
+	protected MavenProject mavenProject;
+
+	@Parameter(property = "session", readonly = true)
+	protected MavenSession session;
+
+	@Component
+	protected MavenReactorRepository mavenReactorRepository;
+
+	protected Workspace getWorkspace() throws MojoFailureException {
+		try {
+			Workspace workspace = Workspace.getWorkspace(mavenProject.getBasedir().getParentFile());
+			if (workspace.getPlugins().stream().noneMatch(plugin -> plugin instanceof MavenReactorRepository)) {
+				workspace.addBasicPlugin(mavenReactorRepository);
+				workspace.refresh();
+			}
+			checkResult(workspace, workspace.isFailOk());
+			return workspace;
+		} catch (Exception e) {
+			throw new MojoFailureException("error while locating workspace!", e);
+		}
+	}
+
+	protected void checkResult(Report report, boolean errorOk) throws MojoFailureException {
+		List<String> warnings = report.getWarnings();
+		for (String warning : warnings) {
+			getLog().warn(warning);
+		}
+		warnings.clear();
+		List<String> errors = report.getErrors();
+		for (String error : errors) {
+			getLog().error(error);
+		}
+		if (errorOk) {
+			errors.clear();
+			return;
+		}
+		if (errors.size() > 0) {
+			throw new MojoFailureException(errors.stream().collect(Collectors.joining(System.lineSeparator())));
+		}
+	}
+
+}

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
@@ -24,20 +24,15 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.ModelReader;
 import org.apache.maven.model.io.ModelWriter;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
 
 @Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE)
-public class BndInitMojo extends AbstractMojo {
-
-	@Parameter(property = "project", readonly = true)
-	protected MavenProject mavenProject;
+public class BndInitMojo extends AbstractBndMojo {
 
 	/**
 	 * The filename of the tycho generated POM file.

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndRunMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndRunMojo.java
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bnd.mojos;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProjectHelper;
+import org.osgi.service.resolver.ResolutionException;
+
+import aQute.bnd.build.Container;
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.exporter.executable.ExecutableJarExporter;
+import aQute.bnd.exporter.runbundles.RunbundlesExporter;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.JarResource;
+import aQute.bnd.osgi.Resource;
+import biz.aQute.resolve.Bndrun;
+import biz.aQute.resolve.ResolveProcess;
+
+@Mojo(name = "run", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+public class BndRunMojo extends AbstractBndMojo {
+
+	private static final String BNDRUN = ".bndrun";
+
+	@Parameter(property = "bndrun.exports")
+	private Set<String> exports;
+
+	@Parameter
+	private Map<String, String> options;
+
+	@Parameter(property = "bndrun.exporter", defaultValue = ExecutableJarExporter.EXECUTABLE_JAR)
+	private String exporter;
+
+	@Parameter(property = "bndrun.attatch", defaultValue = "true")
+	private boolean attatch;
+
+	@Parameter(property = "bndrun.resolve", defaultValue = "false")
+	private boolean resolve;
+
+	@Component
+	MavenProjectHelper helper;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (exports == null || exports.isEmpty()) {
+			return;
+		}
+		List<BndRunFile> bndRuns = getBndRuns();
+		if (bndRuns.isEmpty()) {
+			return;
+		}
+		Workspace workspace = getWorkspace();
+		checkResult(workspace, workspace.isFailOk());
+		for (BndRunFile bndRunFile : bndRuns) {
+			getLog().info(String.format("Exporting %s ...", bndRunFile.name()));
+			try (Bndrun run = getBndRun(workspace, bndRunFile)) {
+				if (resolve) {
+					try {
+						getLog().info(String.format("Resolve %s...", bndRunFile.name()));
+						resolveRun(run);
+					} catch (ResolutionException e) {
+						String msg = ResolveProcess.format(e, false);
+						getLog().error(msg);
+						throw new MojoFailureException("resolve bnd run failed: " + msg, e);
+					}
+				}
+				Path export = export(run, bndRunFile);
+				if (export != null) {
+					getLog().info(String.format("Exported to %s", export));
+					if (attatch && Files.isRegularFile(export)) {
+						helper.attachArtifact(mavenProject, "jar", bndRunFile.name(), export.toFile());
+					}
+				}
+			} catch (IOException e) {
+				getLog().error("failed to close Bndrun", e);
+			}
+		}
+	}
+
+	private void resolveRun(Bndrun run) throws ResolutionException, MojoFailureException {
+		try {
+			String runBundles = run.resolve(false, false);
+			if (runBundles != null && run.isOk()) {
+				run.setProperty(Constants.RUNBUNDLES, runBundles);
+				Collection<Container> collection = run.getRunbundles();
+				if (collection.size() > 0) {
+					String collect = collection.stream()
+							.map(cont -> cont.getBundleSymbolicName() + " " + cont.getVersion())
+							.collect(Collectors.joining(System.lineSeparator() + "\t"));
+					getLog().info(
+							String.format("%s:%s\t%s", Constants.RUNBUNDLES, System.lineSeparator(), collect));
+				}
+			}
+		} catch (ResolutionException re) {
+			throw re;
+		} catch (Exception e) {
+			throw new MojoFailureException("Error resolving bnd run", e);
+		}
+
+	}
+
+	private Path export(Bndrun run, BndRunFile bndRunFile) throws MojoFailureException {
+		try {
+			Entry<String, Resource> result = run.export(exporter, options);
+			try (Resource export = result.getValue()) {
+				Path exportBasePath = Path.of(mavenProject.getBuild().getDirectory()).resolve(getOutputFolder());
+				Files.createDirectories(exportBasePath);
+				if (exporter.equals(RunbundlesExporter.RUNBUNDLES)) {
+					if (export instanceof JarResource jar) {
+						Path exportPath = exportBasePath.resolve(bndRunFile.name());
+						Files.createDirectories(exportPath);
+						jar.getJar().writeFolder(exportPath.toFile());
+						return exportPath;
+					}
+					return null;
+				} else {
+					Path exportPath = exportBasePath.resolve(result.getKey());
+					export.write(exportPath);
+					Files.setLastModifiedTime(exportPath, FileTime.fromMillis(export.lastModified()));
+					return exportPath;
+				}
+			}
+		} catch (Exception e) {
+			throw new MojoFailureException("error exporting bnd run!", e);
+		}
+	}
+
+	private String getOutputFolder() {
+		if (exporter.equals(RunbundlesExporter.RUNBUNDLES)) {
+			return "runbundles";
+		} else if (exporter.equals(ExecutableJarExporter.EXECUTABLE_JAR)) {
+			return "executable";
+		}
+		return "export";
+	}
+
+	private Bndrun getBndRun(Workspace workspace, BndRunFile run) throws MojoFailureException {
+		Bndrun bndRun;
+		try {
+			bndRun = Bndrun.createBndrun(workspace, run.path().toFile());
+			Project project = workspace.getProject(mavenProject.getBasedir().getName());
+			if (project != null) {
+				bndRun.setParent(project);
+			}
+		} catch (Exception e) {
+			throw new MojoFailureException("error creating bnd run!", e);
+		}
+		checkResult(bndRun, workspace.isFailOk());
+		return bndRun;
+	}
+
+	private List<BndRunFile> getBndRuns() throws MojoExecutionException {
+		List<BndRunFile> bndRuns = new ArrayList<>();
+		Path path = mavenProject.getBasedir().toPath();
+		try {
+			Iterator<Path> iterator = Files.list(path).iterator();
+			while (iterator.hasNext()) {
+				Path child = iterator.next();
+				String fn = child.getFileName().toString();
+				if (fn.endsWith(BNDRUN)) {
+					String key = fn.substring(0, fn.length() - BNDRUN.length());
+					if (exports.contains(key)) {
+						bndRuns.add(new BndRunFile(key, child));
+					}
+				}
+			}
+		} catch (IOException e) {
+			throw new MojoExecutionException(e);
+		}
+		return bndRuns;
+	}
+
+	private static record BndRunFile(String name, Path path) {
+
+	}
+
+}

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
@@ -138,6 +138,7 @@ public class BndProjectMapping extends AbstractTychoMapping {
 			addPluginExecution(bndPlugin, execution -> {
 				execution.setId("build");
 				execution.addGoal("build");
+				execution.addGoal("run");
 			});
 		} catch (Exception e) {
 			if (e instanceof IOException io) {


### PR DESCRIPTION
This adds support for "building" bndrun files by exporting them into a runnable jar.

This successfully builds the extended demo project supplied here:
- https://github.com/eclipse-tycho/tycho/pull/4675

FYI @chrisrueger  