### PR TITLE
Handle version range in dependencies for target locations

### DIFF
--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -41,6 +41,24 @@ import org.osgi.framework.VersionRange;
 public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 
     @Test
+    public void testVersionRanges() throws Exception {
+        ITargetLocation target = resolveMavenTarget(
+                """
+                        <location includeDependencyDepth="infinite" includeDependencyScopes="compile,provided,runtime" includeSource="true" label="cucumber" missingManifest="generate" type="Maven">
+                            <dependencies>
+                                <dependency>
+                                    <groupId>io.cucumber</groupId>
+                                    <artifactId>cucumber-java</artifactId>
+                                    <version>7.21.1</version>
+                                    <type>jar</type>
+                                </dependency>
+                            </dependencies>
+                        </location>
+                                """);
+        assertStatusOk(getTargetStatus(target));
+    }
+
+    @Test
     public void testBadDependencyInChain() throws Exception {
         ITargetLocation target = resolveMavenTarget("""
                 <location includeDependencyScope="compile" missingManifest="generate" type="Maven">


### PR DESCRIPTION
Currently if a dependency uses a version range this fails to resolve the target as maven-resolver tries to use the version "as-is"

THis now adds a testcase and a fix to resolve to the highest possible version in such case.