### PR TITLE
Add inner jars parameter

### DIFF
--- a/tycho-sbom-plugin/src/main/java/org/eclipse/tycho/sbom/plugin/GeneratorMojo.java
+++ b/tycho-sbom-plugin/src/main/java/org/eclipse/tycho/sbom/plugin/GeneratorMojo.java
@@ -108,6 +108,9 @@ public class GeneratorMojo extends AbstractMojo {
 	@Parameter(property = "p2sources")
 	private List<String> p2sources;
 
+	@Parameter(name = "process-bundle-classpath")
+	private boolean processBundleClasspath;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		if (installations == null && installation == null) {
@@ -157,6 +160,9 @@ public class GeneratorMojo extends AbstractMojo {
 		}
 		if (centralsearch) {
 			arguments.add("-central-search");
+		}
+		if (processBundleClasspath) {
+			arguments.add("-process-bundle-classpath");
 		}
 		if (p2sources != null && !p2sources.isEmpty()) {
 			arguments.add("-p2sources");


### PR DESCRIPTION
This pull request adds support for a new configuration option in the `GeneratorMojo` class to control whether the bundle classpath should be processed. This includes introducing a new parameter and updating the command-line arguments accordingly.

New feature: Bundle classpath processing

* Added a new boolean parameter `process-bundle-classpath` to the `GeneratorMojo` class, allowing users to enable or disable processing of the bundle classpath.
* Updated the `execute` method to append the `-process-bundle-classpath` argument when the new parameter is set.