### PR TITLE
Fix case where a non jar dependency is in the chain for wrapping

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/ProcessingMessage.java
+++ b/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/ProcessingMessage.java
@@ -19,8 +19,8 @@ import org.eclipse.aether.artifact.Artifact;
  */
 public record ProcessingMessage(Artifact artifact, Type type, String message) {
 
-	public enum Type {
-		ERROR, WARN 
-	}
+    public enum Type {
+        ERROR, WARN, INFO
+    }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -45,6 +45,24 @@ import aQute.bnd.osgi.Jar;
 public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 
     @Test
+    public void testNonJarArtifactInDependencies() throws Exception {
+        ITargetLocation target = resolveMavenTarget(
+                """
+                            <location includeDependencyDepth="infinite" includeDependencyScopes="compile,provided,runtime" includeSource="true" label="Azure OpenAI" missingManifest="generate" type="Maven">
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>com.azure</groupId>
+                                        <artifactId>azure-ai-openai</artifactId>
+                                        <version>1.0.0-beta.13</version>
+                                        <type>jar</type>
+                                    </dependency>
+                                </dependencies>
+                            </location>
+                        """);
+        assertStatusOk(getTargetStatus(target));
+    }
+
+    @Test
     public void testVersionRanges() throws Exception {
         ITargetLocation target = resolveMavenTarget(
                 """


### PR DESCRIPTION
Currently when there is a non jar in the dependency chain it fails to resolve the target because it can not read as a jar.

Needs to be backported to m2e as well!