### PR TITLE
Do not use deprecated API #4948

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoWorkspaceReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoWorkspaceReader.java
@@ -16,6 +16,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.ModelWriter;
@@ -38,21 +42,19 @@ import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 
-@Component(role = WorkspaceReader.class, hint = "TychoWorkspaceReader")
+@Named("TychoWorkspaceReader")
+@Singleton
 public class TychoWorkspaceReader implements MavenWorkspaceReader {
     private final WorkspaceRepository repository;
 
-    @Requirement
+    @Inject
     private LegacySupport legacySupport;
 
-    @Requirement
+    @Inject
     private Logger logger;
 
-    @Requirement
+    @Inject
     private ModelWriter modelWriter;
-
-    @Requirement
-    private TychoProjectManager projectManager;
 
     public TychoWorkspaceReader() {
         repository = new WorkspaceRepository("tycho", null);


### PR DESCRIPTION
Fixes #4948

`LegacySupport.getRepositorySession()` does not return nulls in multithreaded builds when injected via a new API.

It should still be replaced with direct MavenSession injection, but #4948 is fixed just by using the new javax annotation 🤷. See https://eclipse.dev/sisu/org.eclipse.sisu.plexus/conversion-to-jsr330.html

Tested on RCPTT project on Maven 3.9.10-SNAPHOT with:
```
PATH=/tmp/mavendist/bin:$PATH ./build_nodeps.sh --threads=10 -Dmaven.test.skip -e -Dtycho-version=4.0.14-SNAPSHOT
```

Maven 3.9.9 suffers from https://github.com/eclipse-tycho/tycho/issues/4947 so the test there is much harder.