### PR TITLE
Fix dependency is ignored when previously found with other scope

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/MavenDependencyCollector.java
+++ b/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/MavenDependencyCollector.java
@@ -112,7 +112,7 @@ public class MavenDependencyCollector {
         while (!queue.isEmpty()) {
             ArtifactDescriptor current = queue.poll();
             for (Dependency dependency : current.dependencies()) {
-                if (isValidDependency(dependency)) {
+                if (isValidDependency(dependency) && isValidScope(dependency)) {
                     if (isVersionRanged(dependency)) {
                         ArtifactDescriptor dependencyDescriptor = resolveHighestVersion(dependency, current.node(),
                                 artifacts, nodes);
@@ -120,8 +120,7 @@ public class MavenDependencyCollector {
                                 && collected.add(getId(dependencyDescriptor.node().getDependency()))) {
                             queue.add(dependencyDescriptor);
                         }
-                    }
-                    if (collected.add(getId(dependency))) {
+                    } else if (collected.add(getId(dependency))) {
                         ArtifactDescriptor dependencyDescriptor = readArtifactDescriptor(dependency, current.node(),
                                 artifacts, nodes);
                         if (dependencyDescriptor != null) {

--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/AbstractMavenTargetTest.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/AbstractMavenTargetTest.java
@@ -126,6 +126,9 @@ public abstract class AbstractMavenTargetTest {
         if (key == null) {
             return false;
         }
+        if (key.groupId().equals("-")) {
+            return true;
+        }
         URI location = getLocation.apply(unit);
         String expectedPathSuffix = "/" + String.join("/", ".m2", "repository", key.groupId().replace('.', '/'),
                 key.artifactId(), key.version(), key.artifactId() + "-" + key.version() + ".jar");
@@ -146,6 +149,10 @@ public abstract class AbstractMavenTargetTest {
     static ExpectedBundle generatedBundle(String bsn, String version, String groupArtifact) {
         return new ExpectedBundle(bsn, version, false, false,
                 ArtifactKey.fromPortableString(groupArtifact + ":" + version + "::"));
+    }
+
+    static ExpectedBundle bundle(String bsn, String version) {
+        return new ExpectedBundle(bsn, version, false, true, new ArtifactKey("-", bsn, version, ""));
     }
 
     static List<ExpectedBundle> withSourceBundles(List<ExpectedBundle> mainBundles) {

--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/MavenContentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/MavenContentTest.java
@@ -21,30 +21,71 @@ import org.junit.Test;
  * Tests that the content of a location matches the expectation
  */
 public class MavenContentTest extends AbstractMavenTargetTest {
-	@Test
-	public void testIncludeProvidedInfinite() throws Exception {
-		ITargetLocation target = resolveMavenTarget(
-				"""
-						<location includeDependencyDepth="infinite" includeDependencyScopes="provided" includeSource="false" missingManifest="ignore" type="Maven">
-							<dependencies>
-								<dependency>
-									<groupId>org.osgi</groupId>
-									<artifactId>org.osgi.test.common</artifactId>
-									<version>1.3.0</version>
-									<type>jar</type>
-								</dependency>
-							</dependencies>
-						</location>
-						""");
-		assertStatusOk(getTargetStatus(target));
-		List<ExpectedBundle> expectedBundles = List.of( //
-				originalOSGiBundle("osgi.annotation", "8.1.0.202202082230", "org.osgi:osgi.annotation", "8.1.0"),
-				originalOSGiBundle("org.osgi.util.tracker", "1.5.4.202109301733", "org.osgi:org.osgi.util.tracker",
-						"1.5.4"),
-				originalOSGiBundle("org.osgi.test.common", "1.3.0", "org.osgi:org.osgi.test.common"),
-				originalOSGiBundle("org.osgi.dto", "1.0.0.201505202023", "org.osgi:org.osgi.dto", "1.0.0"),
-				originalOSGiBundle("org.osgi.framework", "1.8.0.201505202023", "org.osgi:org.osgi.framework", "1.8.0"),
-				originalOSGiBundle("org.osgi.resource", "1.0.0.201505202023", "org.osgi:org.osgi.resource", "1.0.0"));
-		assertTargetBundles(target, expectedBundles);
-	}
+    @Test
+    public void testIncludeProvidedInfinite() throws Exception {
+        ITargetLocation target = resolveMavenTarget(
+                """
+                        <location includeDependencyDepth="infinite" includeDependencyScopes="provided" includeSource="false" missingManifest="ignore" type="Maven">
+                        	<dependencies>
+                        		<dependency>
+                        			<groupId>org.osgi</groupId>
+                        			<artifactId>org.osgi.test.common</artifactId>
+                        			<version>1.3.0</version>
+                        			<type>jar</type>
+                        		</dependency>
+                        	</dependencies>
+                        </location>
+                        """);
+        assertStatusOk(getTargetStatus(target));
+        List<ExpectedBundle> expectedBundles = List.of( //
+                originalOSGiBundle("osgi.annotation", "8.1.0.202202082230", "org.osgi:osgi.annotation", "8.1.0"),
+                originalOSGiBundle("org.osgi.util.tracker", "1.5.4.202109301733", "org.osgi:org.osgi.util.tracker",
+                        "1.5.4"),
+                originalOSGiBundle("org.osgi.test.common", "1.3.0", "org.osgi:org.osgi.test.common"),
+                originalOSGiBundle("org.osgi.dto", "1.0.0.201505202023", "org.osgi:org.osgi.dto", "1.0.0"),
+                originalOSGiBundle("org.osgi.framework", "1.8.0.201505202023", "org.osgi:org.osgi.framework", "1.8.0"),
+                originalOSGiBundle("org.osgi.resource", "1.0.0.201505202023", "org.osgi:org.osgi.resource", "1.0.0"));
+        assertTargetBundles(target, expectedBundles);
+    }
+
+    @Test
+    public void testJettyWithInDependencies() throws Exception {
+        ITargetLocation target = resolveMavenTarget(
+                """
+                        <location includeDependencyDepth="infinite" includeDependencyScopes="compile,provided,runtime" includeSource="false" label="Jetty" missingManifest="error" type="Maven">
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+                                        <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
+                                        <version>12.0.9</version>
+                                        <type>jar</type>
+                                        </dependency>
+                                </dependencies>
+                            </location>
+                        """);
+        assertStatusOk(getTargetStatus(target));
+        List<ExpectedBundle> expectedBundles = List.of(bundle("org.eclipse.jetty.ee10.plus", "12.0.9"),
+                bundle("jakarta.enterprise.lang-model", "4.0.1"), bundle("jakarta.transaction-api", "2.0.1"),
+                bundle("org.eclipse.jetty.http", "12.0.9"), bundle("slf4j.api", "2.0.12"),
+                bundle("jakarta.servlet-api", "6.0.0"), bundle("org.eclipse.jetty.ee10.webapp", "12.0.9"),
+                bundle("org.eclipse.jetty.io", "12.0.9"), bundle("org.eclipse.jetty.util", "12.0.9"),
+                bundle("jakarta.websocket-api", "2.1.1"), bundle("org.eclipse.jetty.ee10.annotations", "12.0.9"),
+                bundle("jakarta.annotation-api", "2.1.1"), bundle("org.eclipse.jetty.websocket.core.common", "12.0.9"),
+                bundle("org.eclipse.jetty.jndi", "12.0.9"), bundle("org.eclipse.jetty.security", "12.0.9"),
+                bundle("jakarta.enterprise.cdi-api", "4.0.1"), bundle("jakarta.websocket-client-api", "2.1.1"),
+                bundle("org.eclipse.jetty.ee10.servlet", "12.0.9"),
+                bundle("org.eclipse.jetty.websocket.core.client", "12.0.9"), bundle("org.objectweb.asm.tree", "9.7"),
+                bundle("org.eclipse.jetty.ee10.websocket.jakarta.client", "12.0.9"),
+                bundle("org.eclipse.jetty.server", "12.0.9"), bundle("jakarta.el-api", "5.0.0"),
+                bundle("org.eclipse.jetty.ee10.websocket.jakarta.server", "12.0.9"),
+                bundle("org.eclipse.jetty.ee10.websocket.servlet", "12.0.9"),
+                bundle("org.eclipse.jetty.ee10.websocket.jakarta.common", "12.0.9"),
+                bundle("org.eclipse.jetty.websocket.core.server", "12.0.9"),
+                bundle("org.eclipse.jetty.client", "12.0.9"), bundle("org.eclipse.jetty.session", "12.0.9"),
+                bundle("org.eclipse.jetty.ee", "12.0.9"), bundle("org.eclipse.jetty.plus", "12.0.9"),
+                bundle("org.objectweb.asm.commons", "9.7"), bundle("jakarta.inject.jakarta.inject-api", "2.0.1"),
+                bundle("org.eclipse.jetty.alpn.client", "12.0.9"), bundle("org.objectweb.asm", "9.7"),
+                bundle("org.eclipse.jetty.xml", "12.0.9"), bundle("jakarta.interceptor-api", "2.1.0"));
+        assertTargetBundles(target, expectedBundles);
+    }
 }


### PR DESCRIPTION
Currently if a maven dependency is reachable to different chains of dependencies it can happen that the first visited one is from an excluded scope. In this case the maven-target marks the dependency as already processed but then ignore it. If it now appears later with a valid scope it is ignored because already processed.

This now changes the check so it first test if it is a valid scope before processing it any further.

Needs to be ported to m2e as well!