### PR TITLE
[bp] Add support for using conditional packages directive.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,10 @@ def deployBranch = 'tycho-4.0.x'
 def agentLabel
 if(env.BRANCH_NAME == deployBranch) {
 	//branches that are deployable must run on eclipse infra
-	agentLabel = "centos-latest"
+	agentLabel = "ubuntu-latest"
 } else {
 	//others (prs for example) can run on any infra
-	agentLabel = "centos-latest || linux"
+	agentLabel = "ubuntu-latest || linux"
 }
 
 pipeline {
@@ -20,6 +20,9 @@ pipeline {
 	tools {
 		maven 'apache-maven-3.9.1'
 		jdk 'openjdk-jdk17-latest'
+	}
+	environment {
+		MAVEN_OPTS = '-Xmx2500m -XX:+PrintFlagsFinal'
 	}
 	stages {
 		stage('Build') {
@@ -37,7 +40,7 @@ pipeline {
 				branch deployBranch
 			}
 			steps {
-				sh 'mvn --batch-mode -V deploy -DskipTests -DaltDeploymentRepository=repo.eclipse.org::https://repo.eclipse.org/content/repositories/tycho-snapshots/'
+				sh 'mvn --batch-mode -V -ntp deploy -DskipTests -DaltDeploymentRepository=repo.eclipse.org::https://repo.eclipse.org/content/repositories/tycho-snapshots/'
 			}
 		}
 	}

--- a/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -59,8 +59,9 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.m2e.pde.target.shared.ProcessingMessage.Type;
 import org.osgi.framework.Constants;
 
-import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
 import aQute.bnd.version.Version;
 
 /**
@@ -78,7 +79,7 @@ import aQute.bnd.version.Version;
  */
 public class MavenBundleWrapper {
 
-    public static final String ECLIPSE_SOURCE_BUNDLE_HEADER = "Eclipse-SourceBundle";
+    private static final String ECLIPSE_SOURCE_BUNDLE_HEADER = "Eclipse-SourceBundle";
 
     private MavenBundleWrapper() {
     }
@@ -203,7 +204,8 @@ public class MavenBundleWrapper {
                 List<ProcessingMessage> messages = new ArrayList<>();
                 wrapArtifactFile.getParentFile().mkdirs();
                 boolean hasErrors = false;
-                try (Analyzer analyzer = new Analyzer(analyzerJar);) {
+                try (Builder analyzer = new Builder(new Processor());) {
+                    analyzer.setJar(analyzerJar);
                     analyzer.setProperty("mvnGroupId", artifact.getGroupId());
                     analyzer.setProperty("mvnArtifactId", artifact.getArtifactId());
                     analyzer.setProperty("mvnVersion", artifact.getBaseVersion());


### PR DESCRIPTION
bndtools has a feature named "conditional package"[1] that allows to slurp-in certain code into the final jar for example to prevent having a dependency on a full module when maybe only a single class is used,

Currently when using maven targets this can not be used because it is a feature only supported in the builder, this now adds support for using this as well as a test-case to demonstrate it.

[1] https://bnd.bndtools.org/instructions/conditionalpackage.html