### PR TITLE
Fix stack overflow when workspace config folder contains bnd.bnd file

### DIFF
--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
@@ -158,6 +158,10 @@ public abstract class AbstractTychoMapping implements Mapping, ModelReader {
         if (model.getParent() == null) {
             model.setParent(findParent(artifactFile.getParent(), options).parentReference());
         }
+        if (model.getGroupId() == null && model.getParent() == null) {
+            //if nothing has init this yet set at least a value
+            model.setGroupId(artifactFile.getParent().getFileName().toString());
+        }
         if (model.getVersion() == null && model.getParent() != null) {
             //inherit version from parent if not given
             model.setVersion(model.getParent().getVersion());

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/NoParentPomFound.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/NoParentPomFound.java
@@ -19,7 +19,11 @@ import java.nio.file.Path;
 public class NoParentPomFound extends FileNotFoundException {
 
     public NoParentPomFound(Path path) throws IOException {
-        super("No parent pom file found in " + path.toAbsolutePath().toString());
+        this("No parent pom file found in " + path.toAbsolutePath().toString());
+    }
+
+    public NoParentPomFound(String reason) {
+        super(reason);
     }
 
 }


### PR DESCRIPTION
Currently if one places a bnd.bnd file in the config folder of the workspace (what seems to be somehow supported) then this is detected as a project and it tries to find a parent for that what results in the config folder to be considered as a parent and so on leading to stack overflow.

This now detects the situation and throws an exception with a message indicating the cause of the problem.