### PR TITLE
Copy non java sources to the output in bnd-builds

### DIFF
--- a/tycho-bnd-plugin/pom.xml
+++ b/tycho-bnd-plugin/pom.xml
@@ -30,6 +30,10 @@
 			<artifactId>plexus-utils</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-compiler-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-core</artifactId>
 			<version>${project.version}</version>

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/CopyMapping.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/CopyMapping.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 SAP AG and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP AG - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bnd;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.codehaus.plexus.compiler.util.scan.InclusionScanException;
+import org.codehaus.plexus.compiler.util.scan.mapping.SourceMapping;
+
+/**
+ * A source mapping for simply copying files to the target directory.
+ * 
+ * @author jan.sievers@sap.com
+ */
+public class CopyMapping implements SourceMapping {
+
+    List<SourceTargetPair> sourceTargetMappings = new ArrayList<>();
+
+    @Override
+    public Set<File> getTargetFiles(File targetDir, String source) throws InclusionScanException {
+        File targetFile = new File(targetDir, source);
+        sourceTargetMappings.add(new SourceTargetPair(source, targetFile));
+        return Collections.singleton(targetFile);
+    }
+
+    public List<SourceTargetPair> getSourceTargetPairs() {
+        return sourceTargetMappings;
+    }
+
+    public static class SourceTargetPair {
+
+        public String source;
+        public File target;
+
+        public SourceTargetPair(String source, File target) {
+            this.source = source;
+            this.target = target;
+        }
+
+    }
+}

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/AbstractBndCompileMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/AbstractBndCompileMojo.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.bnd.mojos;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.compiler.util.scan.InclusionScanException;
+import org.codehaus.plexus.compiler.util.scan.StaleSourceScanner;
+import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.tycho.bnd.CopyMapping;
+
+import aQute.bnd.build.Project;
+
+public abstract class AbstractBndCompileMojo extends AbstractBndProjectMojo {
+
+	private static final Set<String> MATCH_ALL = Collections.singleton("**/*");
+
+	/**
+	 * Whether all resources in the source folders should be copied to
+	 * ${project.build.outputDirectory}.
+	 * 
+	 * <code>true</code> (default) means that all resources are copied from the
+	 * source folders to <code>${project.build.outputDirectory}</code>.
+	 * 
+	 * <code>false</code> means that no resources are copied from the source folders
+	 * to <code>${project.build.outputDirectory}</code>.
+	 * 
+	 * Set this to <code>false</code> in case you want to keep resources separate
+	 * from java files in <code>src/main/resources</code> and handle them using
+	 * <a href="https://maven.apache.org/plugins/maven-resources-plugin/">
+	 * maven-resources-plugin</a> (e.g. for <a href=
+	 * "https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html">resource
+	 * filtering<a/>.
+	 * 
+	 */
+	@Parameter(defaultValue = "true")
+	private boolean copyResources;
+
+	/**
+	 * A list of exclusion filters for non-java resource files which should not be
+	 * copied to the output directory.
+	 */
+	@Parameter
+	private Set<String> excludeResources = new HashSet<>();
+
+	/*
+	 * mimics the behavior of the compile task which by default copies all
+	 * (non-java) resource files in source directories into the target folder
+	 */
+	protected void doCopyResources(Project project) throws Exception {
+		if (!copyResources) {
+			return;
+		}
+		Collection<File> compileSourceRoots = getSourcePath(project);
+		for (File sourceRootFile : compileSourceRoots) {
+			if (!sourceRootFile.isDirectory()) {
+				getLog().warn("Source directory " + sourceRootFile + " does not exist");
+				continue;
+			}
+
+			Set<String> excludes = new HashSet<>();
+			excludes.addAll(excludeResources);
+			excludes.add("**/*.java");
+			// keep ignoring the following files after
+			// https://github.com/codehaus-plexus/plexus-utils/pull/174
+			excludes.add("**/.gitignore");
+			excludes.add("**/.gitattributes");
+			StaleSourceScanner scanner = new StaleSourceScanner(0L, MATCH_ALL, excludes);
+			CopyMapping copyMapping = new CopyMapping();
+			scanner.addSourceMapping(copyMapping);
+			try {
+				scanner.getIncludedSources(sourceRootFile, getOutput(project));
+				for (CopyMapping.SourceTargetPair sourceTargetPair : copyMapping.getSourceTargetPairs()) {
+					FileUtils.copyFile(new File(sourceRootFile, sourceTargetPair.source), sourceTargetPair.target);
+				}
+			} catch (InclusionScanException e) {
+				throw new MojoExecutionException("Exception while scanning for resource files in " + sourceRootFile, e);
+			} catch (IOException e) {
+				throw new MojoExecutionException(
+						"Exception copying resource files from " + sourceRootFile + " to " + getOutput(project), e);
+			}
+		}
+	}
+
+	protected abstract Collection<File> getSourcePath(Project project) throws Exception;
+
+	protected abstract File getOutput(Project project) throws Exception;
+}

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndCompileMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndCompileMojo.java
@@ -12,18 +12,34 @@
  *******************************************************************************/
 package org.eclipse.tycho.bnd.mojos;
 
+import java.io.File;
+import java.util.Collection;
+
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import aQute.bnd.build.Project;
 
+/**
+ * Compile main project sources
+ */
 @Mojo(name = "compile", defaultPhase = LifecyclePhase.COMPILE, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
-public class BndCompileMojo extends AbstractBndProjectMojo {
+public class BndCompileMojo extends AbstractBndCompileMojo {
 
 	@Override
 	protected void execute(Project project) throws Exception {
 		project.compile(false);
+		doCopyResources(project);
 	}
 
+	@Override
+	protected Collection<File> getSourcePath(Project project) throws Exception {
+		return project.getSourcePath();
+	}
+
+	@Override
+	protected File getOutput(Project project) throws Exception {
+		return project.getOutput();
+	}
 }

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndTestCompileMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/BndTestCompileMojo.java
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.bnd.mojos;
 
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -19,8 +23,11 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import aQute.bnd.build.Project;
 
+/**
+ * Compile test sources
+ */
 @Mojo(name = "test-compile", defaultPhase = LifecyclePhase.TEST_COMPILE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
-public class BndTestCompileMojo extends AbstractBndProjectMojo {
+public class BndTestCompileMojo extends AbstractBndCompileMojo {
 
 	/**
 	 * Set this to <code>true</code> to bypass compilation of test sources. Its use
@@ -35,6 +42,16 @@ public class BndTestCompileMojo extends AbstractBndProjectMojo {
 			return;
 		}
 		project.compile(true);
+	}
+
+	@Override
+	protected Collection<File> getSourcePath(Project project) throws Exception {
+		return List.of(project.getTestSrc());
+	}
+
+	@Override
+	protected File getOutput(Project project) throws Exception {
+		return project.getTestOutput();
 	}
 
 }


### PR DESCRIPTION
Eclipse Builds relies on the behavior of copy any resource in a source path that is not a java file to the output directory during compilation, but currently we do not perform this step in the bnd-builds.

Maven on the other hand has the concept of a resources directory that is copied (and probably filtered), so source files and resources are clearly separated.

To support both cases well, we now do for the bnd-build mojos similar to what we already do for the classic tycho mojos by perform an explicit copy that can be disabled if desired.

This is also the last issue I'm facing [with the OSGi build](https://github.com/osgi/osgi/pull/806), after this change the full project tree can be compiled without any problems.

FYI @chrisrueger 