### PR TITLE
Replace readonly @Parameter annotations for components with @Inject

### DIFF
--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/MirrorTargetPlatformMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/MirrorTargetPlatformMojo.java
@@ -19,10 +19,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -63,7 +64,7 @@ public class MirrorTargetPlatformMojo extends AbstractMojo {
 
     private static final SiteXMLAction CATEGORY_FACTORY = new SiteXMLAction((URI) null, (String) null);
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     private MavenProject project;
 
     @Parameter(defaultValue = "${project.build.directory}/target-platform-repository")
@@ -104,19 +105,19 @@ public class MirrorTargetPlatformMojo extends AbstractMojo {
     @Parameter
     private SlicingOptions options;
 
-    @Component
+    @Inject
     private TargetPlatformService platformService;
 
-    @Component
+    @Inject
     private MirrorApplicationService mirrorService;
 
-    @Component
+    @Inject
     private ReactorRepositoryManager repositoryManager;
 
-    @Component
+    @Inject
     private IProvisioningAgent agent;
 
-    @Component
+    @Inject
     private InstallableUnitSlicer installableUnitSlicer;
 
     @Override

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformMojo.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.target;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetPlatformService;
@@ -30,10 +30,10 @@ public class TargetPlatformMojo extends AbstractMojo {
     private static final String TARGET_PLATFORM_MOJO_EXECUTED = "TargetPlatformMojo.executed";
 
     // TODO site doc (including steps & parameters handled in afterProjectsRead?)
-    @Parameter(property = "project", readonly = true)
+    @Inject
     private MavenProject project;
 
-    @Component
+    @Inject
     private TargetPlatformService platformService;
 
     @Override

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisMojo.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiAnalysisMojo.java
@@ -32,7 +32,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Repository;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -80,7 +79,7 @@ public class ApiAnalysisMojo extends AbstractMojo {
 	@Parameter(property = "plugin.artifacts")
 	protected List<Artifact> pluginArtifacts;
 
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	private MavenProject project;
 
 	@Parameter(defaultValue = "eclipse-plugin")
@@ -112,9 +111,6 @@ public class ApiAnalysisMojo extends AbstractMojo {
 
 	@Parameter()
 	private Repository apiToolsRepository;
-
-	@Parameter(property = "session", readonly = true, required = true)
-	private MavenSession session;
 
 	@Parameter
 	private Map<String, String> properties;

--- a/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java
+++ b/tycho-apitools-plugin/src/main/java/org/eclipse/tycho/apitools/ApiFileGenerationMojo.java
@@ -42,7 +42,7 @@ import org.eclipse.tycho.model.project.EclipseProject;
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.PROCESS_CLASSES, threadSafe = true)
 public class ApiFileGenerationMojo extends AbstractMojo {
 
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	protected MavenProject project;
 
 	@Parameter(defaultValue = "${project.build.directory}")

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BaselineMojo.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/BaselineMojo.java
@@ -19,8 +19,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Repository;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -60,13 +61,10 @@ public class BaselineMojo extends AbstractMojo implements BaselineContext {
 	@Parameter(property = "baselines", name = "baselines")
 	private List<Repository> baselines;
 
-	@Component
+	@Inject
 	private P2RepositoryManager repositoryManager;
 
-	@Parameter(property = "session", readonly = true)
-	private MavenSession session;
-
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	protected MavenProject project;
 
 	/**

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/DependencyCheckMojo.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/DependencyCheckMojo.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -77,10 +79,10 @@ import org.osgi.resource.Namespace;
 @Mojo(defaultPhase = LifecyclePhase.VERIFY, name = "check-dependencies", threadSafe = true, requiresProject = true)
 public class DependencyCheckMojo extends AbstractMojo {
 
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	private MavenProject project;
 
-	@Parameter(property = "session", readonly = true)
+	@Inject
 	private MavenSession session;
 
 	@Parameter(defaultValue = "${project.build.directory}/versionProblems.md", property = "tycho.dependency.check.report")

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/AbstractBndMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/AbstractBndMojo.java
@@ -15,11 +15,10 @@ package org.eclipse.tycho.bnd.mojos;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.maven.execution.MavenSession;
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.bnd.MavenReactorRepository;
 
@@ -28,13 +27,10 @@ import aQute.service.reporter.Report;
 
 public abstract class AbstractBndMojo extends AbstractMojo {
 
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	protected MavenProject mavenProject;
 
-	@Parameter(property = "session", readonly = true)
-	protected MavenSession session;
-
-	@Component
+	@Inject
 	protected MavenReactorRepository mavenReactorRepository;
 
 	protected Workspace getWorkspace() throws MojoFailureException {

--- a/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/GenerateManifestMojo.java
+++ b/tycho-bnd-plugin/src/main/java/org/eclipse/tycho/bnd/mojos/GenerateManifestMojo.java
@@ -23,16 +23,16 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.ArtifactKey;
@@ -72,18 +72,18 @@ public class GenerateManifestMojo extends AbstractMojo {
 		return true;
 	};
 
-	@Component
+	@Inject
 	private BndPluginManager bndPluginManager;
 
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	protected MavenProject mavenProject;
 
-	@Parameter(property = "session", readonly = true)
+	@Inject
 	protected MavenSession session;
 
-	@Component
+	@Inject
 	private PluginRealmHelper pluginRealmHelper;
-	@Component
+	@Inject
 	private TychoProjectManager projectManager;
 
 	@Override

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -39,6 +39,8 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.inject.Inject;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -118,7 +120,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
 
     private static final String PREFS_FILE_PATH = ".settings" + File.separator + "org.eclipse.jdt.core.prefs";
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     protected MavenProject project;
 
     /**
@@ -133,7 +135,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
     @Parameter
     private Dependency[] extraClasspathElements;
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     private MavenSession session;
 
     /**
@@ -187,7 +189,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
     @Parameter(defaultValue = "SYSTEM")
     private JDKUsage useJDK;
 
-    @Component
+    @Inject
     private ToolchainManagerPrivate toolChainManager;
 
     /**
@@ -266,7 +268,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
     @Component(role = TychoProject.class)
     private Map<String, TychoProject> projectTypes;
 
-    @Component
+    @Inject
     private BundleReader bundleReader;
 
     /**
@@ -328,19 +330,19 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
     @Parameter
     private String log;
 
-    @Component
+    @Inject
     ToolchainProvider toolchainProvider;
 
-    @Component
+    @Inject
     private ToolchainManager toolchainManager;
 
-    @Component
+    @Inject
     private PluginRealmHelper pluginRealmHelper;
 
-    @Component
+    @Inject
     private Logger logger;
 
-    @Component
+    @Inject
     private MavenDependenciesResolver dependenciesResolver;
 
     private ExecutionEnvironment[] manifestBREEs;
@@ -351,7 +353,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
 
     private List<String> currentExcludes;
 
-    @Component
+    @Inject
     private TychoProjectManager tychoProjectManager;
 
     private Integer currentRelease;

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/ValidateClassPathMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/ValidateClassPathMojo.java
@@ -14,13 +14,14 @@ package org.eclipse.tycho.compiler;
 
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.ReactorProject;
@@ -36,7 +37,7 @@ import org.eclipse.tycho.core.osgitools.OsgiBundleProject;
 @Mojo(name = "validate-classpath", defaultPhase = LifecyclePhase.VALIDATE, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
 public class ValidateClassPathMojo extends AbstractMojo {
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     private MavenProject project;
 
     @Component(role = TychoProject.class)

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/AbstractP2Mojo.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/AbstractP2Mojo.java
@@ -14,6 +14,8 @@ package org.eclipse.tycho.core.maven;
 
 import java.util.Collection;
 
+import javax.inject.Inject;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Component;
@@ -31,10 +33,10 @@ import org.eclipse.tycho.p2.tools.BuildContext;
 
 public abstract class AbstractP2Mojo extends AbstractMojo {
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     private MavenSession session;
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     private MavenProject project;
 
     @Parameter(property = TychoProperties.BUILD_QUALIFIER)

--- a/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/DeclarativeServicesMojo.java
+++ b/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/DeclarativeServicesMojo.java
@@ -117,7 +117,7 @@ public class DeclarativeServicesMojo extends AbstractMojo {
 	@Parameter(property = "tycho.ds.header", defaultValue = "auto")
 	private HeaderConfiguration header = HeaderConfiguration.auto;
 
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	protected MavenProject project;
 
 	private final TychoProjectManager manager;
@@ -126,7 +126,7 @@ public class DeclarativeServicesMojo extends AbstractMojo {
 
 	private final PluginRealmHelper pluginRealmHelper;
 
-	@Parameter(property = "session", readonly = true)
+	@Inject
 	private MavenSession session;
 
 	@Inject

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuildMojo.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipsebuild/AbstractEclipseBuildMojo.java
@@ -27,13 +27,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Repository;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.Toolchain;
@@ -105,25 +106,25 @@ public abstract class AbstractEclipseBuildMojo<Result extends EclipseBuildResult
 	@Parameter
 	private List<String> features;
 
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	protected MavenProject project;
 
-	@Component
+	@Inject
 	protected MavenSession mavenSession;
 
-	@Component
+	@Inject
 	private EclipseWorkspaceManager workspaceManager;
 
-	@Component
+	@Inject
 	private EclipseApplicationManager eclipseApplicationManager;
 
-	@Component
+	@Inject
 	private EclipseApplicationFactory applicationFactory;
 
-	@Component
+	@Inject
 	private TychoProjectManager projectManager;
 
-	@Component
+	@Inject
 	ToolchainManager toolchainManager;
 
 

--- a/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipserun/EclipseRunMojo.java
+++ b/tycho-eclipse-plugin/src/main/java/org/eclipse/tycho/eclipserun/EclipseRunMojo.java
@@ -24,13 +24,14 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javax.inject.Inject;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -105,7 +106,7 @@ public class EclipseRunMojo extends AbstractMojo {
 	@Parameter(defaultValue = "true")
 	private boolean clearWorkspaceBeforeLaunch;
 
-	@Parameter(property = "project")
+	@Inject
 	private MavenProject project;
 
 	/**
@@ -153,7 +154,7 @@ public class EclipseRunMojo extends AbstractMojo {
 	@Parameter
 	private List<Repository> repositories;
 
-	@Parameter(property = "session", readonly = true, required = true)
+	@Inject
 	private MavenSession session;
 
 	/**
@@ -259,25 +260,25 @@ public class EclipseRunMojo extends AbstractMojo {
 	@Parameter
 	private BundleStartLevel defaultStartLevel;
 
-	@Component
+	@Inject
 	private EquinoxInstallationFactory installationFactory;
 
-	@Component
+	@Inject
 	private EquinoxLauncher launcher;
 
-	@Component
+	@Inject
 	private ToolchainProvider toolchainProvider;
 
-	@Component()
+	@Inject
 	P2ResolverFactory resolverFactory;
 
-	@Component
+	@Inject
 	private Logger logger;
 
-	@Component
+	@Inject
 	private ToolchainManager toolchainManager;
 
-	@Component
+	@Inject
 	private TargetPlatformFactory platformFactory;
 
 	public EclipseRunMojo() {

--- a/tycho-extras/target-platform-validation-plugin/src/main/java/org/eclipse/tycho/extras/tpvalidator/TPValidationMojo.java
+++ b/tycho-extras/target-platform-validation-plugin/src/main/java/org/eclipse/tycho/extras/tpvalidator/TPValidationMojo.java
@@ -23,10 +23,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -59,10 +60,10 @@ import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
 @Mojo(name = "validate-target-platform", defaultPhase = LifecyclePhase.VALIDATE)
 public class TPValidationMojo extends AbstractMojo {
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     private MavenSession session;
 
-    @Parameter(property = "project")
+    @Inject
     private MavenProject project;
 
     /**
@@ -107,19 +108,19 @@ public class TPValidationMojo extends AbstractMojo {
     @Parameter
     private String executionEnvironment;
 
-    @Component
+    @Inject
     DirectorRuntime director;
 
-    @Component
+    @Inject
     private Logger logger;
 
-    @Component
+    @Inject
     private ToolchainManager toolchainManager;
 
-    @Component
+    @Inject
     private P2ResolverFactory factory;
 
-    @Component
+    @Inject
     private TargetDefinitionVariableResolver varResolver;
 
     public void execute() throws MojoExecutionException {

--- a/tycho-extras/tycho-custom-bundle-plugin/src/main/java/org/eclipse/tycho/extras/custombundle/CustomBundleMojo.java
+++ b/tycho-extras/tycho-custom-bundle-plugin/src/main/java/org/eclipse/tycho/extras/custombundle/CustomBundleMojo.java
@@ -23,6 +23,8 @@ import java.util.jar.Attributes;
 import java.util.jar.Attributes.Name;
 import java.util.jar.Manifest;
 
+import javax.inject.Inject;
+
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.execution.MavenSession;
@@ -158,10 +160,10 @@ public class CustomBundleMojo extends AbstractMojo {
 	@Parameter(required = true)
 	private List<DefaultFileSet> fileSets;
 
-	@Parameter(property = "project")
+	@Inject
 	private MavenProject project;
 
-	@Parameter(property = "session", readonly = true)
+	@Inject
 	private MavenSession session;
 
 	@Parameter
@@ -180,7 +182,7 @@ public class CustomBundleMojo extends AbstractMojo {
 	@Component(role = Archiver.class, hint = "jar")
 	private JarArchiver jarArchiver;
 
-	@Component
+	@Inject
 	private MavenProjectHelper projectHelper;
 
 	@Override

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/ListDependenciesMojo.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/ListDependenciesMojo.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -48,7 +50,7 @@ import org.eclipse.tycho.helper.PluginRealmHelper;
 @Mojo(name = "list-dependencies", defaultPhase = LifecyclePhase.GENERATE_TEST_RESOURCES, requiresProject = true, threadSafe = true, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class ListDependenciesMojo extends AbstractMojo {
 
-    @Parameter(property = "project")
+    @Inject
     private MavenProject project;
 
     @Parameter(property = "skip")
@@ -57,13 +59,13 @@ public class ListDependenciesMojo extends AbstractMojo {
     @Component(role = TychoProject.class)
     private Map<String, TychoProject> projectTypes;
 
-    @Component
+    @Inject
     private PluginRealmHelper pluginRealmHelper;
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     private MavenSession session;
 
-    @Component
+    @Inject
     private TychoProjectManager projectManager;
 
     @Override

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/ConvertSchemaToHtmlMojo.java
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/ConvertSchemaToHtmlMojo.java
@@ -23,12 +23,13 @@ import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 
+import javax.inject.Inject;
+
 import org.apache.maven.model.Repository;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -70,15 +71,15 @@ public class ConvertSchemaToHtmlMojo extends AbstractMojo {
 	@Parameter()
 	private String additionalSearchPaths;
 
-	@Parameter(property = "project")
+	@Inject
 	private MavenProject project;
 
 	@Parameter(property = "reactorProjects", required = true, readonly = true)
 	protected List<MavenProject> reactorProjects;
 
-	@Component
+	@Inject
 	private EclipseWorkspaceManager workspaceManager;
-	@Component
+	@Inject
 	private EclipseApplicationManager applicationManager;
 
 	@Override

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
@@ -51,8 +53,8 @@ import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
  * <p>
  * The javadoc executable path is determined in this order:
  * <ul>
- * <li><code>executable</code> argument of the <code>javadocOptions</code> configuration
- * element, if available</li>
+ * <li><code>executable</code> argument of the <code>javadocOptions</code>
+ * configuration element, if available</li>
  * <li>active Maven toolchain</li>
  * <li><code>java.home</code> system property</li>
  * <li><code>JAVA_HOME</code> environment setting</li>
@@ -90,10 +92,10 @@ public class JavadocMojo extends AbstractMojo {
 	@Parameter(property = "cleanFirst", defaultValue = "true")
 	private boolean cleanFirst;
 
-	@Component
+	@Inject
 	private ToolchainManager toolchainManager;
 
-	@Parameter(property = "session", required = true, readonly = true)
+	@Inject
 	private MavenSession session;
 
 	@Parameter(property = "reactorProjects", required = true, readonly = true)
@@ -202,10 +204,10 @@ public class JavadocMojo extends AbstractMojo {
 	@Parameter(property = "project.build.sourceEncoding", readonly = true)
 	private String projectBuildSourceEncoding;
 
-	@Component
+	@Inject
 	private BundleReader bundleReader;
 
-	@Component
+	@Inject
 	private DocletArtifactsResolver docletArtifactsResolver;
 
 	@Component(role = TychoProject.class)

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -28,7 +30,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.logging.Logger;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.tycho.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.IDependencyMetadata.DependencyMetadataType;
@@ -73,10 +74,10 @@ public class CompareWithBaselineMojo extends AbstractMojo {
         fail, warn
     }
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     private MavenProject project;
 
-    @Parameter(property = "mojoExecution", readonly = true)
+    @Inject
     protected MojoExecution execution;
 
     /**
@@ -107,16 +108,13 @@ public class CompareWithBaselineMojo extends AbstractMojo {
     @Parameter(property = "onIllegalVersion", defaultValue = "fail", alias = "tycho.p2.baseline.onIllegalVersion")
     private ReportBehavior onIllegalVersion;
 
-    @Component()
+    @Inject
     P2ResolverFactory resolverFactory;
 
-    @Component
-    private Logger plexusLogger;
-
-    @Component
+    @Inject
     private TychoProjectManager projectManager;
 
-    @Component
+    @Inject
     private TargetPlatformFactory platformFactory;
 
     /**

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -49,16 +51,16 @@ import org.eclipse.tycho.p2tools.RepositoryReferenceTool;
 @Mojo(name = "mirror", threadSafe = true)
 public class MirrorMojo extends AbstractMojo {
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     private MavenProject project;
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     private MavenSession session;
 
-    @Component
+    @Inject
     MirrorApplicationService mirrorService;
 
-    @Component
+    @Inject
     private RepositoryReferenceTool repositoryReferenceTool;
 
     @Component(role = TychoProject.class)

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/PublishFeaturesAndBundlesMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/PublishFeaturesAndBundlesMojo.java
@@ -17,13 +17,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
@@ -32,7 +32,9 @@ import org.eclipse.tycho.p2tools.copiedfromp2.FeaturesAndBundlesPublisherApplica
 /**
  * This goal invokes the feature and bundle publisher on a folder.
  *
- * @see <a href="https://wiki.eclipse.org/Equinox/p2/Publisher#Features_And_Bundles_Publisher_Application">Eclipse Wiki</a>
+ * @see <a href=
+ *      "https://wiki.eclipse.org/Equinox/p2/Publisher#Features_And_Bundles_Publisher_Application">Eclipse
+ *      Wiki</a>
  */
 @Mojo(name = "publish-features-and-bundles", threadSafe = true)
 public class PublishFeaturesAndBundlesMojo extends AbstractMojo {
@@ -85,10 +87,7 @@ public class PublishFeaturesAndBundlesMojo extends AbstractMojo {
     @Parameter(defaultValue = "")
     private String additionalArgs;
 
-    @Parameter(property = "project")
-    private MavenProject project;
-
-    @Component
+    @Inject
     private IProvisioningAgent agent;
 
     @Override

--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/AbstractUpdateMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/AbstractUpdateMojo.java
@@ -15,25 +15,17 @@ package org.eclipse.tycho.versionbump;
 
 import java.io.File;
 
-import org.apache.maven.execution.MavenSession;
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 public abstract class AbstractUpdateMojo extends AbstractMojo {
 
-    @Parameter(property = "project")
+    @Inject
     private MavenProject project;
-
-    @Component
-    private MavenSession mavenSession;
-
-    MavenSession getMavenSession() {
-        return mavenSession;
-    }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         File file = getFileToBeUpdated();

--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateTargetMojo.java
@@ -34,7 +34,6 @@ import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.mojo.versions.api.Segment;
@@ -158,10 +157,10 @@ public class UpdateTargetMojo extends AbstractUpdateMojo {
     @Parameter(defaultValue = "true", property = "tycho.updatetarget.updateEmptyVersion")
     private boolean updateEmptyVersion;
 
-    @Component
+    @Inject
     private MavenSession mavenSession;
 
-    @Parameter(defaultValue = "${mojoExecution}", required = true, readonly = true)
+    @Inject
     private MojoExecution mojoExecution;
 
     @Inject

--- a/tycho-gpg-plugin/src/main/java/org/eclipse/tycho/gpg/SignRepositoryArtifactsMojo.java
+++ b/tycho-gpg-plugin/src/main/java/org/eclipse/tycho/gpg/SignRepositoryArtifactsMojo.java
@@ -15,10 +15,12 @@ import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -26,8 +28,6 @@ import org.apache.maven.plugins.gpg.AbstractGpgMojoExtension;
 import org.apache.maven.plugins.gpg.ProxySignerWithPublicKeyAccess;
 import org.apache.maven.project.MavenProject;
 import org.bouncycastle.openpgp.PGPSignature;
-import org.codehaus.plexus.archiver.Archiver;
-import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.xz.XZArchiver;
 import org.codehaus.plexus.archiver.zip.ZipUnArchiver;
 import org.eclipse.equinox.internal.p2.artifact.processors.pgp.PGPSignatureVerifier;
@@ -63,7 +63,7 @@ public class SignRepositoryArtifactsMojo extends AbstractGpgMojoExtension {
     /**
      * The maven project.
      */
-    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    @Inject
     protected MavenProject project;
 
     /**
@@ -147,16 +147,18 @@ public class SignRepositoryArtifactsMojo extends AbstractGpgMojoExtension {
     @Parameter(defaultValue = "${project.build.outputTimestamp}")
     private String outputTimestamp;
 
-    @Component(role = UnArchiver.class, hint = "zip")
+    @Inject
+    @Named("zip")
     private ZipUnArchiver zipUnArchiver;
 
-    @Component(role = Archiver.class, hint = "xz")
+    @Inject
+    @Named("xz")
     private XZArchiver xzArchiver;
 
-    @Component
+    @Inject
     private SignedContentFactory signedContentFactory;
 
-    @Component
+    @Inject
     private P2RepositoryManager repositoryManager;
 
     @Override

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/AbstractProductMojo.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/AbstractProductMojo.java
@@ -16,10 +16,11 @@ import java.io.File;
 import java.util.Collection;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.BuildDirectory;
@@ -30,10 +31,10 @@ import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 
 abstract class AbstractProductMojo extends AbstractMojo {
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     private MavenProject project;
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     private MavenSession session;
 
     /**
@@ -118,7 +119,7 @@ abstract class AbstractProductMojo extends AbstractMojo {
     @Parameter(property = "p2.timeout", defaultValue = "0")
     private int forkedProcessTimeoutInSeconds;
 
-    @Component
+    @Inject
     private TychoProjectManager projectManager;
 
     int getForkedProcessTimeoutInSeconds() {

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/AbstractP2MetadataMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/AbstractP2MetadataMojo.java
@@ -18,6 +18,8 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -30,7 +32,7 @@ import org.eclipse.tycho.p2tools.copiedfromp2.AbstractPublisherApplication;
 
 public abstract class AbstractP2MetadataMojo extends AbstractMojo {
 
-    @Parameter(property = "project", required = true, readonly = true)
+    @Inject
     protected MavenProject project;
 
     /**

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/DependenciesTreeMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/DependenciesTreeMojo.java
@@ -19,12 +19,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.runtime.CoreException;
@@ -43,13 +43,13 @@ import org.eclipse.tycho.p2.tools.P2DependencyTreeGenerator.DependencyTreeNode;
  */
 @Mojo(name = "dependency-tree", requiresProject = true, threadSafe = true, requiresDependencyCollection = ResolutionScope.TEST)
 public class DependenciesTreeMojo extends AbstractMojo {
-    @Parameter(property = "project")
+    @Inject
     private MavenProject project;
 
-    @Component
+    @Inject
     private P2DependencyTreeGenerator generator;
 
-    @Component
+    @Inject
     private TychoProjectManager projectManager;
 
     @Override

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/P2MetadataMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/P2MetadataMojo.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Repository;
 import org.apache.maven.plugin.AbstractMojo;
@@ -46,16 +48,16 @@ import org.eclipse.tycho.p2.metadata.P2Generator.FileInfo;
 public class P2MetadataMojo extends AbstractMojo {
     private static final Object LOCK = new Object();
 
-    @Parameter(property = "project")
+    @Inject
     protected MavenProject project;
 
     @Parameter(defaultValue = "true")
     protected boolean attachP2Metadata;
 
-    @Component
+    @Inject
     protected MavenProjectHelper projectHelper;
 
-    @Component
+    @Inject
     P2Generator p2generator;
 
     /**

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/UpdateLocalIndexMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/UpdateLocalIndexMojo.java
@@ -14,12 +14,12 @@ package org.eclipse.tycho.plugins.p2;
 
 import java.io.IOException;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.p2.repository.GAV;
 import org.eclipse.tycho.p2.repository.LocalRepositoryP2Indices;
@@ -27,10 +27,10 @@ import org.eclipse.tycho.p2.repository.LocalRepositoryP2Indices;
 @Mojo(name = "update-local-index", threadSafe = true)
 public class UpdateLocalIndexMojo extends AbstractMojo {
 
-    @Parameter(property = "project", readonly = true, required = true)
+    @Inject
     private MavenProject project;
 
-    @Component
+    @Inject
     private LocalRepositoryP2Indices p2index;
 
     @Override

--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
@@ -34,6 +34,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 
+import javax.inject.Inject;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.archiver.MavenArchiver;
@@ -45,7 +47,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -129,10 +130,10 @@ public class MavenP2SiteMojo extends AbstractMojo {
     private static final List<String> DEFAULT_KEY_SERVER = List.of(PGPService.UBUNTU_KEY_SERVER,
             PGPService.MAVEN_CENTRAL_KEY_SERVER);
 
-    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    @Inject
     private MavenProject project;
 
-    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    @Inject
     private MavenSession session;
 
     /**
@@ -203,18 +204,18 @@ public class MavenP2SiteMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.outputTimestamp}")
     private String outputTimestamp;
 
-    @Component
+    @Inject
     private Logger logger;
-    @Component
+    @Inject
     private RepositorySystem repositorySystem;
 
-    @Component
+    @Inject
     private MavenProjectHelper projectHelper;
 
-    @Component
+    @Inject
     private IProvisioningAgent agent;
 
-    @Component
+    @Inject
     private PGPService pgpService;
 
     /**
@@ -247,7 +248,7 @@ public class MavenP2SiteMojo extends AbstractMojo {
     @Parameter(defaultValue = INCLUDE_PGP_DEFAULT + "")
     private boolean includePGPSignature = INCLUDE_PGP_DEFAULT;
 
-    @Parameter(property = "mojoExecution", readonly = true)
+    @Inject
     MojoExecution execution;
 
     @Override

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/AbstractVersionMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/AbstractVersionMojo.java
@@ -29,7 +29,7 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 
 public abstract class AbstractVersionMojo extends AbstractMojo {
 
-    @Parameter(property = "project", required = true, readonly = true)
+	@Inject
     protected MavenProject project;
 
     @Parameter(property = "project.packaging", required = true, readonly = true)

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/buildversion/BuildQualifierMojo.java
@@ -96,7 +96,7 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
 
 	static final String DEFAULT_DATE_FORMAT = "yyyyMMddHHmm";
 
-	@Parameter(property = "session", readonly = true)
+	@Inject
     protected MavenSession session;
 
     /**
@@ -120,7 +120,7 @@ public class BuildQualifierMojo extends AbstractVersionMojo {
 	@Parameter(property = "tycho.buildqualifier.provider")
     protected String timestampProvider;
 
-    @Parameter(property = "mojoExecution", readonly = true)
+	@Inject
     protected MojoExecution execution;
 
 	@Inject

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/AbstractTychoPackagingMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/AbstractTychoPackagingMojo.java
@@ -48,10 +48,10 @@ public abstract class AbstractTychoPackagingMojo extends AbstractMojo {
 	@Parameter(property = "project.build.directory", required = true)
 	protected File buildDirectory;
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     protected MavenSession session;
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     protected MavenProject project;
 
     @Parameter(defaultValue = "true")

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageTargetDefinitionMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageTargetDefinitionMojo.java
@@ -23,7 +23,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
@@ -36,7 +35,7 @@ import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
 @Mojo(name = "package-target-definition", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class PackageTargetDefinitionMojo extends AbstractMojo {
 
-    @Parameter(property = "project", required = true, readonly = true)
+    @Inject
     private MavenProject project;
 
     @Inject

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
@@ -68,16 +68,16 @@ public class UpdateConsumerPomMojo extends AbstractMojo {
 
 	private static final String POLYGLOT_POM_TYCHO = ".polyglot.pom.tycho";
 
-	@Parameter(property = "project", readonly = true, required = true)
+	@Inject
 	protected MavenProject project;
 
-	@Parameter(defaultValue = "${session}", readonly = true, required = true)
+	@Inject
 	private MavenSession session;
 
-		@Inject
+	@Inject
 	protected ModelWriter modelWriter;
 
-		@Inject
+	@Inject
 	protected ModelReader modelReader;
 
 	@Inject

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/VerifyPomMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/VerifyPomMojo.java
@@ -63,10 +63,10 @@ import org.osgi.framework.BundleException;
 public class VerifyPomMojo extends AbstractMojo {
 	static final String NAME = "verify-osgi-pom";
 
-	@Parameter(defaultValue = "${session}", readonly = true, required = true)
+	@Inject
 	private MavenSession session;
 
-	@Parameter(defaultValue = "${project}", readonly = true, required = true)
+	@Inject
 	private MavenProject project;
 
 	@Parameter(property = "tycho.verify.pom")

--- a/tycho-repository-plugin/src/main/java/org/eclipse/tycho/repository/plugin/PackageRepositoryMojo.java
+++ b/tycho-repository-plugin/src/main/java/org/eclipse/tycho/repository/plugin/PackageRepositoryMojo.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.Artifact;
@@ -34,7 +37,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
-import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
@@ -55,7 +57,7 @@ public class PackageRepositoryMojo extends AbstractMojo implements RepositoryCon
 
 	static final String PARAMETER_REPOSITORY_TYPE = "repositoryType";
 
-	@Parameter(property = "session", readonly = true)
+	@Inject
 	protected MavenSession session;
 
 	/**
@@ -69,7 +71,7 @@ public class PackageRepositoryMojo extends AbstractMojo implements RepositoryCon
 	@Parameter(defaultValue = "${project.build.directory}")
 	private File destination;
 
-	@Parameter(property = "project", readonly = true)
+	@Inject
 	private MavenProject project;
 
 	/**
@@ -91,7 +93,7 @@ public class PackageRepositoryMojo extends AbstractMojo implements RepositoryCon
 	@Parameter(defaultValue = DEFAULT_REPOSITORY_TYPE, name = PARAMETER_REPOSITORY_TYPE)
 	private String repositoryType;
 
-	@Parameter(property = "mojoExecution", readonly = true)
+	@Inject
 	MojoExecution execution;
 
 	/**
@@ -110,13 +112,14 @@ public class PackageRepositoryMojo extends AbstractMojo implements RepositoryCon
 	@Parameter(defaultValue = "${project.build.outputTimestamp}")
 	private String outputTimestamp;
 
-	@Component(role = Archiver.class, hint = "zip")
+	@Inject
+	@Named("zip")
 	private ZipArchiver zipArchiver;
 
 	@Component(role = RepositoryGenerator.class)
 	private Map<String, RepositoryGenerator> generators;
 
-	@Component
+	@Inject
 	private MavenProjectHelper mavenProjectHelper;
 
 	@Override

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
@@ -26,6 +26,9 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -91,19 +94,20 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
     /**
      * The Maven Project Object
      */
-    @Parameter(property = "project", readonly = true, required = true)
+    @Inject
     protected MavenProject project;
 
     /**
      * The Maven Session Object
      */
-    @Parameter(property = "session", readonly = true)
+    @Inject
     protected MavenSession session;
 
     /**
      * The Jar archiver.
      */
-    @Component(role = Archiver.class, hint = "jar")
+    @Inject
+    @Named("jar")
     private JarArchiver jarArchiver;
 
     /**

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/PDESourceBundleMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/PDESourceBundleMojo.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 
+import javax.inject.Inject;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Resource;
@@ -54,7 +56,7 @@ import aQute.bnd.osgi.Jar;
 @Mojo(name = "generate-pde-source-header", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class PDESourceBundleMojo extends AbstractMojo {
 
-    @Parameter(property = "project", readonly = true, required = true)
+    @Inject
     protected MavenProject project;
 
     @Parameter(property = "sourceBundleSuffix", defaultValue = ".source")

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.execution.MavenSession;
@@ -114,7 +116,7 @@ public class SourceFeatureMojo extends AbstractMojo {
 
     private static final String GEN_DIR = "sources-feature";
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     private MavenProject project;
 
     /**
@@ -188,7 +190,7 @@ public class SourceFeatureMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     protected boolean useDefaultExcludes;
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     private MavenSession session;
 
     /**
@@ -209,7 +211,7 @@ public class SourceFeatureMojo extends AbstractMojo {
     @Parameter
     private MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
 
-    @Component
+    @Inject
     private BuildPropertiesParser buildPropertiesParser;
 
     /**
@@ -222,19 +224,19 @@ public class SourceFeatureMojo extends AbstractMojo {
     @Component(role = Archiver.class, hint = "jar")
     private JarArchiver jarArchiver;
 
-    @Component
+    @Inject
     private MavenProjectHelper projectHelper;
 
-    @Component
+    @Inject
     private LicenseFeatureHelper licenseFeatureHelper;
 
-    @Component()
+    @Inject
     P2ResolverFactory factory;
 
-    @Component
+    @Inject
     private Logger logger;
 
-    @Component
+    @Inject
     private TychoProjectManager projectManager;
 
     @Override

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -89,7 +89,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
     @Parameter(property = "tycho.surefire.deleteWorkDir")
     private boolean deleteWorkDirAfterTest;
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     protected MavenProject project;
 
     /**
@@ -199,7 +199,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
     @Parameter(property = "tycho.printBundles", defaultValue = "false")
     protected boolean printBundles;
 
-    @Parameter(property = "session", readonly = true, required = true)
+    @Inject
     protected MavenSession session;
 
     @Inject

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoVerifyMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoVerifyMojo.java
@@ -12,6 +12,8 @@
  ******************************************************************************/
 package org.eclipse.tycho.surefire;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.failsafe.VerifyMojo;
@@ -27,7 +29,7 @@ import org.eclipse.tycho.PackagingType;
 @Mojo(name = "verify", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class TychoVerifyMojo extends VerifyMojo {
 
-    @Parameter(property = "project", readonly = true)
+    @Inject
     protected MavenProject project;
 
     @Parameter(property = "tycho.verify-test.packaging", defaultValue = PackagingType.TYPE_ECLIPSE_PLUGIN)

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/AbstractChangeMojo.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/AbstractChangeMojo.java
@@ -52,7 +52,7 @@ public abstract class AbstractChangeMojo extends AbstractMojo {
     @Inject
     private VersionsEngine engine;
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     protected MavenSession session;
 
     @Inject

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/UpdateEclipseMetadataMojo.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/UpdateEclipseMetadataMojo.java
@@ -21,7 +21,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.tycho.versions.engine.EclipseVersionUpdater;
 import org.eclipse.tycho.versions.engine.ProjectMetadataReader;
 
@@ -33,7 +32,7 @@ import org.eclipse.tycho.versions.engine.ProjectMetadataReader;
 public class UpdateEclipseMetadataMojo extends AbstractMojo {
     private static final Object LOCK = new Object();
 
-    @Parameter(property = "session", readonly = true)
+    @Inject
     private MavenSession session;
 
     @Inject

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/UpdatePomMojo.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/UpdatePomMojo.java
@@ -21,7 +21,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.versions.engine.PomVersionUpdater;
 import org.eclipse.tycho.versions.engine.ProjectMetadataReader;
@@ -35,7 +34,7 @@ import org.eclipse.tycho.versions.engine.ProjectMetadataReader;
 public class UpdatePomMojo extends AbstractMojo {
     private static final Object LOCK = new Object();
 
-    @Parameter(defaultValue = "${project}", required = true, readonly = true)
+    @Inject
     private MavenProject project;
 
     @Inject

--- a/tycho-wrap-plugin/src/main/java/org/eclipse/tycho/wrap/WrapMojo.java
+++ b/tycho-wrap-plugin/src/main/java/org/eclipse/tycho/wrap/WrapMojo.java
@@ -19,12 +19,13 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 
+import javax.inject.Inject;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -57,16 +58,16 @@ public class WrapMojo extends AbstractMojo {
 
 	private static final String[] HEADERS = { Constants.BUNDLE_SYMBOLICNAME, Constants.BUNDLE_VERSION };
 
-	@Component
+	@Inject
 	private MavenProject project;
 
-	@Parameter(defaultValue = "${settings}", readonly = true)
+	@Inject
 	Settings settings;
 
-	@Component
+	@Inject
 	private MojoExecution mojoExecution;
 
-	@Component
+	@Inject
 	private MavenProjectHelper helper;
 
 	/**


### PR DESCRIPTION
This modernizes common old ways of configurations like
```
	@Parameter(property = "session", required = true)
	private MavenSession session;
	@Parameter(property = "project", readonly = true)
	private MavenProject project;
```
to just
```
	@Inject
	private MavenSession session;
	@Inject
	private MavenProject project;
```
which should also remove these parameters from the Mojo's help page, which can actually not be configured.


And migrate some plain `@Component` annotations by `@Inject`.