### PR TITLE
Automatically derive EE in UpdateProductMojo

### DIFF
--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateProductMojo.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/UpdateProductMojo.java
@@ -49,14 +49,21 @@ public class UpdateProductMojo extends AbstractUpdateMojo {
     @Parameter(defaultValue = "${project.artifactId}.product")
     private File productFile;
 
-    @Parameter(defaultValue = "JavaSE-21")
+    @Parameter()
     private String executionEnvironment;
 
     @Component
     private P2ResolverFactory factory;
 
     String getExecutionEnvironment() {
+        if (executionEnvironment == null || executionEnvironment.isBlank()) {
+            return getDefaultExecutionEnvironment();
+        }
         return executionEnvironment;
+    }
+
+    String getDefaultExecutionEnvironment() {
+        return "JavaSE-" + Runtime.version().feature();
     }
 
     P2Resolver createResolver() {


### PR DESCRIPTION
Currently we maintain the default EE in code, but this requires adjustments from time to time.

This now derives the default from the java version used to run Tycho.