### PR TITLE
Sort fragments URLs passed to SurefireLoader

### DIFF
--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -401,7 +402,7 @@ public class OsgiSurefireBooter {
             return new Bundle[0];
         }
         return hostWires.stream().map(wire -> wire.getRequirer().getBundle()).filter(Objects::nonNull)
-                .toArray(Bundle[]::new);
+                .sorted(Comparator.comparing(Bundle::getSymbolicName)).toArray(Bundle[]::new);
     }
 
 }


### PR DESCRIPTION
The result of OsgiSurefireBooter.getFragments(Bundle) depends on iterating over HashMap containers, i.e. it doesn't have a stable order.

SurefireLoader will then load service resources in an unstable order, causing JUnit 5 to run tests an unstable order - if the tests have a mix of test suites, JUnit 4 and JUnit 5 tests. With this unstable order, the JUnit 5 vintage test engine can be listed before or after the suite and JUnit 5 test engines.

This change ensures fragments of the bundle
org.eclipse.tycho.surefire.osgibooter (junit5, junit5 vintage) are sorted, ensuring test engines are discovered by JUnit 5 in a stable order.

Fixes: #5241