### PR TITLE
Evaluate Package Attributes from source

### DIFF
--- a/tycho-bndlib/src/main/java/org/eclipse/tycho/bndlib/JdtProjectBuilder.java
+++ b/tycho-bndlib/src/main/java/org/eclipse/tycho/bndlib/JdtProjectBuilder.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bndlib;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.ProjectBuilder;
+
+/**
+ * A project builder that injects information from the sources into the builder
+ */
+public class JdtProjectBuilder extends ProjectBuilder {
+
+	public JdtProjectBuilder(Project project) {
+		super(project);
+		addBasicPlugin(new SourceCodeAnalyzerPlugin());
+	}
+
+	@Override
+	public String _packageattribute(String[] args) {
+		SourceCodeAnalyzerPlugin analyzerPlugin = getPlugin(SourceCodeAnalyzerPlugin.class);
+		try {
+			analyzerPlugin.analyzeJar(this);
+		} catch (Exception e) {
+		}
+		return super._packageattribute(args);
+	}
+}

--- a/tycho-build/pom.xml
+++ b/tycho-build/pom.xml
@@ -153,5 +153,10 @@
 			<artifactId>org.osgi.util.promise</artifactId>
 			<version>1.3.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>tycho-bndlib</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/bnd/BndProjectMapping.java
@@ -28,6 +28,7 @@ import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.bndlib.JdtProjectBuilder;
 import org.eclipse.tycho.pomless.AbstractTychoMapping;
 import org.eclipse.tycho.pomless.NoParentPomFound;
 import org.eclipse.tycho.pomless.ParentModel;
@@ -168,7 +169,7 @@ public class BndProjectMapping extends AbstractTychoMapping {
 	}
 
 	private static ProjectBuilder createBuilder(Project project) throws Exception {
-		ProjectBuilder builder = new ProjectBuilder(project);
+		ProjectBuilder builder = new JdtProjectBuilder(project);
 		builder.setBase(project.getBase());
 		builder.use(project);
 		builder.setFailOk(true);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/PdeInstallableUnitProvider.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/bnd/PdeInstallableUnitProvider.java
@@ -194,7 +194,7 @@ public class PdeInstallableUnitProvider implements InstallableUnitProvider {
             public Clazz getPackageInfo(PackageRef packageRef) {
                 Clazz info = super.getPackageInfo(packageRef);
                 if (info == null) {
-                    return plugin.getPackageInfo(packageRef);
+                    return plugin.getPackageInfoClass(packageRef);
                 }
                 return info;
             }


### PR DESCRIPTION
Currently if the evaluation of a version property contains a reference
to a package attribute this fails in the initial phase because bnd
requires the classfiles to be present in such case it is read from an
package-info annotated file.

This now uses the SourceCodeAnalyzerPlugin to recover this information
from the java source files.