### PR TITLE
Use Java 21 EE as default

### DIFF
--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipserun/EclipseRunMojo.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipserun/EclipseRunMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Sonatype Inc. and others.
+ * Copyright (c) 2011, 2025 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -134,7 +134,7 @@ public class EclipseRunMojo extends AbstractMojo {
 	/**
 	 * Execution environment profile name used to resolve dependencies.
 	 */
-	@Parameter(defaultValue = "JavaSE-17")
+	@Parameter(defaultValue = "JavaSE-21")
 	private String executionEnvironment;
 
 	/**

--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateProductMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateProductMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2021 Sonatype Inc. and others.
+ * Copyright (c) 2010, 2025 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ public class UpdateProductMojo extends AbstractUpdateMojo {
     @Parameter(defaultValue = "${project.artifactId}.product")
     private File productFile;
 
-    @Parameter(defaultValue = "JavaSE-17")
+    @Parameter(defaultValue = "JavaSE-21")
     private String executionEnvironment;
 
     @Component


### PR DESCRIPTION
As Eclipse Platform 2025-03 requires it, default should be changed accordingly in order to keep working with it by default.