### PR TITLE
Workaround for bnd bug when META-INF/services is empty

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.Attributes.Name;
@@ -184,6 +186,10 @@ public class MavenBundleWrapper {
         Jar jar;
         try {
             jar = new Jar(originalFile);
+            //Workaround for https://github.com/bndtools/bnd/pull/6388
+            if (jar.getDirectories().getOrDefault("META-INF/services", Collections.emptyMap()) == null) {
+                jar.getDirectories().put("META-INF/services", new TreeMap<>());
+            }
         } catch (IOException e) {
             visited.put(node,
                     wrappedNode = new WrappedBundle(node, List.of(), null, null, null,
@@ -218,7 +224,8 @@ public class MavenBundleWrapper {
                 List<ProcessingMessage> messages = new ArrayList<>();
                 wrapArtifactFile.getParentFile().mkdirs();
                 boolean hasErrors = false;
-                try (Builder analyzer = new Builder(new Processor());) {
+                try (Builder analyzer = new Builder(new Processor()) {
+                };) {
                     analyzer.setJar(analyzerJar);
                     analyzer.setProperty("mvnGroupId", artifact.getGroupId());
                     analyzer.setProperty("mvnArtifactId", artifact.getArtifactId());

--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/tests/OSGiMetadataGenerationTest.java
@@ -45,6 +45,24 @@ import aQute.bnd.osgi.Jar;
 public class OSGiMetadataGenerationTest extends AbstractMavenTargetTest {
 
     @Test
+    public void testWithEmptyMetaInfServices() throws Exception {
+        ITargetLocation target = resolveMavenTarget(
+                """
+                        <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.apache.qpid</groupId>
+                                    <artifactId>qpid-jms-discovery</artifactId>
+                                    <version>2.7.0</version>
+                                    <type>jar</type>
+                                </dependency>
+                            </dependencies>
+                        </location>
+                        """);
+        assertStatusOk(getTargetStatus(target));
+    }
+
+    @Test
     public void testNonJarArtifactInDependencies() throws Exception {
         ITargetLocation target = resolveMavenTarget(
                 """


### PR DESCRIPTION
bnd-lib 7.1 contains a bug that can lead to a NPE see here:

-  https://github.com/bndtools/bnd/pull/6388

this adds a testcase (and a workaround) for that particular problem unless we have a new bnd-lib release.