### PR TITLE
P2MirrorDisablingArtifactRepositoryManager: Synchronize property access

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/P2MirrorDisablingArtifactRepositoryManager.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/P2MirrorDisablingArtifactRepositoryManager.java
@@ -52,8 +52,10 @@ class P2MirrorDisablingArtifactRepositoryManager implements IArtifactRepositoryM
 	private static void stripMirrorsURLProperty(AbstractRepository<?> repository, Logger logger) {
         try {
             Map<?, ?> properties = getRepositoryProperties(repository);
-            Object removedConfiguration = properties.remove(IRepository.PROP_MIRRORS_URL);
-
+            Object removedConfiguration;
+            synchronized (repository) {
+                removedConfiguration = properties.remove(IRepository.PROP_MIRRORS_URL);
+            }
             if (removedConfiguration != null && logger.isDebugEnabled()) {
                 logger.debug("Removed 'p2.mirrorsURL' property in repository " + repository.getLocation());
             }


### PR DESCRIPTION
When accessing the properties AbstractRepository via reflection, we must adhere to the same synchronization rules as AbstractRepository.

Fixes #4709.