### PR TITLE
Resolve extension for type / do not add local repo as remote repository

### DIFF
--- a/tycho-its/projects/p2Repository.mirror.mvn.protocol/pom.xml
+++ b/tycho-its/projects/p2Repository.mirror.mvn.protocol/pom.xml
@@ -10,23 +10,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty-version>10.0.26</jetty-version>
+    <tycho-version>6.0.0-SNAPSHOT</tycho-version>
   </properties>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>eclipse-maven-releases</id>
-      <url>https://repo.eclipse.org/content/repositories/releases</url>
-    </pluginRepository>
-
-    <pluginRepository>
-      <id>eclipse-cbi-releases</id>
-      <url>https://repo.eclipse.org/content/repositories/cbi-releases</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <build>
     <plugins>
-
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-publisher-plugin</artifactId>

--- a/tycho-its/projects/p2Repository.mirror.mvn.protocol/pom.xml
+++ b/tycho-its/projects/p2Repository.mirror.mvn.protocol/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.eclipse.oomph.jetty.mirror</groupId>
+  <artifactId>org.eclipse.oomph.jetty.mirror</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jetty-version>10.0.26</jetty-version>
+  </properties>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>eclipse-maven-releases</id>
+      <url>https://repo.eclipse.org/content/repositories/releases</url>
+    </pluginRepository>
+
+    <pluginRepository>
+      <id>eclipse-cbi-releases</id>
+      <url>https://repo.eclipse.org/content/repositories/cbi-releases</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-publisher-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho.extras</groupId>
+        <artifactId>tycho-p2-extras-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>mirror</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <source>
+            <repository>
+              <id>jetty</id>
+              <layout>p2</layout>
+              <url>mvn:org.eclipse.jetty:jetty-p2:${jetty-version}:zip:p2site</url>
+            </repository>
+          </source>
+          <compress>true</compress>
+          <xzCompress>true</xzCompress>
+          <keepNonXzIndexFiles>false</keepNonXzIndexFiles>
+          <followStrictOnly>true</followStrictOnly>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorMvnProtocolTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorMvnProtocolTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ed Merks and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Ed Merks - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.p2Repository;
+
+import java.util.List;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class P2RepositoryMirrorMvnProtocolTest extends AbstractTychoIntegrationTest {
+
+	/**
+	 * Tests whether Tycho is able to recover from a bad mirror repository. If
+	 * multiple mirrors are specified for a repository, Tycho might be able to
+	 * continue by requesting an artifact from a different mirror, depending on the
+	 * error code returned by Equinox.
+	 */
+	@Test
+	public void testMirrorMvnProtocol() throws Exception {
+		Verifier verifier = getVerifier("p2Repository.mirror.mvn.protocol", false);
+		verifier.executeGoals(List.of("verify"));
+		verifier.verifyErrorFreeLog();
+	}
+}


### PR DESCRIPTION
Currently it can happen that a _type_ instead of an _extension_ is
passed to the mvn protocol and then it fails to download. For example
maven-plugin must map to jar (same for eclipse-plugin). Also adding the
local repository will confuse the maven resolver.

This now do the following:
1) resolve the type into an extension before passing it as a resolver
artifact
2) do not add the local repository to the repositories of the request
3) simplify testcase / add default tycho-version property to not confuse
m2e (will be overridden anyways)