### PR TITLE
Replace snapshot by qualifier for the artifact key of target projects

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/TargetPlatformProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/TargetPlatformProject.java
@@ -57,7 +57,9 @@ public class TargetPlatformProject extends AbstractTychoProject {
 
     @Override
     public ArtifactKey getArtifactKey(ReactorProject project) {
-        return new DefaultArtifactKey("target", project.getArtifactId(), project.getVersion());
+        String version = project.getVersion();
+        version = version.replace(TychoConstants.SUFFIX_SNAPSHOT, TychoConstants.SUFFIX_QUALIFIER);
+        return new DefaultArtifactKey("target", project.getArtifactId(), version);
     }
 
     @Override


### PR DESCRIPTION
Tycho assumes that TychoProject.getArtifactKey(ReactorProject) returns something that points to OSGi and has an OSGi parseable version, but TargetPlatformProject currently just returns the plain maven version what can lead to exceptions in some cases.

This now simply replace -SNAPSHOT with .qualifier for comptibilty reasons with other implementations.

FYI @hd42 