### PR TITLE
IT test for Issue 4653 reproducer

### DIFF
--- a/tycho-its/projects/target.eagerResolver/dependee/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.eagerResolver/dependee/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: dependee
+Bundle-SymbolicName: dependee
+Bundle-Version: 0.0.1.qualifier
+Export-Package: dependee,
+ org.apache.commons.lang3
+Bundle-ClassPath: .,
+ lib/commons-lang3.jar

--- a/tycho-its/projects/target.eagerResolver/dependee/build.properties
+++ b/tycho-its/projects/target.eagerResolver/dependee/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = classes/
+bin.includes = META-INF/,\
+               .,\
+               lib/commons-lang3.jar

--- a/tycho-its/projects/target.eagerResolver/dependee/pom.xml
+++ b/tycho-its/projects/target.eagerResolver/dependee/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>tycho-its-project.osgitools.artifactsWithKnownLocation</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>dependee</artifactId>
+  <packaging>eclipse-plugin</packaging>
+  <properties>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
+  </properties>
+  <!-- Taken and adapted from https://stackoverflow.com/questions/28542595/how-to-embed-a-library-jar-in-an-osgi-bundle-using-tycho/30872071#30872071 -->
+  <build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>copy-libraries</id>
+                    <phase>validate</phase>
+                    <goals>
+                        <goal>copy</goal>
+                    </goals>
+                    <configuration>
+                        <artifactItems>
+                            <item>
+                                <groupId>org.apache.commons</groupId>
+                                <artifactId>commons-lang3</artifactId>
+                                <version>${commons-lang3.version}</version>
+                            </item>
+                        </artifactItems>
+                        <outputDirectory>lib</outputDirectory>
+                        <stripVersion>true</stripVersion>
+                        <overWriteReleases>true</overWriteReleases>
+                        <overWriteSnapshots>true</overWriteSnapshots>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tycho-its/projects/target.eagerResolver/dependee/src/dependee/DependeeExample.java
+++ b/tycho-its/projects/target.eagerResolver/dependee/src/dependee/DependeeExample.java
@@ -1,0 +1,18 @@
+package dependee;
+
+import org.apache.commons.lang3.BitField;
+import org.apache.commons.lang3.StringUtils;
+
+public class DependeeExample {
+
+    public DependeeExample() { }
+
+    public boolean isStringBlank(String s) {
+        return StringUtils.isBlank(s);
+    }
+    
+    public BitField getBitField() {
+    	return new BitField(0xFFFFFF);
+    }
+
+}

--- a/tycho-its/projects/target.eagerResolver/dependent/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.eagerResolver/dependent/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: dependent
+Bundle-SymbolicName: dependent
+Bundle-Version: 0.0.1.qualifier
+Require-Bundle: dependee
+Bundle-ClassPath: .

--- a/tycho-its/projects/target.eagerResolver/dependent/build.properties
+++ b/tycho-its/projects/target.eagerResolver/dependent/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = classes/
+bin.includes = META-INF/,\
+               .,\

--- a/tycho-its/projects/target.eagerResolver/dependent/pom.xml
+++ b/tycho-its/projects/target.eagerResolver/dependent/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>tycho-its-project.osgitools.artifactsWithKnownLocation</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>dependent</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/target.eagerResolver/dependent/src/DependentExample.java
+++ b/tycho-its/projects/target.eagerResolver/dependent/src/DependentExample.java
@@ -1,0 +1,14 @@
+import org.apache.commons.lang3.StringUtils;
+import dependee.DependeeExample;
+
+public class DependentExample {
+
+    public static void main(String[] args) {
+    	DependeeExample dependeeEx = new DependeeExample();
+    	String s = " ";
+        boolean sIsBlank = StringUtils.isBlank(s);
+
+        System.out.println("s is blank:  " + sIsBlank);
+        System.out.println("bitfield is: " + dependeeEx.getBitField());
+    }
+}

--- a/tycho-its/projects/target.eagerResolver/pom.xml
+++ b/tycho-its/projects/target.eagerResolver/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>tycho-its-project.osgitools.artifactsWithKnownLocation</groupId>
+  <artifactId>parent</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <modules>
+    <module>dependee</module>
+    <module>dependent</module>
+  </modules>
+  <build>
+    <plugins>
+        <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-maven-plugin</artifactId>
+            <version>${tycho-version}</version>
+            <extensions>true</extensions>
+        </plugin>
+        <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>target-platform-configuration</artifactId>
+            <version>${tycho-version}</version>
+            <configuration>
+                <requireEagerResolve>true</requireEagerResolve>
+            </configuration>
+        </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformEagerResolverTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformEagerResolverTest.java
@@ -1,0 +1,17 @@
+package org.eclipse.tycho.test.target;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+import java.util.List;
+
+// See issue https://github.com/eclipse-tycho/tycho/issues/4653
+public class TargetPlatformEagerResolverTest extends AbstractTychoIntegrationTest {
+    @Test
+    public void testTargetPlatformForJUnit5() throws Exception {
+        Verifier verifier = getVerifier("target.eagerResolver", false, true);
+        verifier.executeGoals(List.of("clean", "verify"));
+        verifier.verifyErrorFreeLog();
+    }
+}


### PR DESCRIPTION
- External dependency `org.apache.commons:commons-lang3-${commons-lang3.version}.jar` is downloaded and placed into `target.eagerResolver/dependee/lib` at build time using `maven-dependency-plugin`.
- Please also review the naming of the project, naming and placement of the test class, and naming and placement of the other files and let me know if adjustments are requested.