### PR TITLE
Classify source IUs as sources

### DIFF
--- a/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -108,6 +108,8 @@ public interface TychoConstants {
 
     String CLASSIFIER_P2_METADATA = "p2metadata";
 
+    String CLASSIFIER_SOURCES = "sources";
+
     String EXTENSION_P2_METADATA = "xml";
 
     /**

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
@@ -298,6 +298,9 @@ public class TychoProjectManager {
         List<ArtifactDescriptor> dependencies = tychoProject
                 .getDependencyArtifacts(DefaultReactorProject.adapt(project)).getArtifacts();
         for (ArtifactDescriptor descriptor : dependencies) {
+            if (TychoConstants.CLASSIFIER_SOURCES.equals(descriptor.getClassifier())) {
+                continue;
+            }
             File location = descriptor.fetchArtifact().get();
             if (location.equals(project.getBasedir())) {
                 continue;

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/TargetPlatformProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/TargetPlatformProject.java
@@ -72,8 +72,9 @@ public class TargetPlatformProject extends AbstractTychoProject {
                 for (IInstallableUnit iu : installableUnits) {
                     for (IArtifactKey key : iu.getArtifacts()) {
                         ArtifactKey artifactKey = ArtifactTypeHelper.toTychoArtifactKey(iu, key);
-                        artifacts.addArtifactFile(artifactKey, () -> targetPlatform.getArtifactLocation(artifactKey),
-                                List.of(iu));
+                        String classifier = ArtifactTypeHelper.toMavenClassifier(iu);
+                        artifacts.addArtifactFile(artifactKey, classifier,
+                                () -> targetPlatform.getArtifactLocation(artifactKey), List.of(iu));
                     }
                 }
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/target/ArtifactTypeHelper.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/target/ArtifactTypeHelper.java
@@ -16,6 +16,8 @@ import static org.eclipse.tycho.ArtifactType.TYPE_BUNDLE_FRAGMENT;
 import static org.eclipse.tycho.ArtifactType.TYPE_ECLIPSE_FEATURE;
 import static org.eclipse.tycho.ArtifactType.TYPE_ECLIPSE_PLUGIN;
 
+import java.util.Collection;
+
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IProvidedCapability;
@@ -24,7 +26,6 @@ import org.eclipse.equinox.p2.metadata.MetadataFactory;
 import org.eclipse.equinox.p2.metadata.MetadataFactory.InstallableUnitDescription;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.metadata.VersionRange;
-import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
@@ -34,6 +35,8 @@ import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.IllegalArtifactReferenceException;
 import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 
 public class ArtifactTypeHelper {
 
@@ -141,6 +144,17 @@ public class ArtifactTypeHelper {
             // other artifacts don't have files that can be referenced by their Eclipse coordinates
             return null;
         }
+    }
+
+    public static String toMavenClassifier(IInstallableUnit iu) {
+        Collection<IProvidedCapability> providedCapabilities = iu.getProvidedCapabilities();
+        for (IProvidedCapability capability : providedCapabilities) {
+            if ("org.eclipse.equinox.p2.eclipse.type".equals(capability.getNamespace())
+                    && "source".equals(capability.getProperties().get("org.eclipse.equinox.p2.eclipse.type"))) {
+                return TychoConstants.CLASSIFIER_SOURCES;
+            }
+        }
+        return null;
     }
 
     public static ArtifactKey toTychoArtifactKey(IInstallableUnit iu, IArtifactKey p2ArtifactKey) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -407,7 +407,8 @@ public class P2DependencyResolver implements DependencyResolver, Initializable {
             if (otherProject != null) {
                 platform.addReactorArtifact(key, otherProject, entry.getClassifier(), entry.getInstallableUnits());
             } else {
-                platform.addArtifactFile(key, () -> entry.getLocation(true), entry.getInstallableUnits());
+                platform.addArtifactFile(key, entry.getClassifier(), () -> entry.getLocation(true),
+                        entry.getInstallableUnits());
             }
         }
         for (P2ResolutionResult.Entry entry : result.getDependencyFragments()) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2ResolverImpl.java
@@ -41,7 +41,6 @@ import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.equinox.p2.metadata.MetadataFactory;
 import org.eclipse.equinox.p2.metadata.MetadataFactory.InstallableUnitDescription;
 import org.eclipse.equinox.p2.metadata.VersionRange;
-import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryResult;
 import org.eclipse.equinox.p2.query.IQueryable;
@@ -74,6 +73,7 @@ import org.eclipse.tycho.p2.publisher.AuthoredIUAction;
 import org.eclipse.tycho.p2.resolver.ResolverException;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformFactory;
+import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 import org.eclipse.tycho.p2tools.copiedfromp2.QueryableArray;
 import org.eclipse.tycho.p2tools.copiedfromp2.Slicer;
 import org.eclipse.tycho.targetplatform.P2TargetPlatform;
@@ -450,9 +450,15 @@ public class P2ResolverImpl implements P2Resolver {
 
     private static void addArtifactFile(DefaultP2ResolutionResult result, IInstallableUnit iu,
             IArtifactKey p2ArtifactKey, P2TargetPlatform context) {
-        String mavenClassifier = null;
-
+        String mavenClassifier = iu.getProperty("maven-classifier");
+        if (mavenClassifier != null && mavenClassifier.isBlank()) {
+            mavenClassifier = null;
+        }
+        if (mavenClassifier == null) {
+            mavenClassifier = ArtifactTypeHelper.toMavenClassifier(iu);
+        }
         ArtifactKey artifactKey = ArtifactTypeHelper.toTychoArtifactKey(iu, p2ArtifactKey);
+        System.out.println(artifactKey + " : " + mavenClassifier);
         if (artifactKey != null) {
             result.addArtifact(artifactKey, mavenClassifier, iu, p2ArtifactKey);
         }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomUnits.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PomUnits.java
@@ -95,8 +95,8 @@ public class PomUnits {
                             new MavenChecksumAdvice(facade.getLocation()));
                     publisher.applyAdvices(dependency.installableUnit(), result.getValue(), advices);
                     if (dependencyArtifacts instanceof ArtifactCollection collection) {
-                        collection.addArtifactFile(result.getKey(), dependency.location(),
-                                dependency.installableUnit());
+                        collection.addArtifactFile(result.getKey(), dependency.artifactFacade().getClassifier(),
+                                dependency.location(), dependency.installableUnit());
                     }
                 }
             });


### PR DESCRIPTION
Currently the classifier of an Installable unit is not propagated to the dependency artifact and IUs that are native source bundles are not classfied as such. This makes it currently impossible to reliable check if a dependency is a source (that might be uninteresting in some use cases).

This now correctly classify IU artifacts as being sources and filter them from the baseline bundles to prevent unnecessary source downloads that only bloat the target platform in such case.