### PR TITLE
Use a fixed release for the test-case to make it stable

### DIFF
--- a/tycho-its/projects/target.maven.autofeature/test.target
+++ b/tycho-its/projects/target.maven.autofeature/test.target
@@ -3,7 +3,7 @@
 <target includeMode="feature" name="issue-242">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/releases/latest"/>
+			<repository location="http://download.eclipse.org/releases/2024-12"/>
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 		</location>
 		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" missingManifest="generate" type="Maven">


### PR DESCRIPTION
Currently the testacase uses "latest" URL that makes it possibly unstable as we have no control over when/what this points to.

This fixes the repository to use that latest working release for that test-case.

This is currently the reason while since GA now Tycho test started failing.