### PR TITLE
Add integration test for SourceForge HTTP 302 redirects

### DIFF
--- a/tycho-its/projects/http302RedirectSourceForge/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/http302RedirectSourceForge/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: http302RedirectSourceForge
+Bundle-SymbolicName: http302RedirectSourceForge
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.rodinp.core;bundle-version="[1.7.0,2.0.0)"

--- a/tycho-its/projects/http302RedirectSourceForge/build.properties
+++ b/tycho-its/projects/http302RedirectSourceForge/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/http302RedirectSourceForge/pom.xml
+++ b/tycho-its/projects/http302RedirectSourceForge/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>tycho-its-project.http302RedirectSourceForge</groupId>
+	<version>1.0.0-SNAPSHOT</version>
+	<artifactId>http302RedirectSourceForge</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	
+	<repositories>
+		<repository>
+			<id>rodinOnSourceForge</id>
+			<url>https://rodin-b-sharp.sourceforge.net/core-updates/</url>
+			<layout>p2</layout>
+		</repository>
+	</repositories>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
Reproduces issue #5250. When run using Tycho 4.0.11 or later, this should fail with an error like:

```
[INFO] Downloading from p2: https://rodin-b-sharp.sourceforge.net/core-updates/3.9/plugins/org.rodinp.core_1.10.0.202406100730-9b87fe13d-dirty.jar
[INFO] Downloaded from p2: https://rodin-b-sharp.sourceforge.net/core-updates/3.9/plugins/org.rodinp.core_1.10.0.202406100730-9b87fe13d-dirty.jar (349 bytes at 340 KB/s)
[ERROR] An error occurred while transferring artifact canonical: osgi.bundle,org.rodinp.core,1.10.0.202406100730-9b87fe13d-dirty from repository https://rodin-b-sharp.sourceforge.net/core-updates/3.9:
[ERROR]    Problems downloading artifact: osgi.bundle,org.rodinp.core,1.10.0.202406100730-9b87fe13d-dirty.:
[ERROR]       SHA-512 hash is not as expected. Expected: cbe544a17634898546747e12f4e9435f7f0c5632ad03bac79f0fb0e21dbb089154949641ca69515974ea230f0f6303f1be47adf3b02f8618bf630ade549a0dfc and found 8af9141e4ae384e3c33238a64631ecfb3ab7d99abeca12bc29eefcbc8834e68b50b39676cda9f7472ca3a402800462affeaa2af8239d1b7dc18c46927195c064.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.682 s
[INFO] Finished at: 2025-08-26T15:22:58+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Could not mirror artifact osgi.bundle,org.rodinp.core,1.10.0.202406100730-9b87fe13d-dirty into the local Maven repository.See log output for details.
```