### PR TITLE
Print the equinox logfile to the log if error occurs in director

### DIFF
--- a/sisu-osgi/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/internal/EquinoxInstallationLaunchConfiguration.java
+++ b/sisu-osgi/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/internal/EquinoxInstallationLaunchConfiguration.java
@@ -35,9 +35,12 @@ public class EquinoxInstallationLaunchConfiguration implements LaunchConfigurati
     private final File equinoxDirectory;
     private final String[] programArguments;
     private File launcherJar;
+    private File logfileLocation;
 
-    public EquinoxInstallationLaunchConfiguration(File equinoxDirectory, List<String> programArguments) {
+    public EquinoxInstallationLaunchConfiguration(File equinoxDirectory, File logfileLocation,
+            List<String> programArguments) {
         this.equinoxDirectory = equinoxDirectory;
+        this.logfileLocation = logfileLocation;
         this.programArguments = programArguments.toArray(new String[0]);
     }
 
@@ -112,6 +115,9 @@ public class EquinoxInstallationLaunchConfiguration implements LaunchConfigurati
 
     @Override
     public String[] getVMArguments() {
+        if (logfileLocation != null) {
+            return new String[] { "-Dosgi.logfile=" + logfileLocation.getAbsolutePath() };
+        }
         return new String[0];
     }
 

--- a/tycho-its/projects/product.metaRequirements/touchpoint/src/org/eclipse/tycho/its/CustomTouchpointAction.java
+++ b/tycho-its/projects/product.metaRequirements/touchpoint/src/org/eclipse/tycho/its/CustomTouchpointAction.java
@@ -17,12 +17,21 @@ import java.util.Map;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.p2.engine.spi.ProvisioningAction;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 public class CustomTouchpointAction extends ProvisioningAction {
 
     @Override
     public IStatus execute(Map<String, Object> parameters) {
         System.out.println("The custom touchpoint action has been executed");
+		BundleContext bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
+		Bundle[] bundles = bundleContext.getBundles();
+		for (Bundle bundle : bundles) {
+			System.out
+					.println(bundle.getSymbolicName() + " " + bundle.getVersion() + " [" + bundle.getLocation() + "]");
+		}
         return Status.OK_STATUS;
     }
 


### PR DESCRIPTION
When the call to the director application fails it is not always clear what is the reason of the failure, the log then mentions a file to look at but thats often not easily accessible on CI systems.

Because of this, we now specify an own logfile name in the director call and if an error occurs print the content to the log for easier investigation.