### PR TITLE
Ensure actual tested JUnit version is used

### DIFF
--- a/tycho-its/projects/surefire.junit54/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit54/bundle.test/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: JUnit54 Test Plug-in
 Bundle-SymbolicName: bundle.test.junit54
 Bundle-Version: 1.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: org.junit.jupiter.api;version="5.4.0"
+Import-Package: org.junit.jupiter.api;version="[5.4.0,5.5.0)"

--- a/tycho-its/projects/surefire.junit54/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit54/bundle.test/pom.xml
@@ -6,11 +6,12 @@
   <packaging>eclipse-test-plugin</packaging>
   <version>1.0.0</version>
   
-  <repositories>
+   <repositories>
     <repository>
-      <id>eclipse201903</id>
+      <id>eclipse</id>
       <layout>p2</layout>
-      <url>${target-platform}</url>
+      <!-- We need this explicitly here as it contains Junit 5.4 -->
+      <url>https://download.eclipse.org/releases/2019-06/</url>
     </repository>
   </repositories>
   

--- a/tycho-its/projects/surefire.junit56/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit56/bundle.test/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: JUnit56 Test Plug-in
 Bundle-SymbolicName: bundle.test.junit56
 Bundle-Version: 1.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: org.junit.jupiter.api;version="5.6.0"
+Import-Package: org.junit.jupiter.api;version="[5.6.0,5.7.0)"

--- a/tycho-its/projects/surefire.junit56/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit56/bundle.test/pom.xml
@@ -6,11 +6,12 @@
   <packaging>eclipse-test-plugin</packaging>
   <version>1.0.0</version>
   
-  <repositories>
+    <repositories>
     <repository>
-      <id>eclipse202003</id>
+      <id>eclipse</id>
       <layout>p2</layout>
-      <url>${target-platform}</url>
+      <!-- We need this specific URL as it contains JUnit 5.6 -->
+      <url>https://download.eclipse.org/releases/2020-09/</url>
     </repository>
   </repositories>
   

--- a/tycho-its/projects/surefire.junit59/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit59/bundle.test/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: JUnit59 Test Plug-in
 Bundle-SymbolicName: bundle.test.junit59
 Bundle-Version: 1.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: org.junit.jupiter.api;version="5.9.0",
- org.junit.jupiter.params;version="5.9.0",
- org.junit.jupiter.params.provider;version="5.9.0"
+Import-Package: org.junit.jupiter.api;version="[5.9.0,5.10.0)",
+ org.junit.jupiter.params;version="[5.9.0,5.10.0)",
+ org.junit.jupiter.params.provider;version="[5.9.0,5.10.0)"
+

--- a/tycho-its/projects/surefire.junit59/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit59/bundle.test/pom.xml
@@ -8,9 +8,10 @@
   
   <repositories>
     <repository>
-      <id>eclipse202003</id>
+      <id>eclipse</id>
       <layout>p2</layout>
-      <url>${target-platform}</url>
+      <!-- We need this explicit release as it contains JUnit 5.9 release -->
+      <url>https://download.eclipse.org/releases/2023-03/</url>
     </repository>
   </repositories>
   

--- a/tycho-its/projects/surefire.junit59suite/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.junit59suite/bundle.test/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: JUnit5 Suite Test Plug-in
 Bundle-SymbolicName: bundle.test.junit59suite
 Bundle-Version: 1.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: org.junit.jupiter.api;version="5.9.0",
- org.junit.platform.suite.api;version="1.9.0"
+Import-Package: org.junit.jupiter.api;version="[5.9.0,5.10.0)",
+ org.junit.platform.suite.api;version="[1.9.0,1.10.0)"

--- a/tycho-its/projects/surefire.junit59suite/bundle.test/pom.xml
+++ b/tycho-its/projects/surefire.junit59suite/bundle.test/pom.xml
@@ -10,7 +10,8 @@
     <repository>
       <id>eclipse</id>
       <layout>p2</layout>
-      <url>${target-platform}</url>
+      <!-- We need this explicit release as it contains JUnit 5.9 release -->
+      <url>https://download.eclipse.org/releases/2023-03/</url>
     </repository>
   </repositories>
   


### PR DESCRIPTION
Currently we have some tests that claim to test a certain JUnit version but their manifest actually allows any higher version. Together with the usage of the latest target platform, these test actually all test the same junit version.

This change the manifest with an upper bound so it fails to compile if not the intended version is used and fix the used eclipse release to supply a compatible implementation.