### PR TITLE
Consider runbundles when computing dependencies

### DIFF
--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/BndRunFile.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/BndRunFile.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bnd;
+
+import java.nio.file.Path;
+
+public record BndRunFile(String name, Path path) {
+
+}


### PR DESCRIPTION
If we have a bndrun activated then the runbundles become dependencies of the maven project.

This now calculates the enabled bndruns and return the bundle names so they can be used to add required reactor projects.

FYI @chrisrueger 