### PR TITLE
make synchronization of classpath calculation more fine-grained

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -320,13 +320,8 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
         return getBundleClassPath(project).getExtraBootClasspathAccessRules();
     }
 
-    public synchronized BundleClassPath getBundleClassPath(ReactorProject project) {
-        if (project.getContextValue(CTX_CLASSPATH) instanceof BundleClassPath bundleClassPath) {
-            return bundleClassPath;
-        }
-        BundleClassPath cp = resolveClassPath(getMavenSession(project), getMavenProject(project));
-        project.setContextValue(CTX_CLASSPATH, cp);
-        return cp;
+    public BundleClassPath getBundleClassPath(ReactorProject project) {
+        return project.computeContextValue(CTX_CLASSPATH, () -> resolveClassPath(getMavenSession(project), getMavenProject(project)));
     }
 
     /**


### PR DESCRIPTION
Currently, the calculation of the classpath for a project is effectively a singleton because the BundleProject is used as monitor (synchronization). This leads to a poor performance if executing a tycho build with  many threads, many projects and complex dependencies.

This change replaces the global monitor with a fine-grained monitor the given project the classpath should be calculated for. This speeds up the parallel build.