### PR TITLE
Install the standalone director from the Eclipse P2 repository

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/PublisherActionRunner.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/PublisherActionRunner.java
@@ -15,6 +15,7 @@ package org.eclipse.tycho.p2.tools.publisher;
 import java.util.Collection;
 import java.util.List;
 
+import org.codehaus.plexus.logging.Logger;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.publisher.IPublisherAction;
@@ -25,7 +26,6 @@ import org.eclipse.equinox.p2.publisher.PublisherInfo;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.tycho.TargetEnvironment;
-import org.eclipse.tycho.core.shared.MavenLogger;
 import org.eclipse.tycho.helper.StatusTool;
 
 /**
@@ -35,10 +35,10 @@ public class PublisherActionRunner {
 
     private IMetadataRepository contextIUs;
     private List<TargetEnvironment> environments;
-    private MavenLogger logger;
+    private Logger logger;
 
     public PublisherActionRunner(IMetadataRepository contextInstallableUnits, List<TargetEnvironment> environments,
-            MavenLogger logger) {
+            Logger logger) {
         this.contextIUs = contextInstallableUnits;
         this.environments = environments;
         this.logger = logger;

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PublisherServiceFactoryImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PublisherServiceFactoryImpl.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
 import org.eclipse.tycho.Interpolator;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetEnvironment;
@@ -41,6 +42,9 @@ public class PublisherServiceFactoryImpl implements PublisherServiceFactory {
 
     @Requirement
     private TargetPlatformService targetPlatformService;
+
+    @Requirement
+    private Logger logger;
 
     @Override
     public PublisherService createPublisher(ReactorProject project, List<TargetEnvironment> environments) {
@@ -68,8 +72,7 @@ public class PublisherServiceFactoryImpl implements PublisherServiceFactory {
 
     private PublisherActionRunner getPublisherRunnerForProject(P2TargetPlatform targetPlatform,
             List<TargetEnvironment> environments) {
-        return new PublisherActionRunner(targetPlatform.getMetadataRepository(), environments,
-                mavenContext.getLogger());
+        return new PublisherActionRunner(targetPlatform.getMetadataRepository(), environments, logger);
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishProductToolTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishProductToolTest.java
@@ -99,7 +99,7 @@ public class PublishProductToolTest extends TychoPlexusTestCase {
                 Set.of());
 
         PublisherActionRunner publisherRunner = new PublisherActionRunner(targetPlatform.getMetadataRepository(),
-                ENVIRONMENTS, logVerifier.getMavenLogger());
+                ENVIRONMENTS, logVerifier.getLogger());
         return new PublishProductToolImpl(publisherRunner, outputRepository, targetPlatform, QUALIFIER,
                 interpolatorMock, logVerifier.getMavenLogger());
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublisherServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublisherServiceTest.java
@@ -75,7 +75,7 @@ public class PublisherServiceTest extends TychoPlexusTestCase {
         outputRepository = new PublishingRepositoryImpl(lookup(IProvisioningAgent.class),
                 new ReactorProjectIdentitiesStub(projectDirectory));
         PublisherActionRunner publisherRunner = new PublisherActionRunner(context, DEFAULT_ENVIRONMENTS,
-                logVerifier.getMavenLogger());
+                logVerifier.getLogger());
         subject = new PublisherServiceImpl(publisherRunner, DEFAULT_QUALIFIER, outputRepository);
     }
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/MetaRequirementsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/MetaRequirementsTest.java
@@ -12,10 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.product;
 
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWithIgnoringCase;
-import static org.junit.Assume.assumeThat;
-
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
@@ -24,9 +20,6 @@ public class MetaRequirementsTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testProductInstallationWithCustomTouchpoint() throws Exception {
-		// TODO: fix this test for windows
-		assumeThat(System.getProperty("os.name"), not(startsWithIgnoringCase("windows")));
-
 		/*
 		 * Project building a product distribution which includes a bundle that uses a
 		 * custom touchpoint. The implementation of the touchpoint is installed into the

--- a/tycho-p2-director-plugin/pom.xml
+++ b/tycho-p2-director-plugin/pom.xml
@@ -52,13 +52,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.tycho</groupId>
-			<artifactId>tycho-bundles-external</artifactId>
-			<!-- use a fixed version here for now, this is only used when working with a standalone director -->
-			<version>2.7.5</version>
-			<type>zip</type>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 			<exclusions>

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/MaterializeProductsMojo.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/MaterializeProductsMojo.java
@@ -313,7 +313,7 @@ public final class MaterializeProductsMojo extends AbstractProductMojo {
         return switch (directorRuntime) {
         case internal -> director;
         case standalone -> standaloneDirectorFactory.createStandaloneDirector(getBuildDirectory().getChild("director"),
-                getSession().getLocalRepository(), getForkedProcessTimeoutInSeconds());
+                getForkedProcessTimeoutInSeconds());
         default -> throw new MojoFailureException(
                 "Unsupported value for attribute 'directorRuntime': \"" + directorRuntime + "\"");
         };

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/runtime/StandaloneDirectorRuntimeFactory.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/runtime/StandaloneDirectorRuntimeFactory.java
@@ -13,20 +13,34 @@
 package org.eclipse.tycho.plugins.p2.director.runtime;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.publisher.eclipse.ProductAction;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.sisu.equinox.launching.EquinoxLauncher;
+import org.eclipse.tycho.MavenRepositoryLocation;
 import org.eclipse.tycho.TargetEnvironment;
+import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.p2.tools.director.shared.DirectorCommandException;
 import org.eclipse.tycho.p2.tools.director.shared.DirectorRuntime;
+import org.eclipse.tycho.p2.tools.publisher.PublisherActionRunner;
+import org.eclipse.tycho.p2maven.repository.P2RepositoryManager;
 
 @Component(role = StandaloneDirectorRuntimeFactory.class)
 public class StandaloneDirectorRuntimeFactory {
@@ -43,45 +57,75 @@ public class StandaloneDirectorRuntimeFactory {
     @Requirement
     private Logger logger;
 
-    public StandaloneDirectorRuntime createStandaloneDirector(File installLocation,
-            ArtifactRepository localMavenRepository, int forkedProcessTimeoutInSeconds) throws MojoExecutionException {
+    @Requirement
+    private P2RepositoryManager repositoryManager;
 
-        installStandaloneDirector(installLocation, localMavenRepository);
+    @Requirement
+    private IProvisioningAgent agent;
+
+    public StandaloneDirectorRuntime createStandaloneDirector(File installLocation, int forkedProcessTimeoutInSeconds)
+            throws MojoExecutionException {
+
+        installStandaloneDirector(installLocation);
         return new StandaloneDirectorRuntime(installLocation, launchHelper, forkedProcessTimeoutInSeconds, logger);
     }
 
-    private void installStandaloneDirector(File installLocation, ArtifactRepository localMavenRepository)
-            throws MojoExecutionException {
+    private void installStandaloneDirector(File installLocation) throws MojoExecutionException {
+        Path productFile;
         try {
-            // ... install from a zipped p2 repository obtained via Maven ...
-            URI directorRuntimeRepo = URI
-                    .create("jar:" + getDirectorRepositoryZip(localMavenRepository).toURI() + "!/");
+            //TODO it would be good to enhance P2 so we can read a product from a stream...
+            productFile = installLocation.toPath().resolve("director.product");
+            Files.createDirectories(productFile.getParent());
+            try (InputStream stream = StandaloneDirectorRuntimeFactory.class.getResourceAsStream("/director.product")) {
+                Files.copy(stream, productFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Unable to extract director product!", e);
+        }
+        URI eclipseLatest = URI.create(TychoConstants.ECLIPSE_LATEST);
+        IMetadataRepository eclipseLatestRepository;
+        try {
+            eclipseLatestRepository = repositoryManager
+                    .getMetadataRepository(new MavenRepositoryLocation("standalone-director", eclipseLatest));
+        } catch (ProvisionException e) {
+            throw new MojoExecutionException("Could not load director source repository", e);
+        }
+        IMetadataRepository productRepository;
+        try {
+            productRepository = repositoryManager
+                    .createLocalMetadataRepository(installLocation.toPath().resolve("repo"), "director", Map.of());
+        } catch (ProvisionException e) {
+            throw new MojoExecutionException("Could not create local product repository for director application", e);
+        }
+        StandaloneProduct product;
+        try {
+            product = new StandaloneProduct(productFile.toFile(), eclipseLatestRepository);
+        } catch (CoreException e) {
+            throw new MojoExecutionException("Can not parse standalone director product", e);
+        }
+        TargetEnvironment environment = TargetEnvironment.getRunningEnvironment();
+        PublisherActionRunner runner = new PublisherActionRunner(eclipseLatestRepository, List.of(environment), null);
+        ProductAction productAction = new ProductAction(null, product, "tooling", null, null);
+        runner.executeAction(productAction, productRepository, null);
+        try {
             DirectorRuntime.Command command = bootstrapDirector.newInstallCommand("standalone");
-            command.addMetadataSources(Arrays.asList(directorRuntimeRepo));
-            command.addArtifactSources(Arrays.asList(directorRuntimeRepo));
+            command.addMetadataSources(Arrays.asList(eclipseLatest, productRepository.getLocation()));
+            command.addArtifactSources(Arrays.asList(eclipseLatest));
 
+            command.addUnitToInstall("org.eclipse.equinox.launcher");
             // ... a product that includes the p2 director application ...
-            command.addUnitToInstall("tycho-bundles-external");
+            command.addUnitToInstall("director");
             command.setProfileName("director");
-
             // ... to a location in the target folder
             command.setDestination(installLocation);
-
-            // there is only this environment in the p2 repository zip
-            // TODO use a "no environment-specific units" setting
-            command.setEnvironment(new TargetEnvironment("linux", "gtk", "x86_64"));
-
+            command.setEnvironment(environment);
             logger.info("Installing a standalone p2 Director");
             command.execute();
-        } catch (DirectorCommandException e) {
+        } catch (
+
+        DirectorCommandException e) {
             throw new MojoExecutionException("Could not install the standalone director", e);
         }
     }
 
-    private File getDirectorRepositoryZip(ArtifactRepository localMavenRepository) {
-        // this artifact is a dependency of the Mojo, so we expect it in the local Maven repo
-        Artifact artifact = repositorySystem.createArtifact("org.eclipse.tycho", "tycho-bundles-external", "2.7.5",
-                "eclipse-repository");
-        return new File(localMavenRepository.getBasedir(), localMavenRepository.pathOf(artifact));
-    }
 }

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/runtime/StandaloneProduct.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/runtime/StandaloneProduct.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.plugins.p2.director.runtime;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.equinox.frameworkadmin.BundleInfo;
+import org.eclipse.equinox.internal.p2.publisher.eclipse.IProductDescriptor;
+import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductContentType;
+import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IVersionedId;
+import org.eclipse.equinox.p2.metadata.VersionedId;
+import org.eclipse.equinox.p2.publisher.eclipse.IMacOsBundleUrlType;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.equinox.p2.repository.IRepositoryReference;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+
+class StandaloneProduct implements IProductDescriptor {
+
+    private final IProductDescriptor delegate;
+
+    private List<IVersionedId> expandedBundles = new ArrayList<>();
+
+    public StandaloneProduct(File productFile, IMetadataRepository repository) throws CoreException {
+        this.delegate = new ProductFile(productFile.getAbsolutePath(), null);
+        List<IVersionedId> bundles = delegate.getBundles();
+        for (IVersionedId bundle : bundles) {
+            Iterator<IInstallableUnit> iterator = repository.query(QueryUtil.createIUQuery(bundle.getId()), null)
+                    .iterator();
+            if (iterator.hasNext()) {
+                IInstallableUnit next = iterator.next();
+                expandedBundles.add(new VersionedId(next.getId(), next.getVersion()));
+            } else {
+                expandedBundles.add(bundle);
+            }
+        }
+    }
+
+    @Override
+    public String getVersion() {
+        return delegate.getVersion();
+    }
+
+    @Override
+    public List<IVersionedId> getBundles() {
+        return expandedBundles;
+    }
+
+    @Override
+    public List<IVersionedId> getFeatures() {
+        return getFeatures(INCLUDED_FEATURES);
+    }
+
+    @Override
+    public List<IVersionedId> getFeatures(int options) {
+        return delegate.getFeatures(options);
+    }
+
+    @Override
+    public Map<String, String> getConfigurationProperties() {
+        return delegate.getConfigurationProperties();
+    }
+
+    @Override
+    public Map<String, String> getConfigurationProperties(String os, String arch) {
+        return delegate.getConfigurationProperties(os, arch);
+    }
+
+    @Override
+    public boolean hasBundles() {
+        return delegate.hasBundles();
+    }
+
+    @Override
+    public boolean hasFeatures() {
+        return delegate.hasFeatures();
+    }
+
+    @Override
+    public String getLauncherName() {
+        return delegate.getLauncherName();
+    }
+
+    @Override
+    public String getConfigIniPath(String os) {
+        return delegate.getConfigIniPath(os);
+    }
+
+    @Override
+    public String getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public String getProductId() {
+        return delegate.getProductId();
+    }
+
+    @Override
+    public String getApplication() {
+        return delegate.getApplication();
+    }
+
+    @Override
+    public String getSplashLocation() {
+        return delegate.getSplashLocation();
+    }
+
+    @Override
+    public String getProductName() {
+        return delegate.getProductName();
+    }
+
+    @Override
+    public boolean useFeatures() {
+        return delegate.useFeatures();
+    }
+
+    @Override
+    public ProductContentType getProductContentType() {
+        return delegate.getProductContentType();
+    }
+
+    @Override
+    public String getVMArguments(String os) {
+        return delegate.getVMArguments(os);
+    }
+
+    @Override
+    public String getVMArguments(String os, String arch) {
+        return delegate.getVMArguments(os, arch);
+    }
+
+    @Override
+    public String getProgramArguments(String os) {
+        return delegate.getProgramArguments(os);
+    }
+
+    @Override
+    public String getProgramArguments(String os, String arch) {
+        return delegate.getProgramArguments(os, arch);
+    }
+
+    @Override
+    public String[] getIcons(String os) {
+        return delegate.getIcons(os);
+    }
+
+    @Override
+    public List<BundleInfo> getBundleInfos() {
+        return delegate.getBundleInfos();
+    }
+
+    @Override
+    public File getLocation() {
+        return delegate.getLocation();
+    }
+
+    @Override
+    public boolean includeLaunchers() {
+        return delegate.includeLaunchers();
+    }
+
+    @Override
+    public String getLicenseURL() {
+        return delegate.getLicenseURL();
+    }
+
+    @Override
+    public String getLicenseText() {
+        return delegate.getLicenseText();
+    }
+
+    @Override
+    public List<IRepositoryReference> getRepositoryEntries() {
+        return delegate.getRepositoryEntries();
+    }
+
+    @Override
+    public String getVM(String os) {
+        return delegate.getVM(os);
+    }
+
+    @Override
+    public List<IMacOsBundleUrlType> getMacOsBundleUrlTypes() {
+        return delegate.getMacOsBundleUrlTypes();
+    }
+
+}

--- a/tycho-p2-director-plugin/src/main/resources/director.product
+++ b/tycho-p2-director-plugin/src/main/resources/director.product
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="director" application="org.eclipse.equinox.p2.director" version="1.0.0" type="bundles" includeLaunchers="false" autoIncludeRequirements="true">
+
+   <plugins>
+      <plugin id="org.apache.felix.scr"/>
+      <plugin id="org.eclipse.core.runtime"/>
+      <plugin id="org.eclipse.equinox.p2.director.app"/>
+      <plugin id="org.eclipse.equinox.p2.touchpoint.eclipse"/>
+      <plugin id="org.eclipse.equinox.simpleconfigurator"/>
+      <plugin id="org.eclipse.equinox.p2.publisher.eclipse"/>
+      <plugin id="org.eclipse.equinox.p2.touchpoint.natives"/>
+      <plugin id="org.eclipse.equinox.p2.updatesite"/>
+      <plugin id="org.eclipse.equinox.p2.repository.tools"/>
+      <plugin id="org.eclipse.equinox.p2.transport.ecf"/>
+      <plugin id="org.eclipse.osgi.compatibility.state"/>
+      <plugin id="org.eclipse.osgi"/>
+   </plugins>
+
+   <configurations>
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
+   </configurations>
+
+</product>


### PR DESCRIPTION
Currently we use a very old P2 install from Tycho 2.7 for the standalone director.

This now try to replace this with using the latest Eclipse Repository instead.

Fixes https://github.com/eclipse-tycho/tycho/issues/1325