### PR TITLE
Add a mojo that executes the PDE 'Organize Manifest' cleanups

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -42,6 +42,7 @@
 			<item name="PDE API Tools Plugin" href="tycho-apitools-plugin/plugin-info.html" />
 			<item name="Source Plugin" href="tycho-source-plugin/plugin-info.html" />
 			<item name="Versions Plugin" href="tycho-versions-plugin/plugin-info.html" />
+			<item name="CleanCode Plugin" href="tycho-cleancode-plugin/plugin-info.html" />
 		</menu>
 		<!-- always include all reports -->
 		<menu ref="reports" inherit="bottom"/>

--- a/tycho-cleancode-plugin/pom.xml
+++ b/tycho-cleancode-plugin/pom.xml
@@ -86,6 +86,17 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.pde</groupId>
+			<artifactId>org.eclipse.pde.ui</artifactId>
+			<version>3.16.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
 	</dependencies>
 

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/OrganizeManifest.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/OrganizeManifest.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.pde.internal.ui.refactoring.PDERefactor;
+import org.eclipse.pde.internal.ui.wizards.tools.OrganizeManifestsProcessor;
+import org.eclipse.tycho.eclipsebuild.AbstractEclipseBuild;
+
+public class OrganizeManifest extends AbstractEclipseBuild<OrganizeManifestResult> {
+
+	private boolean addMissing;
+	private boolean markInternal;
+	private String packageFilter;
+	private boolean removeUnresolved;
+	private boolean calculateUses;
+	private boolean modifyDep;
+	private boolean removeDependencies;
+	private boolean unusedDependencies;
+	private boolean removeLazy;
+	private boolean removeUselessFiles;
+	private boolean prefixIconNL;
+	private boolean unusedKeys;
+	private boolean addDependencies;
+	private boolean computeImports;
+
+	OrganizeManifest(Path projectDir, boolean debug) {
+		super(projectDir, debug);
+	}
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	protected OrganizeManifestResult createResult(IProject project) throws Exception {
+		OrganizeManifestsProcessor processor = new OrganizeManifestsProcessor(List.of(project));
+		processor.setAddMissing(addMissing);
+		processor.setMarkInternal(markInternal);
+		processor.setPackageFilter(packageFilter);
+		processor.setRemoveUnresolved(removeUnresolved);
+		processor.setCalculateUses(calculateUses);
+		processor.setModifyDep(modifyDep);
+		processor.setRemoveDependencies(removeDependencies);
+		processor.setUnusedDependencies(unusedDependencies);
+		processor.setRemoveLazy(removeLazy);
+		processor.setRemoveUselessFiles(removeUselessFiles);
+		processor.setPrefixIconNL(prefixIconNL);
+		processor.setUnusedKeys(unusedKeys);
+		processor.setAddDependencies(addDependencies);
+		processor.setComputeImports(computeImports);
+		PDERefactor refactor = new PDERefactor(processor);
+		final RefactoringStatus status = refactor.checkAllConditions(this);
+		if (status.isOK()) {
+			Change change = refactor.createChange(this);
+			change.initializeValidationData(this);
+			PerformChangeOperation performChangeOperation = new PerformChangeOperation(change);
+			performChangeOperation.run(this);
+		} else if (status.hasError()) {
+			throw new RuntimeException("Organize failed: " + status);
+		}
+		return new OrganizeManifestResult();
+	}
+
+	void setAddMissing(boolean addMissing) {
+		this.addMissing = addMissing;
+	}
+
+	void setMarkInternal(boolean markInternal) {
+		this.markInternal = markInternal;
+	}
+
+	void setPackageFilter(String packageFilter) {
+		this.packageFilter = packageFilter;
+	}
+
+	void setRemoveUnresolved(boolean removeUnresolved) {
+		this.removeUnresolved = removeUnresolved;
+	}
+
+	void setCalculateUses(boolean calculateUses) {
+		this.calculateUses = calculateUses;
+	}
+
+	void setModifyDep(boolean modifyDep) {
+		this.modifyDep = modifyDep;
+	}
+
+	void setRemoveDependencies(boolean removeDependencies) {
+		this.removeDependencies = removeDependencies;
+	}
+
+	void setUnusedDependencies(boolean unusedDependencies) {
+		this.unusedDependencies = unusedDependencies;
+	}
+
+	void setRemoveLazy(boolean removeLazy) {
+		this.removeLazy = removeLazy;
+	}
+
+	void setRemoveUselessFiles(boolean removeUselessFiles) {
+		this.removeUselessFiles = removeUselessFiles;
+	}
+
+	void setPrefixIconNL(boolean prefixIconNL) {
+		this.prefixIconNL = prefixIconNL;
+	}
+
+	void setUnusedKeys(boolean unusedKeys) {
+		this.unusedKeys = unusedKeys;
+	}
+
+	void setAddDependencies(boolean addDependencies) {
+		this.addDependencies = addDependencies;
+	}
+
+	void setComputeImports(boolean computeImports) {
+		this.computeImports = computeImports;
+	}
+
+}

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/OrganizeManifestMojo.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/OrganizeManifestMojo.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.tycho.core.MarkdownBuilder;
+import org.eclipse.tycho.eclipsebuild.AbstractEclipseBuildMojo;
+
+/**
+ * A manifest to perform actions from PDE 'Organize Manifest' (similar to java
+ * code cleanups) to cleanup plugins.
+ */
+@Mojo(name = "manifest", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class OrganizeManifestMojo extends AbstractEclipseBuildMojo<OrganizeManifestResult> {
+
+	@Parameter(defaultValue = "${project.build.directory}/organizeManifest.md", property = "tycho.organizeManifest.report")
+	private File reportFileName;
+
+	/**
+	 * Calculate 'uses' directive for public packages
+	 */
+	@Parameter(property = "organizeManifest.calculateUses")
+	private boolean calculateUses;
+
+	@Override
+	protected void handleResult(OrganizeManifestResult result) throws MojoFailureException {
+		MarkdownBuilder builder = new MarkdownBuilder(reportFileName);
+		builder.h3("The following Manifest cleanups where applied:");
+		if (calculateUses) {
+			builder.addListItem("Calculate 'uses' directive for public packages");
+		}
+		builder.newLine();
+		builder.newLine();
+		builder.write();
+	}
+
+	@Override
+	protected OrganizeManifest createExecutable() {
+		OrganizeManifest manifest = new OrganizeManifest(project.getBasedir().toPath(), debug);
+		if (calculateUses) {
+			getLog().info("Organize Manifest: Calculate 'uses' directive for public packages");
+		}
+		manifest.setCalculateUses(calculateUses);
+		return manifest;
+	}
+
+	@Override
+	protected String getName() {
+		return "Organize Manifest";
+	}
+
+	@Override
+	protected String[] getRequireBundles() {
+		return new String[] { "org.eclipse.pde.ui" };
+	}
+
+}

--- a/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/OrganizeManifestResult.java
+++ b/tycho-cleancode-plugin/src/main/java/org/eclipse/tycho/cleancode/OrganizeManifestResult.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.cleancode;
+
+import org.eclipse.tycho.eclipsebuild.EclipseBuildResult;
+
+public class OrganizeManifestResult extends EclipseBuildResult {
+
+}


### PR DESCRIPTION
PDE offers a way to cleanup manifests, but this seems not really often used. One drawback is that this has to be manually performed by the developer.

This now adds a new tycho-cleancode:manifest mojo that allows automatic execution of this task inside a maven build. This will hopefully make more projects to cleanup their manifests as well as lead to more automatic cleanup actions added in PDE itself leading to a constant improvement in manfest metadata.