### PR TITLE
Do not inject sources into the maven model

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
@@ -117,6 +117,10 @@ public final class MavenDependencyInjector {
         MavenDependencyInjector generator = new MavenDependencyInjector(project, bundleReader, descriptorMapping,
                 logger);
         for (ArtifactDescriptor artifact : dependencies.getArtifacts()) {
+            if (TychoConstants.CLASSIFIER_SOURCES.equals(artifact.getClassifier())) {
+                //there is no need to struggle with source when we inject dependencies
+                continue;
+            }
             generator.addDependency(artifact, Artifact.SCOPE_COMPILE);
         }
         if (testDependencies != null) {


### PR DESCRIPTION
Currently we inject sources that are resolved from the targetplatform, but this can lead to additional downloads and confuses other tools.

This now skip injecting source to the maven model as this is usually not done when working with maven.