### PR TITLE
Improve debug for bad maven artifacts

### DIFF
--- a/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinitionFile.java
+++ b/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinitionFile.java
@@ -242,7 +242,6 @@ public final class TargetDefinitionFile implements TargetDefinition {
 			builder.append(getVersion());
 			builder.append(", ArtifactType = ");
 			builder.append(getArtifactType());
-			builder.append(", IncludeDependencyScope = ");
 			return builder.toString();
 		}
 


### PR DESCRIPTION
Currently if a dependency fails to be wrapped the user gets a quite vague error message that don'T give a hint where the problem originates and how to possibly solve it.

This now do the following:
- name the offender and the root artifact that require it
- add a hint to exclude the offending artifact