### PR TITLE
Improve output for Target Platform File Cache Key

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/DefaultProvisioningAgent.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/DefaultProvisioningAgent.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
@@ -125,6 +126,15 @@ public class DefaultProvisioningAgent implements IProvisioningAgent {
 	@Override
 	public String getProperty(String key) {
 		return propertyHelper.getGlobalProperty(key);
+	}
+
+	@Override
+	public String toString() {
+		ClassLoader cl = getClass().getClassLoader();
+		if (cl instanceof ClassRealm realm) {
+			return "Tycho Provisioning Agent (" + realm.getId() + ")";
+		}
+		return "Tycho Provisioning Agent (" + System.identityHashCode(this) + ")";
 	}
 
 	private static final class LazyAgentServiceFactory implements Supplier<Object> {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverService.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverService.java
@@ -189,8 +189,7 @@ public class TargetDefinitionResolverService {
         public String toString() {
             return "target definition " + definition.getOrigin() + " for environments=" + environments
                     + ", include source mode=" + includeSourceMode + ", referenced repository mode ="
-                    + referencedRepositoryMode + ", execution environment=" + jreIUs + ", remote p2 repository options="
-                    + agent;
+                    + referencedRepositoryMode + ", execution environment=" + jreIUs + " with " + agent;
         }
 
     }


### PR DESCRIPTION
Currently a targetplatform cache key is printing something like

> remote p2 repository options = org.eclipse.tycho.p2maven.DefaultProvisioningAgent@5b854587

this is hardly understandable and only useful to see that something is different but not what agent is actually used.

This now changes to use the realm name instead and looks like this:

> with Tycho Provisioning Agent (extension>org.eclipse.tycho:tycho-maven-plugin:5.0.0-SNAPSHOT)

what is much more helpful in case of debugging.