### PR TITLE
Upgrade LocalRepositoryCrosstalkTest to use more recent Eclipse

### DIFF
--- a/tycho-its/projects/TYCHO0367localRepositoryCrosstalk/bundle01/src/TYCHO0367localRepositoryCrosstalk/bundle01/Eclipse34Test.java
+++ b/tycho-its/projects/TYCHO0367localRepositoryCrosstalk/bundle01/src/TYCHO0367localRepositoryCrosstalk/bundle01/Eclipse34Test.java
@@ -29,7 +29,7 @@ public class Eclipse34Test
         Bundle equinox = getBundle( "org.eclipse.osgi");
 
         assertEquals( 3, equinox.getVersion().getMajor() );
-        assertEquals( 13, equinox.getVersion().getMinor() );
+        assertEquals( 20, equinox.getVersion().getMinor() );
     }
     
     public Bundle getBundle( String id )

--- a/tycho-its/projects/TYCHO0367localRepositoryCrosstalk/bundle02/src/TYCHO0367localRepositoryCrosstalk/bundle02/Eclipse35Test.java
+++ b/tycho-its/projects/TYCHO0367localRepositoryCrosstalk/bundle02/src/TYCHO0367localRepositoryCrosstalk/bundle02/Eclipse35Test.java
@@ -25,7 +25,7 @@ public class Eclipse35Test extends TestCase {
         Bundle equinox = getBundle("org.eclipse.osgi");
 
         assertEquals(3, equinox.getVersion().getMajor());
-        assertTrue(equinox.getVersion().getMinor() > 13);
+        assertTrue(equinox.getVersion().getMinor() > 20);
     }
 
     public Bundle getBundle(String id) {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0367localRepositoryCrosstalk/LocalRepositoryCrosstalkTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0367localRepositoryCrosstalk/LocalRepositoryCrosstalkTest.java
@@ -27,7 +27,7 @@ public class LocalRepositoryCrosstalkTest extends AbstractTychoIntegrationTest {
 		// now run bundle1 test, it should not "see" artifacts in local repo from newer
 		// update site
 		Verifier v02 = getVerifier("/TYCHO0367localRepositoryCrosstalk/bundle01", false);
-		v02.addCliOption("-Dp2.repo=https:////download.eclipse.org/releases/photon/");
+		v02.addCliOption("-Dp2.repo=https:////download.eclipse.org/releases/2024-06/");
 		v02.executeGoal("install");
 		v02.verifyErrorFreeLog();
 	}


### PR DESCRIPTION
The test only needs two eclipse releases where the Equinox Minor version differs, currently we use a quite outdated photon release.

To prevent issues with upgrade of test dependencies this now upgrades to a more recent 2024-06 eclipse release.