### PR TITLE
Also handle invalid version in fallback branch

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryImpl.java
@@ -343,7 +343,11 @@ public class TargetPlatformFactoryImpl implements TargetPlatformFactory {
             } catch (IllegalArgumentException ex) {
             }
         }
-        return version.map(Version::parseVersion).orElse(DEFAULT_P2_ADVICE_VERSION);
+        try {
+            return version.map(Version::parseVersion).orElse(DEFAULT_P2_ADVICE_VERSION);
+        } catch (IllegalArgumentException ex) {
+            return DEFAULT_P2_ADVICE_VERSION;
+        }
     }
 
     private List<MavenArtifactKey> getMissingJunitBundles(ReactorProject project, Set<IInstallableUnit> externalUIs) {


### PR DESCRIPTION
Currently during gathering of p2inf units they can in some rare cases fail to parse a version, e.g. if one uses

`<qualifiedVersion>${unqualifiedVersion}.${buildQualifier}</qualifiedVersion>`

that is only later provided by `build-helper-maven-plugin:parse-version`

We already handle the case the artifactkey version can not be parsed, but the same issue can arise a little bit lower then in the fallback.

This now catches the issue there as well and then return the default p2 advice version as a last resort.

FYI @hd42 