### PR TITLE
Remove signatures from wrapped source bundles

### DIFF
--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/AbstractMavenTargetTest.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/AbstractMavenTargetTest.java
@@ -32,7 +32,9 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IStatus;
@@ -174,6 +176,17 @@ public abstract class AbstractMavenTargetTest {
                 tb -> tb.isSourceBundle(),
                 tb -> tb.getSourceTarget() != null ? tb.getSourceTarget().getSymbolicName() : null,
                 tb -> tb.getBundleInfo().getSymbolicName() + ":" + tb.getBundleInfo().getVersion());
+    }
+
+    static void assertValidSignature(TargetBundle targetBundle) throws IOException {
+        try (JarInputStream stream = new JarInputStream(
+                targetBundle.getBundleInfo().getLocation().toURL().openStream())) {
+            for (JarEntry entry = stream.getNextJarEntry(); entry != null; entry = stream.getNextJarEntry()) {
+                for (byte[] drain = new byte[4096]; stream.read(drain, 0, drain.length) != -1;) {
+                    // nothing we just want to trigger the signature verification
+                }
+            }
+        }
     }
 
     // --- assertion utilities for Features in a target ---

--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -73,6 +73,39 @@ public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
     }
 
     @Test
+    public void testSourceWithSignature() throws Exception {
+        ITargetLocation target = resolveMavenTarget(
+                """
+                        <location includeDependencyDepth="none" includeDependencyScopes="compile" label="LemMinX" includeSource="true" missingManifest="error" type="Maven">
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.eclipse.lemminx</groupId>
+                                    <artifactId>org.eclipse.lemminx</artifactId>
+                                    <version>0.29.0</version>
+                                    <type>jar</type>
+                                </dependency>
+                            </dependencies>
+                            <repositories>
+                                <repository>
+                                    <id>lemminx-releases</id>
+                                    <url>https://repo.eclipse.org/content/repositories/lemminx-releases/</url>
+                                </repository>
+                            </repositories>
+                        </location>
+                        """);
+        assertStatusOk(getTargetStatus(target));
+        TargetBundle[] allBundles = target.getBundles();
+        boolean sourcesFound = false;
+        for (TargetBundle targetBundle : allBundles) {
+            if (targetBundle.isSourceBundle()) {
+                sourcesFound = true;
+                assertValidSignature(targetBundle);
+            }
+        }
+        assertTrue("No source bundle generated!", sourcesFound);
+    }
+
+    @Test
     public void testBadDependencyDirect() throws Exception {
         ITargetLocation target = resolveMavenTarget("""
                 <location missingManifest="generate" type="Maven">


### PR DESCRIPTION
Currently when the source bundle is signed, wrapping it into a source bundle will break the signature and make the jar invalid.

This now removes the signature from source bundles as they are transformed.