### PR TITLE
Bug: 2482 - Fixed performance issue with respect to classpath resolution

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/ArtifactCollection.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/ArtifactCollection.java
@@ -316,10 +316,10 @@ public class ArtifactCollection {
      *         default artifact)
      */
     public Map<String, ArtifactDescriptor> getArtifact(File location) {
-        artifacts.values().forEach(artifact -> artifact.getLocation(true));
         File normalized = normalizeLocation(location);
         Map<String, ArtifactDescriptor> map = artifactsWithKnownLocation.get(normalized);
         if (map == null) {
+            artifacts.values().forEach(artifact -> artifact.getLocation(true));
             LinkedHashMap<String, ArtifactDescriptor> hashMap = new LinkedHashMap<>();
             for (ArtifactDescriptor descriptor : artifacts.values()) {
                 ReactorProject mavenProject = descriptor.getMavenProject();


### PR DESCRIPTION
This PR relates to bug #2482 

Improves the efficiency of classpath lookups by fetching artifacts on demand (instead of always). In larger projects this bug could consume more than half of the entire build time.

With this fix applied, our largest project went from **55** to **25** minutes build time (without unit test execution).