### PR TITLE
Support custom properties from bnd files and enhance the documentation

### DIFF
--- a/src/site/markdown/BndBuild.md
+++ b/src/site/markdown/BndBuild.md
@@ -34,7 +34,7 @@ In contrast to a traditional maven build where each module has to contain a `pom
 </extensions>
 ```
 
-- create a file called `maven.config` in the `.mvn` folder with the following content (adjust the version accordingly!):
+- create a file called `maven.config` in the `.mvn` folder with the following content (adjust the Tycho version accordingly to the [latest release](https://github.com/eclipse-tycho/tycho/releases)!):
 ```properties
 -Dtycho-version=4.0.10
 ```
@@ -42,6 +42,14 @@ In contrast to a traditional maven build where each module has to contain a `pom
 - You can now run your build with `mvn clean verify`.
 
 You can check more details in a [demo project](https://github.com/eclipse-tycho/tycho/tree/master/demo/bnd-workspace).
+
+### Configure the pomless build
+
+If you want to further configure the build can be done in these ways:
+
+1. You can specify additional global properties in the `.mvn/maven.config`.
+2. You can define properties per project properties in the `bnd.bnd` file `pom.model.property.<some property>: true`, see [the wiki](https://github.com/eclipse-tycho/tycho/wiki/Tycho-Pomless#overwrite-group-and-artifact-ids) for more details.
+3. You can place a `pom.xml` in your `cnf` folder this will then be used as a parent for the aggregator, here you can add additional mojos, profiles and so on. If you want to enable certain things only for some of the projects you can use properties as described in (2) to skip the execution of mojos not relevant for other projects.
 
 ## Mixed Builds
 

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndBuildMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndBuildMojo.java
@@ -13,7 +13,11 @@
 package org.eclipse.tycho.bnd.mojos;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.List;
+import java.util.jar.JarOutputStream;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.Component;
@@ -56,7 +60,24 @@ public class BndBuildMojo extends AbstractBndProjectMojo {
 				helper.attachArtifact(mavenProject, "jar", name, file);
 			}
 		}
+		ensureArtifactIsSet();
+	}
 
+	private void ensureArtifactIsSet() throws IOException, FileNotFoundException {
+		if ("pom".equals(mavenProject.getPackaging())) {
+			// pom packaging is allowed to have no main artifact...
+			return;
+		}
+		Artifact artifact = mavenProject.getArtifact();
+		if (artifact.getFile() == null) {
+			artifact.setFile(new File(mavenProject.getBuild().getDirectory(), mavenProject.getArtifactId() + ".jar"));
+		}
+		if (!artifact.getFile().exists()) {
+			try (JarOutputStream jarOutputStream = new JarOutputStream(
+					new FileOutputStream(artifact.getFile()))) {
+				// create a dummy result as otherwise maven is not happy
+			}
+		}
 	}
 
 }

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
@@ -14,9 +14,12 @@ package org.eclipse.tycho.build.bnd;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.maven.lifecycle.Lifecycle;
 import org.apache.maven.model.Build;
@@ -75,6 +78,15 @@ public class BndProjectMapping extends AbstractTychoMapping {
 	@Override
 	public String getFlavour() {
 		return "bnd";
+	}
+
+	@Override
+	protected Properties getEnhancementProperties(Path file) throws IOException {
+		Properties bnd = new Properties();
+		try (InputStream stream = Files.newInputStream(file)) {
+			bnd.load(stream);
+			return bnd;
+		}
 	}
 
 	@Override

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndWorkspaceMapping.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndWorkspaceMapping.java
@@ -125,6 +125,15 @@ public class BndWorkspaceMapping extends AbstractTychoMapping {
 	@Override
 	protected ParentModel findParent(Path projectRoot, Map<String, ?> projectOptions) throws IOException {
 		try {
+			Workspace workspace = Workspace.findWorkspace(projectRoot.toFile());
+			File base = workspace.getBase();
+			if (Files.isSameFile(projectRoot, base.toPath())) {
+				File buildDir = workspace.getBuildDir();
+				return loadParent(projectRoot, buildDir.toPath());
+			}
+		} catch (Exception e) {
+		}
+		try {
 			return super.findParent(projectRoot, projectOptions);
 		} catch (NoParentPomFound e) {
 			// this can happen in 100% pomless mode!

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
@@ -184,6 +184,10 @@ public abstract class AbstractTychoMapping implements Mapping, ModelReader {
         // assumption parent pom must be physically located in parent directory if not given by build.properties
         String parentRef = buildProperties.getProperty(TYCHO_POMLESS_PARENT_PROPERTY, PARENT_POM_DEFAULT_VALUE);
         Path fileOrFolder = projectRoot.resolve(parentRef).toRealPath();
+        return loadParent(projectRoot, fileOrFolder);
+    }
+
+    protected ParentModel loadParent(Path projectRoot, Path fileOrFolder) throws NoParentPomFound, IOException {
         PomReference parentPom;
         if (Files.isRegularFile(fileOrFolder)) {
             parentPom = locatePomReference(fileOrFolder.getParent(), getFileName(fileOrFolder));


### PR DESCRIPTION
This now makes the bnd.bnd file available as plain properties to the build so one is able to define the magic pomless properties to further customize the pomless build.

Additionally the workspace cnf folder is now searched for a pom.xml file as the parent of the aggregator to allow further customization and the documentation is enhanced to describe these options.

FYI @chrisrueger this should now be the final pice in the puzzle to fully leverage the power of maven with little configuration efforts.