### PR TITLE
Use (explicit) Java target level 8 for testcase to support Java 21

### DIFF
--- a/tycho-its/projects/TYCHO309pomDependencyConsider/artifact/pom.xml
+++ b/tycho-its/projects/TYCHO309pomDependencyConsider/artifact/pom.xml
@@ -4,7 +4,10 @@
 	<groupId>TYCHO309pomDependencyConsider</groupId>
 	<artifactId>artifact</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-
+	<properties>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/tycho-its/projects/TYCHO418pomDependencyConsider/artifact/pom.xml
+++ b/tycho-its/projects/TYCHO418pomDependencyConsider/artifact/pom.xml
@@ -4,7 +4,10 @@
 	<groupId>TYCHO418pomDependencyConsider</groupId>
 	<artifactId>artifact</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-
+	<properties>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
Java 21 will no longer support default 1.7 level used in the tests.

See 
- https://github.com/eclipse-tycho/tycho/pull/4955