### PR TITLE
Add JUnit 6 provider support

### DIFF
--- a/tycho-its/projects/tycho-surefire-plugin/junit6/basic/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-surefire-plugin/junit6/basic/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: JUnit6 Test Plug-in
+Bundle-SymbolicName: bundle.test.junit6
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Import-Package: org.junit.jupiter.api;version="[6.0, 7.0)",
+ org.junit.jupiter.params;version="[6.0, 7.0)",
+ org.junit.jupiter.params.provider;version="[6.0, 7.0)"

--- a/tycho-its/projects/tycho-surefire-plugin/junit6/basic/build.properties
+++ b/tycho-its/projects/tycho-surefire-plugin/junit6/basic/build.properties
@@ -1,0 +1,3 @@
+source.. = src/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/tycho-surefire-plugin/junit6/basic/pom.xml
+++ b/tycho-its/projects/tycho-surefire-plugin/junit6/basic/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eclipse.tycho.tycho-its.surefire-junit6</groupId>
+  <artifactId>bundle.test.junit6</artifactId>
+  <packaging>eclipse-test-plugin</packaging>
+  <version>1.0.0</version>
+  
+  <properties>
+  	<tycho-version>6.0.0-SNAPSHOT</tycho-version>
+  </properties>
+  
+  <repositories>
+    <repository>
+      <id>oxygen</id>
+      <layout>p2</layout>
+      <url>${target-platform}</url>
+    </repository>
+  </repositories>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <providerHint>junit6</providerHint>
+          <excludedGroups>slow</excludedGroups>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tycho-its/projects/tycho-surefire-plugin/junit6/basic/src/bundle/test/JUnit6Test.java
+++ b/tycho-its/projects/tycho-surefire-plugin/junit6/basic/src/bundle/test/JUnit6Test.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse Foundation and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+package bundle.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class JUnit6Test {
+
+    @Test
+    @DisplayName("My 1st JUnit 6 test!")
+    void myFirstJUnit6Test(TestInfo testInfo) {
+        assertEquals(2, 1+1, "1 + 1 should equal 2");
+        assertEquals("My 1st JUnit 6 test!", testInfo.getDisplayName(), () -> "TestInfo is injected correctly");
+    }
+
+    @Test
+    @Tag("slow")
+    void slowJUnit6Test() {
+        assertEquals(2, 1+1, "1 + 1 should equal 2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "one", "two" })
+    void parameterizedJUnit6Test(String input) {
+        assertEquals(3, input.length(), "input length should be 3");
+    }
+
+    @RepeatedTest(3)
+    void repeatedJUnit6Test() {
+        assertEquals(2, 1+1, "1 + 1 should equal 2");
+    }
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit6Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit6Test.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse Foundation and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.surefire;
+
+import static org.eclipse.tycho.test.util.SurefireUtil.assertNumberOfSuccessfulTests;
+import static org.eclipse.tycho.test.util.SurefireUtil.assertTestMethodWasSuccessfullyExecuted;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+public class JUnit6Test extends AbstractTychoIntegrationTest {
+
+	/**
+	 * Tests that the JUnit 6 provider can be explicitly selected using
+	 * providerHint. Since JUnit 6 doesn't exist yet, this test uses JUnit 5.x
+	 * libraries with the junit6 provider hint to verify that the provider
+	 * infrastructure is in place.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testJUnit6ProviderHint() throws Exception {
+		final Verifier verifier = getVerifier("/tycho-surefire-plugin/junit6/basic", false);
+		verifier.addCliOption("-Dtarget-platform=https:///download.eclipse.org/releases/2025-12");
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+		final String projectBasedir = verifier.getBasedir();
+		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit6Test", "My 1st JUnit 6 test!");
+		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit6Test",
+				"parameterizedJUnit6Test(String)[1] \"one\"");
+		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit6Test",
+				"parameterizedJUnit6Test(String)[2] \"two\"");
+		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit6Test",
+				"repeatedJUnit6Test() repetition 1 of 3");
+		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit6Test",
+				"repeatedJUnit6Test() repetition 2 of 3");
+		assertTestMethodWasSuccessfullyExecuted(projectBasedir, "bundle.test.JUnit6Test",
+				"repeatedJUnit6Test() repetition 3 of 3");
+		// make sure test tagged as 'slow' was skipped
+		assertNumberOfSuccessfulTests(projectBasedir, "bundle.test.JUnit6Test", 6);
+	}
+
+}

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/.gitignore
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/.gitignore
@@ -1,0 +1,7 @@
+# override global rule
+!/.settings/
+
+# only include specified files
+/.settings/*
+!/.settings/org.eclipse.jdt.core.prefs
+!/.settings/org.eclipse.jdt.ui.prefs

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/bnd.bnd
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/bnd.bnd
@@ -1,0 +1,17 @@
+# We only import some of the junit packages here to create a requirement on them and to allow
+# to load them if the test bundle itself does not import them already.
+# Apart from that the content in this bundle is only used to bootstrap
+# surefire and we include all we need for that as it does not comply with OSGi rules.
+Import-Package: \
+ org.junit.platform.launcher, \
+ org.junit.jupiter.api, \
+ org.junit.jupiter.engine, \
+ org.junit.platform.suite.api, \
+ org.junit.platform.suite.engine;status=INTERNAL, \
+ java.*
+Fragment-Host: org.eclipse.tycho.surefire.osgibooter
+# The JUnit Runner is still compatible with Java 1.8, as all included upstream dependencies are.
+# (This is checked in the tycho-surefire-plugin's pom.xml. See execution 'enforce-runtime-jdk-compatibility'.)
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+-removeheaders: Tool, Bnd-*, Created-By, Private-Package
+-fixupmessages "Classes found in the wrong directory"; is:=warning

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/pom.xml
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright (c) 2025 Eclipse Foundation and others.
+ - All rights reserved. This program and the accompanying materials
+ - are made available under the terms of the Eclipse Public License v1.0
+ - which accompanies this distribution, and is available at
+ - https://www.eclipse.org/legal/epl-v10.html
+ -
+ - Contributors:
+ -    Eclipse Foundation - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-surefire</artifactId>
+		<version>6.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>org.eclipse.tycho.surefire.junit6</artifactId>
+	<packaging>jar</packaging>
+	<name>Tycho Surefire OSGi JUnit 6.x Runner</name>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<configuration>
+					<excludes>META-INF/**</excludes>
+					<artifactItems>
+						<artifactItem>
+							<groupId>org.apache.maven.surefire</groupId>
+							<artifactId>surefire-junit-platform</artifactId>
+							<version>${surefire-version}</version>
+						</artifactItem>
+					</artifactItems>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
@@ -1,0 +1,2 @@
+org.junit.jupiter.engine.JupiterTestEngine
+org.junit.platform.suite.engine.SuiteTestEngine

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/about.html
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/about.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 25, 2012</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="https://www.eclipse.org/legal/epl-v10.html">https://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="https://www.eclipse.org">https://www.eclipse.org</a>.</p>
+		
+<h3>Third Party Content</h3>
+<p>The Content includes items that have been sourced from third parties as set out below. If you 
+did not receive this Content directly from the Eclipse Foundation, the following is provided 
+for informational purposes only, and you should look to the Redistributor&rsquo;s license for 
+terms and conditions of use.</p>
+
+<h4>JUnit Platform Surefire Provider ${surefire-version}</h4>
+<p>The plug-in includes JUnit Platform Surefire Provider ${surefire-version} developed by the Apache Software Foundation.  Therefore:</p>
+
+<blockquote>
+This product includes software developed by the Apache Software Foundation (<a href="http://www.apache.org/">http://www.apache.org/</a>).
+</blockquote>
+
+<p>JUnit Platform Surefire Provider ${surefire-version} is:</p>
+
+<blockquote>Copyright (c) 2004-2011 The Apache Software Foundation. All rights reserved.</blockquote>
+
+<p>Your use of the JUnit Platform Surefire Provider code is subject to the terms and conditions of the Apache Software License 2.0.  A copy of the license is contained
+in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a>.
+
+<p>The Apache attribution <a href="about_files/NOTICE">NOTICE</a> file is included with the Content in accordance with 4d of the Apache License, Version 2.0.</p>
+
+<p>Examples and documentation as well as updated source code for SureFire JUnitCore Runner is available at <a href="http://maven.apache.org/surefire/">http://maven.apache.org/surefire/</a>.</p>
+
+</body>
+</html>

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/about_files/LICENSE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/about_files/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/about_files/LICENSE.md
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/about_files/LICENSE.md
@@ -1,0 +1,98 @@
+Eclipse Public License - v 2.0
+==============================
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+### 1. Definitions
+
+“Contribution” means:
+* **a)** in the case of the initial Contributor, the initial content Distributed under this Agreement, and
+* **b)** in the case of each subsequent Contributor:
+	* **i)** changes to the Program, and
+	* **ii)** additions to the Program;
+where such changes and/or additions to the Program originate from and are Distributed by that particular Contributor. A Contribution “originates” from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include changes or additions to the Program that are not Modified Works.
+
+“Contributor” means any person or entity that Distributes the Program.
+
+“Licensed Patents” mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+“Program” means the Contributions Distributed in accordance with this Agreement.
+
+“Recipient” means anyone who receives the Program under this Agreement or any Secondary License (as applicable), including Contributors.
+
+“Derivative Works” shall mean any work, whether in Source Code or other form, that is based on (or derived from) the Program and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship.
+
+“Modified Works” shall mean any work in Source Code or other form that results from an addition to, deletion from, or modification of the contents of the Program, including, for purposes of clarity any new file in Source Code form that contains any contents of the Program. Modified Works shall not include works that contain only declarations, interfaces, types, classes, structures, or files of the Program solely in each case in order to link to, bind by name, or subclass the Program or Modified Works thereof.
+
+“Distribute” means the acts of **a)** distributing or **b)** making available in any manner that enables the transfer of a copy.
+
+“Source Code” means the form of a Program preferred for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+“Secondary License” means either the GNU General Public License, Version 2.0, or any later versions of that license, including any exceptions or additional permissions as identified by the initial Contributor.
+
+### 2. Grant of Rights
+
+**a)** Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, Distribute and sublicense the Contribution of such Contributor, if any, and such Derivative Works.
+
+**b)** Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in Source Code or other form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+
+**c)** Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to Distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+
+**d)** Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+
+**e)** Notwithstanding the terms of any Secondary License, no Contributor makes additional grants to any Recipient (other than those set forth in this Agreement) as a result of such Recipient's receipt of the Program under the terms of a Secondary License (if permitted under the terms of Section 3).
+
+### 3. Requirements
+
+**3.1** If a Contributor Distributes the Program in any form, then:
+
+* **a)** the Program must also be made available as Source Code, in accordance with section 3.2, and the Contributor must accompany the Program with a statement that the Source Code for the Program is available under this Agreement, and informs Recipients how to obtain it in a reasonable manner on or through a medium customarily used for software exchange; and
+
+* **b)** the Contributor may Distribute the Program under a license different than this Agreement, provided that such license:
+	* **i)** effectively disclaims on behalf of all other Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+	* **ii)** effectively excludes on behalf of all other Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+	* **iii)** does not attempt to limit or alter the recipients' rights in the Source Code under section 3.2; and
+	* **iv)** requires any subsequent distribution of the Program by any party to be under a license that satisfies the requirements of this section 3.
+
+**3.2** When the Program is Distributed as Source Code:
+
+* **a)** it must be made available under this Agreement, or if the Program **(i)** is combined with other material in a separate file or files made available under a Secondary License, and **(ii)** the initial Contributor attached to the Source Code the notice described in Exhibit A of this Agreement, then the Program may be made available under the terms of such Secondary Licenses, and
+* **b)** a copy of this Agreement must be included with each copy of the Program.
+
+**3.3** Contributors may not remove or alter any copyright, patent, trademark, attribution notices, disclaimers of warranty, or limitations of liability (“notices”) contained within the Program from any copy of the Program which they Distribute, provided that Contributors may add their own appropriate notices.
+
+### 4. Commercial Distribution
+
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (“Commercial Contributor”) hereby agrees to defend and indemnify every other Contributor (“Indemnified Contributor”) against any losses, damages and costs (collectively “Losses”) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: **a)** promptly notify the Commercial Contributor in writing of such claim, and **b)** allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+### 5. No Warranty
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+### 6. Disclaimer of Liability
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+### 7. General
+
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be Distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to Distribute the Program (including its Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved. Nothing in this Agreement is intended to be enforceable by any entity that is not a Contributor or Recipient. No third-party beneficiary rights are created under this Agreement.
+
+#### Exhibit A - Form of Secondary Licenses Notice
+
+> “This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: {name license(s), version(s), and exceptions or additional permissions here}.”
+
+Simply including a copy of this Agreement, including this Exhibit A is not sufficient to license the Source Code under Secondary Licenses.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/src/main/resources/about_files/NOTICE
@@ -1,0 +1,8 @@
+
+Shared Java 5 Provider Base
+Copyright 2004-2015 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+

--- a/tycho-surefire/pom.xml
+++ b/tycho-surefire/pom.xml
@@ -25,6 +25,7 @@
 		<module>org.eclipse.tycho.surefire.osgibooter</module>
 		<module>org.eclipse.tycho.surefire.junit4</module>
 		<module>org.eclipse.tycho.surefire.junit5</module>
+		<module>org.eclipse.tycho.surefire.junit6</module>
 		<module>org.eclipse.tycho.surefire.junit5.vintage</module>
 		<module>org.eclipse.tycho.surefire.junit5.vintage.internal</module>
 		<module>org.eclipse.tycho.surefire.testng</module>

--- a/tycho-surefire/tycho-surefire-plugin/pom.xml
+++ b/tycho-surefire/tycho-surefire-plugin/pom.xml
@@ -114,6 +114,18 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>org.eclipse.tycho.surefire.junit6</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>org.eclipse.tycho.surefire.junit5.vintage</artifactId>
 			<version>${project.version}</version>
 			<scope>runtime</scope>

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit6Provider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/JUnit6Provider.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse Foundation and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tycho.surefire.provider.impl;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.tycho.surefire.provider.impl.DefaultProviderHelper.newDependency;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.inject.Named;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.tycho.ClasspathEntry;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+
+@Named("junit6")
+public class JUnit6Provider extends AbstractJUnitProvider {
+
+    private static final VersionRange JUNIT6_VERSION_RANGE = new VersionRange("[6,7)");
+    private static final VersionRange JUNIT5_VERSION_RANGE = new VersionRange("[5,6)");
+
+    private static final Version VERSION = Version.parseVersion("6");
+
+    private static final Set<String> JUNIT6_BUNDLES = Set.of("org.junit.jupiter.api", "junit-jupiter-api");
+
+    @Override
+    public Version getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public List<Dependency> getRequiredArtifacts() {
+        return singletonList(newDependency("org.eclipse.tycho.surefire.junit6"));
+    }
+
+    @Override
+    public boolean isEnabled(MavenProject project, List<ClasspathEntry> testBundleClassPath,
+            Properties surefireProperties) {
+        return isJUnit6(project, testBundleClassPath, JUNIT6_VERSION_RANGE)
+                && !AbstractJUnit5Provider.isJUnit5(project, testBundleClassPath, JUNIT5_VERSION_RANGE)
+                && !JUnit4Provider.isJUnit4(project, testBundleClassPath);
+    }
+
+    static boolean isJUnit6(MavenProject project, List<ClasspathEntry> testBundleClassPath, VersionRange versionRange) {
+        return isEnabled(project, testBundleClassPath, JUNIT6_BUNDLES, versionRange);
+    }
+
+    @Override
+    public VersionRange getVersionRange() {
+        return JUNIT6_VERSION_RANGE;
+    }
+
+    @Override
+    public String getSurefireProviderClassName() {
+        return "org.apache.maven.surefire.junitplatform.JUnitPlatformProvider";
+    }
+}

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/JUnit6ProviderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/JUnit6ProviderTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse Foundation and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tycho.surefire.provider.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class JUnit6ProviderTest extends AbstractJUnitProviderTest {
+
+    @Test
+    public void testEnabled() throws Exception {
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit.jupiter.api:6.0.0"), new Properties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("junit-jupiter-api:6.1.0"), new Properties()));
+        assertTrue(junitProvider.isEnabled(null, classPath("org.junit.jupiter.api:6.5.0"), new Properties()));
+    }
+
+    @Test
+    public void testDisabled() throws Exception {
+        assertFalse(junitProvider.isEnabled(null, classPath("foo:1.0"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit:4.8.2"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit.jupiter.api:5.0"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("junit-jupiter-api:5.9.0"), new Properties()));
+        assertFalse(junitProvider.isEnabled(null, classPath("org.junit.jupiter.api:7.0"), new Properties()));
+    }
+
+    @Override
+    protected AbstractJUnitProvider createJUnitProvider() {
+        return new JUnit6Provider();
+    }
+
+}


### PR DESCRIPTION
Basic structure derived from
- https://github.com/eclipse-tycho/tycho/pull/5413

but there is a lot more to do. e.g. currently the test does not really uses JUnit 6 ... we need a target with JUnit 6 and providers need to use proper ranges excluding each other.

FYI @akurtakov 