### PR TITLE
EclipseProject meta model: Support custom variables in linked resources

### DIFF
--- a/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/project/ProjectParser.java
+++ b/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/project/ProjectParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Christoph Läubrich and others.
+ * Copyright (c) 2023, 2025 Christoph Läubrich and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *    Christoph Läubrich - initial API and implementation
+ *    SAP SE - support custom variables
  *******************************************************************************/
 package org.eclipse.tycho.model.project;
 
@@ -21,10 +22,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -42,6 +41,8 @@ import org.xml.sax.SAXException;
 
 class ProjectParser {
 
+    private static final String PROJECT_LOC = "PROJECT_LOC";
+    private static final Pattern DOLLAR_VARIABLE_PATTERN = Pattern.compile("\\$\\{([^\\$]+)\\}");
     private static final Pattern PARENT_PROJECT_PATTERN = Pattern.compile("PARENT-(\\d+)-PROJECT_LOC");
 
     public static EclipseProject parse(Path path) throws IOException {
@@ -75,10 +76,12 @@ class ProjectParser {
             List<ProjectVariable> variables = IntStream.range(0, variableNodes.getLength())
                     .mapToObj(i -> variableNodes.item(i)).map(Element.class::cast).map(e -> parseVariable(e))
                     .filter(Objects::nonNull).toList();
+            Map<String, URI> variablesMap = variables.stream()
+                    .collect(Collectors.toMap(ProjectVariable::name, ProjectVariable::value));
             NodeList linkNodes = root.getElementsByTagName("link");
-            Map<Path, LinkDescription> links = IntStream.range(0, linkNodes.getLength())
-                    .mapToObj(i -> linkNodes.item(i)).map(Element.class::cast).map(e -> parseLink(e))
-                    .filter(Objects::nonNull).collect(Collectors.toMap(LinkDescription::name, Function.identity()));
+            Set<LinkDescription> links = IntStream.range(0, linkNodes.getLength()).mapToObj(i -> linkNodes.item(i))
+                    .map(Element.class::cast).map(e -> parseLink(e)).filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
 
             return new EclipseProject() {
 
@@ -136,23 +139,9 @@ class ProjectParser {
                         return path;
                     }
                     Path relative = location.relativize(path);
-                    for (Entry<Path, LinkDescription> entry : links.entrySet()) {
-                        Path linkPath = entry.getKey();
-                        if (relative.startsWith(linkPath)) {
-                            LinkDescription link = entry.getValue();
-                            if (link.type() == LinkDescription.FILE) {
-                                //the path must actually match each others as it is a file!
-                                if (linkPath.startsWith(relative)) {
-                                    Path resolvedPath = resolvePath(link.locationURI(), this);
-                                    return location.resolve(resolvedPath).normalize();
-                                }
-                            } else if (link.type() == LinkDescription.FOLDER) {
-                                Path linkRelative = linkPath.relativize(relative);
-                                Path resolvedPath = resolvePath(link.locationURI(), this);
-                                if (resolvedPath != null) {
-                                    return location.resolve(resolvedPath).resolve(linkRelative).normalize();
-                                }
-                            }
+                    for (LinkDescription link : links) {
+                        if (relative.startsWith(link.name())) {
+                            return resolvePath(link, relative, location, variablesMap);
                         }
                     }
                     return path;
@@ -173,34 +162,144 @@ class ProjectParser {
         }
     }
 
-    private static Path resolvePath(URI uri, EclipseProject project) {
-        String schemeSpecificPart = uri.getSchemeSpecificPart();
-        if (schemeSpecificPart != null) {
-            Path path = Path.of(schemeSpecificPart);
-            int count = path.getNameCount();
-            if (count > 0) {
-                //only the first path is allowed to be a variable...
-                Path first = path.getName(0);
-                String name = first.toString();
-                if ("PROJECT_LOC".equals(name)) {
-                    return appendRemaining(path, count, project.getLocation());
-                }
-                Matcher parentMatcher = PARENT_PROJECT_PATTERN.matcher(name);
-                if (parentMatcher.matches()) {
-                    Path resolvedPath = Path.of("..");
-                    int p = Integer.parseInt(parentMatcher.group(1));
-                    for (int i = 1; i < p; i++) {
-                        resolvedPath = resolvedPath.resolve("..");
-                    }
-                    return appendRemaining(path, count, resolvedPath);
-                }
-                return path;
-            }
+    private static Path uriToPath(URI uri) {
+        if (uri.getScheme() == null || "file".equals(uri.getScheme())) {
+            return Path.of(uri.getSchemeSpecificPart());
         }
         return null;
     }
 
-    private static Path appendRemaining(Path path, int count, Path resolvedPath) {
+    static Path resolvePath(LinkDescription link, Path path, Path projectLocation, Map<String, URI> variablesMap) {
+        Path linkPath;
+        if (link.location() != null) {
+            linkPath = link.location();
+        } else if (link.locationURI() != null) {
+            URI uri = link.locationURI();
+            if (uri == null) {
+                return null;
+            }
+            String schemeSpecificPart = uri.getSchemeSpecificPart();
+            if (schemeSpecificPart == null) {
+                return null;
+            }
+            linkPath = Path.of(schemeSpecificPart);
+            int count = linkPath.getNameCount();
+            if (count == 0) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+        if (link.type() == LinkDescription.FILE) {
+            //the path must actually match each others as it is a file!
+            if (path.getNameCount() > 1) {
+                return null;
+            }
+        }
+
+        Path result = resolveVariables(linkPath, projectLocation, variablesMap);
+        if (result == null) {
+            return null;
+        }
+        result = projectLocation.resolve(result);
+        result = appendRemaining(path, result);
+        result = result.normalize();
+
+        return result;
+    }
+
+    private static Path resolveVariables(Path path, Path projectLocation, Map<String, URI> variablesMap) {
+        //only the first path is allowed to be a variable...
+        Path first = path.getName(0);
+        String name = first.toString();
+
+        // Expand user-defined variables
+        // https://github.com/eclipse-tycho/tycho/issues/3820
+        // Note: Eclipse supports many more user-defined variables and even nesting
+        // This is a best-effort implementation to support the straight-forward case:
+        // If the first segment matches one of the user-defined variables, e.g.
+        // {
+        //   "FOO": "${BAR}/foo",
+        //   "BAR": "${BAZ}/bar",
+        //   "BAZ": "${PROJECT-2-PARENT_LOC}/baz"
+        // }
+        // we expand it recursively:
+        // FOO/dir -> ${BAR}/foo/dir -> ${BAZ}/bar/foo/dir -> ${PROJECT-2-PARENT_LOC}/baz/bar/foo/dir
+        // When we find known placeholders, we continue with that logic:
+        // ${PROJECT-2-PARENT_LOC}/baz/bar/foo/dir -> ../../baz/bar/foo/dir
+        URI variableUri = variablesMap.get(name);
+        if (variableUri != null) {
+            Path variablePath = uriToPath(variableUri);
+            if (variablePath == null) {
+                return null;
+            }
+
+            Path[] resolvedPath = new Path[] { variablePath };
+            Set<String> seenVariables = new HashSet<>(Set.of(name));
+            while (resolveDollarVariable(resolvedPath, projectLocation, seenVariables, variablesMap)) {
+            }
+            if (resolvedPath[0] == null) {
+                return null;
+            }
+            return appendRemaining(path, resolvedPath[0]);
+        }
+
+        if (PROJECT_LOC.equals(name)) {
+            return appendRemaining(path, projectLocation);
+        }
+        Matcher parentMatcher = PARENT_PROJECT_PATTERN.matcher(name);
+        if (parentMatcher.matches()) {
+            return appendRemaining(path, dotDotTimes(Integer.parseInt(parentMatcher.group(1))));
+        }
+
+        return path;
+    }
+
+    private static boolean resolveDollarVariable(Path[] resolvedPath, Path projectLocation, Set<String> seenVariables,
+            Map<String, URI> variablesMap) {
+
+        Matcher dollarVariableMatcher = DOLLAR_VARIABLE_PATTERN.matcher(resolvedPath[0].getName(0).toString());
+        if (!dollarVariableMatcher.matches()) {
+            return false;
+        }
+        String expanded = dollarVariableMatcher.group(1);
+        if (PROJECT_LOC.equals(expanded)) {
+            resolvedPath[0] = appendRemaining(resolvedPath[0], projectLocation);
+            return false;
+        }
+        Matcher parentMatcher = PARENT_PROJECT_PATTERN.matcher(expanded);
+        if (parentMatcher.matches()) {
+            resolvedPath[0] = appendRemaining(resolvedPath[0], dotDotTimes(Integer.parseInt(parentMatcher.group(1))));
+            return false;
+        }
+        URI variableUri = variablesMap.get(expanded);
+        if (variableUri == null) {
+            // give up and leave path unexpanded
+            return false;
+        }
+        Path variablePath = uriToPath(variableUri);
+        if (variablePath == null) {
+            resolvedPath[0] = null;
+            return false;
+        }
+        if (!seenVariables.add(expanded)) {
+            resolvedPath[0] = null; // recursion -> invalid
+            return false;
+        }
+        resolvedPath[0] = appendRemaining(resolvedPath[0], variablePath);
+        return true;
+    }
+
+    private static Path dotDotTimes(int count) {
+        Path path = Path.of("..");
+        for (int i = 1; i < count; i++) {
+            path = path.resolve("..");
+        }
+        return path;
+    }
+
+    private static Path appendRemaining(Path path, Path resolvedPath) {
+        int count = path.getNameCount();
         for (int i = 1; i < count; i++) {
             resolvedPath = resolvedPath.resolve(path.getName(i));
         }
@@ -211,7 +310,7 @@ class ProjectParser {
         try {
             String name = element.getElementsByTagName("name").item(0).getTextContent();
             String value = element.getElementsByTagName("value").item(0).getTextContent();
-            return new ProjectVariable(name, value);
+            return new ProjectVariable(name, URI.create(value));
         } catch (RuntimeException e) {
             //something is wrong here...
             return null;
@@ -222,15 +321,18 @@ class ProjectParser {
         try {
             String name = element.getElementsByTagName("name").item(0).getTextContent();
             String type = element.getElementsByTagName("type").item(0).getTextContent();
-            String locationURI = element.getElementsByTagName("locationURI").item(0).getTextContent();
-            return new LinkDescription(Path.of(name), Integer.parseInt(type), URI.create(locationURI));
+            Node locationNode = element.getElementsByTagName("location").item(0);
+            Node locationUriNode = element.getElementsByTagName("locationURI").item(0);
+            Path location = locationNode == null ? null : Path.of(locationNode.getTextContent());
+            URI locationURI = locationUriNode == null ? null : URI.create(locationUriNode.getTextContent());
+            return new LinkDescription(Path.of(name), Integer.parseInt(type), location, locationURI);
         } catch (RuntimeException e) {
             //something is wrong here...
             return null;
         }
     }
 
-    static final record LinkDescription(Path name, int type, URI locationURI) {
+    static final record LinkDescription(Path name, int type, Path location, URI locationURI) {
         /**
          * Type constant (bit mask value 1) which identifies file resources.
          */

--- a/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/project/ProjectVariable.java
+++ b/tycho-metadata-model/src/main/java/org/eclipse/tycho/model/project/ProjectVariable.java
@@ -1,5 +1,7 @@
 package org.eclipse.tycho.model.project;
 
-public record ProjectVariable(String name, String value) {
+import java.net.URI;
+
+public record ProjectVariable(String name, URI value) {
 
 }

--- a/tycho-metadata-model/src/test/java/org/eclipse/tycho/model/project/ProjectParserTest.java
+++ b/tycho-metadata-model/src/test/java/org/eclipse/tycho/model/project/ProjectParserTest.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2025 SAP SE and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.model.project;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.eclipse.tycho.model.project.ProjectParser.LinkDescription;
+import org.junit.jupiter.api.Test;
+
+public class ProjectParserTest {
+
+    private static final Path PROJECT_PATH = Path.of("/path/to/project");
+
+    private static final Map<String, URI> VARS = Map.of( //
+            "FOO1", URI.create("$%7BBAR1%7D/foo"), //
+            "BAR1", URI.create("$%7BBAZ1%7D/bar"), //
+            "BAZ1", URI.create("$%7BPROJECT_LOC%7D/other/dir"), //
+
+            "FOO2", URI.create("$%7BBAR2%7D/foo"), //
+            "BAR2", URI.create("$%7BBAZ2%7D/bar"), //
+            "BAZ2", URI.create("$%7BPARENT-1-PROJECT_LOC%7D/otherproject/dir"), //
+
+            "RECURSION1", URI.create("$%7BRECURSION2%7D/foo"), //
+            "RECURSION2", URI.create("$%7BRECURSION1%7D/foo"), //
+
+            "LITERAL", URI.create("value"), //
+
+            "UNKNOWN", URI.create("$%7BDONTKNOW%7D/foo") //
+    );
+
+    @Test
+    void testLinkNoLocationOrUri() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null, null);
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertNull(result);
+    }
+
+    @Test
+    void testLinkDirSimpleCase() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null,
+                URI.create("foo/bar"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/project/foo/bar/subdir"), result);
+    }
+
+    @Test
+    void testLinkDirProjectLoc() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null,
+                URI.create("PROJECT_LOC/bar"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/project/bar/subdir"), result);
+    }
+
+    @Test
+    void testLinkDirParent1ProjectLoc() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null,
+                URI.create("PARENT-1-PROJECT_LOC/otherproject"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/otherproject/subdir"), result);
+    }
+
+    @Test
+    void testLinkDirParent2ProjectLoc() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null,
+                URI.create("PARENT-2-PROJECT_LOC/anotherdir"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/anotherdir/subdir"), result);
+    }
+
+    @Test
+    void testLinkDirVarExpandEndingInProjectLoc() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null, URI.create("FOO1/x"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/project/other/dir/bar/foo/x/subdir"), result);
+    }
+
+    @Test
+    void testLinkDirVarExpandEndingInParent1ProjectLoc() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null, URI.create("FOO2/x"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/otherproject/dir/bar/foo/x/subdir"), result);
+    }
+
+    @Test
+    void testLinkDirRecursion() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null,
+                URI.create("RECURSION1/x"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertNull(result);
+    }
+
+    @Test
+    void testLinkDirVarExpandLiteral() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null,
+                URI.create("LITERAL/x"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/project/value/x/subdir"), result);
+    }
+
+    @Test
+    void testLinkDirVarExpandFailingKeepDollarVariable() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, null,
+                URI.create("UNKNOWN/x"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/project/${DONTKNOW}/foo/x/subdir"), result);
+    }
+
+    @Test
+    void testLinkDirAbsolutePathInsteadOfUri() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link"), LinkDescription.FOLDER, Path.of("/absolute/path"),
+                null);
+        Path result = ProjectParser.resolvePath(link, Path.of("link/subdir"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/absolute/path/subdir"), result);
+    }
+
+    @Test
+    void testLinkFileSimpleCase() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link.txt"), LinkDescription.FILE, null,
+                URI.create("linktarget.txt"));
+        Path result = ProjectParser.resolvePath(link, Path.of("link.txt"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/project/linktarget.txt"), result);
+    }
+
+    @Test
+    void testLinkFileAbsolutePathInsteadOfUri() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link.txt"), LinkDescription.FILE,
+                Path.of("/path/to/some/txtfile.txt"), null);
+        Path result = ProjectParser.resolvePath(link, Path.of("link.txt"), PROJECT_PATH, VARS);
+        assertEquals(Path.of("/path/to/some/txtfile.txt"), result);
+    }
+
+    @Test
+    void testLinkFileIllegalSegmentAfterFile() throws Exception {
+        LinkDescription link = new LinkDescription(Path.of("link.txt"), LinkDescription.FILE,
+                Path.of("/path/to/some/txtfile.txt"), null);
+        Path result = ProjectParser.resolvePath(link, Path.of("link.txt/thisisinvalid"), PROJECT_PATH, VARS);
+        assertNull(result);
+    }
+
+}


### PR DESCRIPTION
* Support resolving of custom variables.

* Refactor code.

* Handle certain (invalid) edge cases.

* `<link>` elements may either contain a `<locationUri>` with variable expansion or a literal `<location>` with an absolute path. Also add support for the latter.

* Add unit tests.

Resolves #3820.