### PR TITLE
Add artifact to feature dependendencies

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/actions/AbstractDependenciesAction.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/actions/AbstractDependenciesAction.java
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IProvidedCapability;
 import org.eclipse.equinox.p2.metadata.IRequirement;
@@ -77,6 +78,7 @@ public abstract class AbstractDependenciesAction extends AbstractPublisherAction
         InstallableUnitDescription iud = new MetadataFactory.InstallableUnitDescription();
         iud.setId(getId());
         iud.setVersion(getVersion());
+        iud.setArtifacts(getArtifacts());
 
         Set<IProvidedCapability> provided = new LinkedHashSet<>();
         addProvidedCapabilities(provided);
@@ -106,6 +108,10 @@ public abstract class AbstractDependenciesAction extends AbstractPublisherAction
         }
 
         return Status.OK_STATUS;
+    }
+
+    protected IArtifactKey[] getArtifacts() {
+        return new IArtifactKey[0];
     }
 
     protected void addPublisherAdvice(IPublisherInfo publisherInfo) {

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/actions/FeatureDependenciesAction.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/actions/FeatureDependenciesAction.java
@@ -20,6 +20,7 @@ import java.util.StringTokenizer;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IProvidedCapability;
 import org.eclipse.equinox.p2.metadata.IRequirement;
@@ -32,6 +33,7 @@ import org.eclipse.equinox.p2.publisher.AdviceFileAdvice;
 import org.eclipse.equinox.p2.publisher.IPublisherInfo;
 import org.eclipse.equinox.p2.publisher.eclipse.Feature;
 import org.eclipse.equinox.p2.publisher.eclipse.FeatureEntry;
+import org.eclipse.equinox.p2.publisher.eclipse.FeaturesAction;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
 
@@ -134,6 +136,11 @@ public class FeatureDependenciesAction extends AbstractDependenciesAction {
     @Override
     protected String getId() {
         return feature.getId() + FEATURE_GROUP_IU_SUFFIX;
+    }
+
+    @Override
+    protected IArtifactKey[] getArtifacts() {
+        return new IArtifactKey[] { FeaturesAction.createFeatureArtifactKey(feature.getId(), getVersion().toString()) };
     }
 
     @Override


### PR DESCRIPTION
Fixes issue resolving version for included features that are pom dependencies and not included in the current reactor.

## Issue description
In `tycho-packaging-plugin` when not using the default timestamp provider `BuildQualifierAggregatorMojo` creates a dependency walker to resolve the build qualifier of all dependencies. 

When visiting a feature with an included feature that is a maven dependency, declared in the pom.xml file, but but present in the current reactor, `AbstractArtifactDependencyWalker#traverseFeature` cannot find the included artifact.

This is caused by `P2ResolverImpl#addUnit` not adding the artifact due to no artifact being linked to the `InstallableUnit`.

The included bundles are working without any issues.

## Solution
Comparing the execution of `FeatureDependencyAction` and `BundleAction` I found that `BundleAction` is setting the artifacts explicitly during the IU creation.

Applying this strategy to `FeatureDependencyAction` solved the issue.