### PR TITLE
Align bnd mojos with maven-surefire / maven-compiler plugin

### DIFF
--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndInitMojo.java
@@ -31,7 +31,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-@Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE)
+@Mojo(name = "initialize", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
 public class BndInitMojo extends AbstractBndMojo {
 
 	/**

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndIntegrationTestMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndIntegrationTestMojo.java
@@ -14,6 +14,7 @@ package org.eclipse.tycho.bnd.mojos;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import aQute.bnd.build.Project;
@@ -22,8 +23,32 @@ import aQute.bnd.osgi.Constants;
 @Mojo(name = "integration-test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class BndIntegrationTestMojo extends AbstractBndProjectMojo {
 
+	/**
+	 * Set this to <code>true</code> to bypass unit tests entirely. Its use is
+	 * <b>NOT RECOMMENDED</b>, especially if you enable it using the
+	 * "maven.test.skip" property, because maven.test.skip disables both running the
+	 * tests and compiling the tests. Consider using the <code>skipTests</code>
+	 * parameter instead that only skip the <i>execution</i> of tests.
+	 */
+	@Parameter(property = "maven.test.skip")
+	private boolean skip;
+
+	/**
+	 * Set this to "true" to skip running tests, but still compile them. Its use is
+	 * NOT RECOMMENDED, but quite convenient on occasion.
+	 */
+	@Parameter(property = "skipTests")
+	private boolean skipTests;
+
 	@Override
 	protected void execute(Project project) throws Exception {
+		if (skip) {
+			return;
+		}
+		if (skipTests) {
+			getLog().warn("Tests execution is skipped!");
+			return;
+		}
 		String testcases = project.getProperty(Constants.TESTCASES);
 		if (testcases == null) {
 			return;

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndTestCompileMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndTestCompileMojo.java
@@ -14,6 +14,7 @@ package org.eclipse.tycho.bnd.mojos;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import aQute.bnd.build.Project;
@@ -21,8 +22,18 @@ import aQute.bnd.build.Project;
 @Mojo(name = "test-compile", defaultPhase = LifecyclePhase.TEST_COMPILE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class BndTestCompileMojo extends AbstractBndProjectMojo {
 
+	/**
+	 * Set this to <code>true</code> to bypass compilation of test sources. Its use
+	 * is <b>NOT RECOMMENDED</b>, but quite convenient on occasion.
+	 */
+	@Parameter(property = "maven.test.skip")
+	private boolean skip;
+
 	@Override
 	protected void execute(Project project) throws Exception {
+		if (skip) {
+			return;
+		}
 		project.compile(true);
 	}
 


### PR DESCRIPTION
In maven-compiler and maven-surefire there are some ways skip compile/execution of tests. Even though it is not recommended to to so it is quite convenient on occasion.

This now adds analogous parameters to the bnd mojos so these can be used in a similar fashion.

FYI @chrisrueger 