### PR TITLE
Improve performance by only ask for locations once

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/ArtifactCollection.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/ArtifactCollection.java
@@ -316,10 +316,17 @@ public class ArtifactCollection {
      *         default artifact)
      */
     public Map<String, ArtifactDescriptor> getArtifact(File location) {
-        artifacts.values().forEach(artifact -> artifact.getLocation(true));
         File normalized = normalizeLocation(location);
         Map<String, ArtifactDescriptor> map = artifactsWithKnownLocation.get(normalized);
         if (map == null) {
+            //Force init of the map indirectly
+            artifacts.values().forEach(artifact -> artifact.getLocation(true));
+            //check if something is there?
+            map = artifactsWithKnownLocation.get(normalized);
+            if (map != null) {
+                return map;
+            }
+            //Still null? Use a fallback with only reactor projects because it might be that a reactor project location is queried...
             LinkedHashMap<String, ArtifactDescriptor> hashMap = new LinkedHashMap<>();
             for (ArtifactDescriptor descriptor : artifacts.values()) {
                 ReactorProject mavenProject = descriptor.getMavenProject();


### PR DESCRIPTION
Currently the location of all artifacts is queried each time one asks for an artifact by a given location. Depending on the number of artifacts this might decrease performance.

This now uses a different approach where we first check if the location is known. If thats the case, simply return the value, if not ask for all locations to fill the map. If that still do not help, compute a map only with reactor projects in it.