### PR TITLE
Pass the target environment to the SetTargetPlatform operation

### DIFF
--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuildMojo.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuildMojo.java
@@ -201,7 +201,10 @@ public abstract class AbstractEclipseBuildMojo<Result extends EclipseBuildResult
 
 			if (hasPDENature(eclipseProject)) {
 				if (framework.hasBundle(Bundles.BUNDLE_PDE_CORE)) {
-					framework.execute(new SetTargetPlatform(projectDependencies, debug));
+					Collection<TargetEnvironment> targetEnvironments = projectManager.getBaselineEnvironments(project);
+					Map<String, String> targetEnvironment = targetEnvironments.stream().findFirst()
+							.map(te -> te.toFilterProperties()).orElse(Map.of());
+					framework.execute(new SetTargetPlatform(projectDependencies, targetEnvironment, debug));
 				} else {
 					getLog().info("Skip set Target Platform because " + Bundles.BUNDLE_PDE_CORE
 							+ " is not part of the framework...");


### PR DESCRIPTION
Currently we only have a generic target platform that then falls back to the current environment used. This can be problematic if a platform filter is used for a plugin.

This now determines the current "best" environment (s) for a given project and pass them to the SetTargetPlatform action to propagate it to the target specified to PDE.