### PR TITLE
Make a context project optional for EclipseRunMojo

### DIFF
--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipserun/EclipseRunMojo.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipserun/EclipseRunMojo.java
@@ -67,7 +67,7 @@ import org.eclipse.tycho.p2.target.facade.TargetPlatformFactory;
  * Launch an eclipse process with arbitrary commandline arguments. The eclipse
  * installation is defined by the dependencies to bundles specified.
  */
-@Mojo(name = "eclipse-run", threadSafe = true)
+@Mojo(name = "eclipse-run", threadSafe = true, requiresProject = false)
 public class EclipseRunMojo extends AbstractMojo {
 
 	/**
@@ -105,7 +105,7 @@ public class EclipseRunMojo extends AbstractMojo {
 	@Parameter(defaultValue = "true")
 	private boolean clearWorkspaceBeforeLaunch;
 
-	@Parameter(property = "project")
+	@Parameter(property = "project", readonly = true)
 	private MavenProject project;
 
 	/**
@@ -446,7 +446,7 @@ public class EclipseRunMojo extends AbstractMojo {
 					+ ". Current Java runtime will be used");
 		}
 		cli.setJvmExecutable(executable);
-		cli.setWorkingDirectory(project.getBasedir());
+		cli.setWorkingDirectory(project != null ? project.getBasedir() : new File("").getAbsoluteFile());
 
 		cli.addVMArguments(splitArgLine(argLine));
 		if (jvmArgs != null) {

--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/Repo2RunnableMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/Repo2RunnableMojo.java
@@ -19,7 +19,7 @@ import org.eclipse.tycho.p2tools.copiedfromp2.RepositoryDescriptor;
  * Mojo that provides the "repo2runnable" functionality described
  * <a href="https://wiki.eclipse.org/Equinox/p2/Ant_Tasks#Repo2Runnable">here</a>.
  */
-@Mojo(name = "repo-to-runnable")
+@Mojo(name = "repo-to-runnable", requiresProject = false)
 public class Repo2RunnableMojo extends AbstractMojo {
 
     @Component
@@ -60,7 +60,7 @@ public class Repo2RunnableMojo extends AbstractMojo {
         try {
             repo2Runnable.run(null);
         } catch (ProvisionException e) {
-            throw new MojoFailureException(e);
+            throw new MojoExecutionException(e);
         }
     }
 


### PR DESCRIPTION
This might be useful if one wants to run Eclipse from Maven without a context project.