### PR TITLE
Support multiple redirects with HTTP_MOVED_TEMP code

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/Java11HttpTransportFactory.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/Java11HttpTransportFactory.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
@@ -52,6 +54,7 @@ import org.eclipse.tycho.p2maven.transport.Response.ResponseConsumer;
 public class Java11HttpTransportFactory implements HttpTransportFactory, Initializable {
 	private static final int MAX_DISCARD = 1024 * 10;
 	private static final byte[] DUMMY_BUFFER = new byte[MAX_DISCARD];
+	private final CookieManager cookieManager = new CookieManager(null, CookiePolicy.ACCEPT_ALL);
 
 	// see https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3
 	// per RFC there are three different formats:
@@ -271,9 +274,11 @@ public class Java11HttpTransportFactory implements HttpTransportFactory, Initial
 		};
 		client = HttpClient.newBuilder().connectTimeout(Duration.ofMinutes(TIMEOUT_SECONDS))
 				.followRedirects(Redirect.NEVER)
+				.cookieHandler(cookieManager)
 				.proxy(proxySelector).build();
 		clientHttp1 = HttpClient.newBuilder().connectTimeout(Duration.ofMinutes(TIMEOUT_SECONDS))
 				.version(Version.HTTP_1_1).followRedirects(Redirect.NEVER)
+				.cookieHandler(cookieManager)
 				.proxy(proxySelector).build();
 
 	}


### PR DESCRIPTION
Currently when we get HTTP_MOVED_TEMP code the redirect location is assumed to be the final location of the file. But sometimes there are cases where multiple redirects take place instead and then the fetching of artifacts fails.

This now checks first if the next location is also a redirect, and if it is the case it performs a temporary redirect again until getting the real location. Beside that the Java11HttpClient now also support cookie handling as these are used by some servers during the redirect.

Fixes https://github.com/eclipse-tycho/tycho/issues/5250