### PR TITLE
Resolve jars and library extra.classpath entries optionally

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/publisher/AbstractMetadataGenerator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/publisher/AbstractMetadataGenerator.java
@@ -38,10 +38,10 @@ import org.eclipse.tycho.BuildProperties;
 import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.IDependencyMetadata.DependencyMetadataType;
-import org.eclipse.tycho.core.shared.StatusTool;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.shared.StatusTool;
 import org.eclipse.tycho.p2.metadata.PublisherOptions;
 
 public abstract class AbstractMetadataGenerator {
@@ -110,7 +110,7 @@ public abstract class AbstractMetadataGenerator {
         Matcher m = TychoConstants.PLATFORM_URL_PATTERN.matcher(url);
         if (m.matches())
             result.add(MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, m.group(2),
-                    VersionRange.emptyRange, null, false, false));
+                    VersionRange.emptyRange, null, true, false));
     }
 
     private DependencyMetadata publish(IPublisherInfo publisherInfo, List<IPublisherAction> actions) {


### PR DESCRIPTION
If a bundle is referenced in an 'jars.extra.classpath' entry cannot be resolved (e.g. because it's a fragment) then the resolution of the referencing project should not fail. This is also in accordance with PDE where entries that cannot be resolved are simply ignored.

A reproducer is https://github.com/eclipse-platform/eclipse.platform.swt/pull/1638, where we have the following entry in the `build.properties` of a new `o.e.swt.svg` fragment:
```
jars.extra.classpath = platform:/plugin/org.eclipse.swt.cocoa.macosx.aarch64,\
                       platform:/plugin/org.eclipse.swt.cocoa.macosx.x86_64,\
                       platform:/plugin/org.eclipse.swt.gtk.linux.aarch64,\
                       platform:/plugin/org.eclipse.swt.gtk.linux.ppc64le,\
                       platform:/plugin/org.eclipse.swt.gtk.linux.riscv64,\
                       platform:/plugin/org.eclipse.swt.gtk.linux.x86_64,\
                       platform:/plugin/org.eclipse.swt.win32.win32.aarch64,\
                       platform:/plugin/org.eclipse.swt.win32.win32.x86_64
```
That currently fails with the following error:
```
[ERROR] Cannot resolve dependencies of project eclipse.platform.swt:org.eclipse.swt.svg:eclipse-plugin:1.0.0-SNAPSHOT
 [ERROR]  with context {osgi.os=linux, org.eclipse.update.install.features=true, org.eclipse.swt.buildtime=true, osgi.arch=x86_64, org.eclipse.update.install.sources=true, osgi.ws=gtk, org.eclipse.jdt.buildtime=true}
 [ERROR]   Software being installed: org.eclipse.swt.svg 1.0.0.qualifier
 [ERROR]   Missing requirement: org.eclipse.swt.svg 1.0.0.qualifier requires 'org.eclipse.equinox.p2.iu; org.eclipse.swt.win32.win32.x86_64 0.0.0' but it could not be found: See log for details
```
It does so, even if one only specifies only the fragment of the current platform.

If necessary we can also make this new behavior configurable.