### PR TITLE
Support exchangeable OSGi framework implementations in junit-platform

### DIFF
--- a/tycho-spi/src/main/java/org/eclipse/tycho/osgi/OSGiFramework.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/osgi/OSGiFramework.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.osgi;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.function.Function;
+
+import org.osgi.framework.BundleContext;
+
+/**
+ * A launched Framework that allows to control the state of the OSGi Framework
+ */
+public interface OSGiFramework extends AutoCloseable {
+
+    /**
+     * Runs the given action in the framework, the action will be supplied with the a bundle context
+     * to perform its action and return a result. Depending on framework type it might be required
+     * to serialize the code, execute it in a remote process and serialize its return type. It
+     * should therefore be ensured to use minimal API and all call parameters to be properly
+     * encoded.
+     * 
+     * @param <R>
+     * @param <Action>
+     * @param action
+     * @return the result of the call
+     * @throws IOException
+     *             if executing the call fails
+     */
+    <Action extends Function<BundleContext, R> & Serializable, R extends Serializable> R runInFramework(Action action)
+            throws IOException;
+
+    @Override
+    void close();
+}

--- a/tycho-spi/src/main/java/org/eclipse/tycho/osgi/OSGiFrameworkLauncher.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/osgi/OSGiFrameworkLauncher.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.osgi;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.maven.project.MavenProject;
+
+/**
+ * A {@link OSGiFrameworkLauncher} allows to start an OSGi framework and execute some code inside
+ * it.
+ */
+public interface OSGiFrameworkLauncher {
+
+    /**
+     * Boolean property that can be passed to the {@link #launchFramework(MavenProject, Map)} and is
+     * interpreted in the way that all directly executed code is considered standalone executable in
+     * a way that it does not need to import any classes from other bundles except the OSGi and Java
+     * API. Launcher implementation might use this to perform more efficient execution.
+     */
+    static String STANDALONE = "OSGiFrameworkLauncher.standalone";
+
+    /**
+     * Launch a new Framework using the given properties, see <a href=
+     * "https://docs.osgi.org/specification/osgi.core/8.0.0/framework.lifecycle.html#framework.lifecycle.launchingproperties">Launching
+     * Properties</a> for standardized properties to use, while custom properties might be
+     * supported. Especially the <code>org.osgi.framework.storage</code> should usually be defined
+     * to allow the launcher to store files. Apart from that the launcher implementation should
+     * choose sensible defaults for the provided type of launcher.
+     * 
+     * @param project
+     *            the maven project this framework should be created for, some launchers might
+     *            support to be created without a project
+     * @param properties
+     * 
+     * @return the launched Framework
+     * @throws IOException
+     *             if creation of the framework fails due to I/O problems
+     */
+    OSGiFramework launchFramework(MavenProject project, Map<String, String> properties) throws IOException;
+}

--- a/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/EmbeddedFrameworkLauncher.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/EmbeddedFrameworkLauncher.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.osgi.impl;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.osgi.OSGiFramework;
+import org.eclipse.tycho.osgi.OSGiFrameworkLauncher;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
+import org.osgi.framework.launch.Framework;
+import org.osgi.framework.launch.FrameworkFactory;
+
+/**
+ * The {@link EmbeddedFrameworkLauncher} launches a framework in the same JVM
+ */
+@Component(role = OSGiFrameworkLauncher.class, hint = "embedded")
+public class EmbeddedFrameworkLauncher implements OSGiFrameworkLauncher {
+
+    @Override
+    public OSGiFramework launchFramework(MavenProject project, Map<String, String> properties) throws IOException {
+        if (properties == null) {
+            properties = Map.of();
+        }
+        String storage = properties.get(Constants.FRAMEWORK_STORAGE);
+        Path workDir;
+        if (storage != null) {
+            workDir = Path.of(storage);
+        } else {
+            if (project == null) {
+                workDir = Files.createTempDirectory("embedded");
+            } else {
+                workDir = Files.createTempDirectory(Path.of(project.getBuild().getDirectory()), "embedded");
+            }
+        }
+        cleanWorkDir(workDir);
+        Files.createDirectories(workDir);
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("osgi.configuration.area", workDir.resolve("configuration").toAbsolutePath().toString());
+        map.put("osgi.instance.area", workDir.resolve("data").toAbsolutePath().toString());
+        map.put("osgi.compatibility.bootdelegation", "true");
+        map.put("osgi.classloader.copy.natives", "true");
+        map.put("osgi.framework.useSystemProperties", "false");
+        map.put("eclipse.ignoreApp", "true");
+        map.put("osgi.noShutdown", "true");
+        String sl = properties.get(Constants.FRAMEWORK_BEGINNING_STARTLEVEL);
+        if (sl != null) {
+            map.put("osgi.bundles.defaultStartLevel", sl);
+        }
+        if (properties != null) {
+            map.putAll(properties);
+        }
+        map.remove(Constants.FRAMEWORK_STORAGE);
+        ServiceLoader<FrameworkFactory> loader = ServiceLoader.load(FrameworkFactory.class,
+                getClass().getClassLoader());
+        FrameworkFactory factory = loader.findFirst()
+                .orElseThrow(() -> new IOException("No FrameworkFactory found on classpath"));
+        Framework framework = factory.newFramework(map);
+        try {
+            framework.init();
+        } catch (BundleException e) {
+            throw new IOException("Initialize the framework failed!", e);
+        }
+        try {
+            framework.start();
+        } catch (BundleException e) {
+            throw new IOException("Start the framework failed!", e);
+        }
+        return new EmbeddedOSGiFramework(framework, Boolean.parseBoolean(properties.get(STANDALONE)));
+    }
+
+    private void cleanWorkDir(Path workDir) {
+        try {
+            Files.walkFileTree(workDir, new FileVisitor<Path>() {
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+        }
+    }
+
+}

--- a/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/EmbeddedOSGiFramework.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/EmbeddedOSGiFramework.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.osgi.impl;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.eclipse.tycho.osgi.OSGiFramework;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.launch.Framework;
+
+class EmbeddedOSGiFramework implements OSGiFramework {
+
+    private Framework framework;
+    private boolean standalone;
+
+    EmbeddedOSGiFramework(Framework framework, boolean standalone) {
+        this.framework = framework;
+        this.standalone = standalone;
+    }
+
+    @Override
+    public <Action extends Function<BundleContext, R> & Serializable, R extends Serializable> R runInFramework(
+            Action action) throws IOException {
+        if (standalone) {
+            //for standalone case we can just call code directly and pass the system bundle context
+            return action.apply(framework.getBundleContext());
+        }
+        throw new IOException("not implemented yet");
+    }
+
+    @Override
+    public void close() {
+        try {
+            framework.stop();
+        } catch (BundleException e) {
+        }
+        try {
+            framework.waitForStop(TimeUnit.SECONDS.toMillis(30));
+        } catch (InterruptedException e) {
+        }
+    }
+
+}

--- a/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformFailureException.java
+++ b/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformFailureException.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.testing.plugin;
+
+public class JUnitPlatformFailureException extends Exception {
+	private static final long serialVersionUID = 1L;
+
+	public JUnitPlatformFailureException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public JUnitPlatformFailureException(String message) {
+		super(message);
+	}
+
+}

--- a/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformMojo.java
+++ b/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformMojo.java
@@ -15,26 +15,14 @@ package org.eclipse.tycho.testing.plugin;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.spi.ToolProvider;
-import java.util.stream.StreamSupport;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
@@ -48,21 +36,9 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.core.TychoProjectManager;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleException;
-import org.osgi.framework.FrameworkEvent;
-import org.osgi.framework.FrameworkListener;
-import org.osgi.framework.launch.Framework;
-import org.osgi.framework.launch.FrameworkFactory;
-import org.osgi.framework.namespace.HostNamespace;
-import org.osgi.framework.startlevel.BundleStartLevel;
-import org.osgi.framework.startlevel.FrameworkStartLevel;
-import org.osgi.framework.wiring.BundleRevision;
-import org.osgi.framework.wiring.BundleRevisions;
-import org.osgi.framework.wiring.BundleWire;
-import org.osgi.framework.wiring.BundleWiring;
-import org.osgi.framework.wiring.FrameworkWiring;
+import org.eclipse.tycho.osgi.OSGiFramework;
+import org.eclipse.tycho.osgi.OSGiFrameworkLauncher;
+import org.osgi.framework.Constants;
 
 /**
  * Execute tests using the JUnit Platform inside an OSGi Framework using the
@@ -72,13 +48,14 @@ import org.osgi.framework.wiring.FrameworkWiring;
 @Mojo(name = "junit-platform", threadSafe = true, defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresProject = true, requiresDependencyCollection = ResolutionScope.TEST)
 public class JUnitPlatformMojo extends AbstractMojo {
 
-	private static final String JUNIT_TOOLPROVIDER_NAME = "junit";
-
 	@Component
 	TychoProjectManager projectManager;
 
 	@Component
 	MavenProject mavenProject;
+
+	@Component
+	Map<String, OSGiFrameworkLauncher> launchers;
 
 	/**
 	 * Select specific test classes to execute. Each entry should be a fully
@@ -178,7 +155,7 @@ public class JUnitPlatformMojo extends AbstractMojo {
 	/**
 	 * Fail and return exit status code 2 if no tests are found.
 	 */
-	@Parameter(property = "fail-if-no-tests", defaultValue = "false")
+	@Parameter(property = "fail-if-no-tests", defaultValue = "true")
 	private boolean failIfNoTests;
 
 	/**
@@ -203,6 +180,9 @@ public class JUnitPlatformMojo extends AbstractMojo {
 	@Parameter
 	private Map<String, String> config;
 
+	/**
+	 * Additional OSGi framework properties to use when executing the test
+	 */
 	@Parameter
 	private Map<String, String> frameworkProperties = new LinkedHashMap<>();
 
@@ -239,6 +219,9 @@ public class JUnitPlatformMojo extends AbstractMojo {
 	@Parameter(property = "junit-platform.skip")
 	private boolean skip;
 
+	@Parameter(defaultValue = "embedded", property = "junit-platform.launchType")
+	private String launchType;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		Log log = getLog();
@@ -265,338 +248,165 @@ public class JUnitPlatformMojo extends AbstractMojo {
 		for (Path path : projectDependencies) {
 			log.debug(path.getFileName().toString());
 		}
-		Map<String, String> frameworkProperties = getFrameworkProperties(
-				Path.of(mavenProject.getBuild().getDirectory()).resolve("work"));
-		frameworkProperties.putAll(this.frameworkProperties);
-		frameworkProperties.put("eclipse.ignoreApp", "true");
-		frameworkProperties.put("osgi.noShutdown", "true");
-		ServiceLoader<FrameworkFactory> loader = ServiceLoader.load(FrameworkFactory.class,
-				getClass().getClassLoader());
-		FrameworkFactory factory = loader.findFirst()
-				.orElseThrow(() -> new MojoExecutionException("No ConnectFrameworkFactory found"));
-		Framework framework = factory.newFramework(frameworkProperties);
+		JUnitPlatformRunnerResult runnerResult;
+		try (OSGiFramework framework = launchFramework()) {
+			try {
+				runnerResult = framework.runInFramework(
+						new JUnitPlatformRunner(projectDependencies, mavenProject.getArtifact().getFile().toPath(),
+								applicationStartLevel,
+								extenderStartLevel, startExtender, startupTimout, printBundles, buildArguments()));
+			} catch (IOException | RuntimeException e) {
+				throw new MojoExecutionException("Execute runner failed!", e);
+			}
+		}
+		runnerResult.infoMessages().forEach(log::info);
+		if (log.isDebugEnabled()) {
+			runnerResult.debugMessages().forEach(log::debug);
+		}
+		Exception exception = runnerResult.getException();
+		if (exception == null) {
+			return;
+		}
+		if (exception instanceof JUnitPlatformFailureException jf) {
+			throw new MojoExecutionException(jf.getMessage(), jf.getCause());
+		} else {
+			throw new MojoExecutionException("Runner execution failed!", exception);
+		}
+	}
+
+	private OSGiFramework launchFramework() throws MojoExecutionException {
+		OSGiFrameworkLauncher launcher = launchers.get(launchType);
+		if (launcher == null) {
+			throw new MojoExecutionException("Launch type '" + launchType + "' is not available");
+		}
+		OSGiFramework framework;
 		try {
-			framework.init();
-		} catch (BundleException e) {
-			throw new MojoExecutionException("Initialize the framework failed!", e);
+			framework = launcher.launchFramework(mavenProject, Map.of( //
+					Constants.FRAMEWORK_STORAGE, Path.of(mavenProject.getBuild().getDirectory())
+							.resolve("junit-platform-work").toAbsolutePath().toString(),
+					Constants.FRAMEWORK_BEGINNING_STARTLEVEL, Integer.toString(1),
+					OSGiFrameworkLauncher.STANDALONE, "true")
+			);
+		} catch (Exception e) {
+			throw new MojoExecutionException("Can't launch '" + launchType + "' framework!", e);
 		}
-		try {
-			try {
-				framework.start();
-			} catch (BundleException e) {
-				throw new MojoExecutionException("Start the framework failed!", e);
-			}
-			FrameworkWiring wiring = framework.adapt(FrameworkWiring.class);
-			FrameworkStartLevel startLevel = framework.adapt(FrameworkStartLevel.class);
-			startLevel.setInitialBundleStartLevel(applicationStartLevel);
-			BundleContext systemBundleContext = framework.getBundleContext();
-			log.debug("Install Bundles ...");
-			for (Path path : projectDependencies) {
-				if (path.getFileName().toString().startsWith("org.eclipse.osgi")) {
-					continue;
-				}
-				try {
-					Bundle bundle = systemBundleContext.installBundle(path.toString(), Files.newInputStream(path));
-					log.debug("Installed " + bundle);
-				} catch (BundleException | IOException e) {
-					log.debug(path.getFileName() + ": " + e);
-				}
-			}
-			log.debug("Resolve bundles...");
-			wiring.resolveBundles(null);
-			Bundle[] bundles = systemBundleContext.getBundles();
-			setStartLevels(bundles);
-			CountDownLatch latch = new CountDownLatch(1);
-			startLevel.setStartLevel(applicationStartLevel, new FrameworkListener() {
-
-				@Override
-				public void frameworkEvent(FrameworkEvent event) {
-					latch.countDown();
-				}
-			});
-			try {
-				if (!latch.await(startupTimout, TimeUnit.SECONDS)) {
-					new MojoExecutionException("Framework did not reached the required startlevel in time!");
-				}
-			} catch (InterruptedException e) {
-				return;
-			}
-			printBundleInfo(bundles, printBundles ? log::info : log::debug);
-			Bundle testBundle = findTestProbe(bundles)
-					.orElseThrow(() -> new MojoFailureException("Testprobe not found in Framework"));
-			ToolProvider junit = findToolProvider(testBundle, bundles).orElseThrow(() -> new MojoFailureException(
-					"No compatible tool provider for junit make sure to have defined a matching junit-platform-console in your pom!"));
-			if (isFragment(testBundle)) {
-				testBundle = getHost(testBundle).orElseThrow(
-						() -> new MojoFailureException("Testprobe is a fragment but not attached to any host bundle"));
-			}
-			try {
-				testBundle.start();
-			} catch (BundleException e) {
-				throw new MojoExecutionException("Testprobe " + testBundle + " can not be started!", e);
-			}
-			executeTestWithTestProbe(testBundle, junit, bundles);
-		} finally {
-			try {
-				framework.stop();
-			} catch (BundleException e) {
-				// we can't really do anything or care much here...
-			}
-		}
+		return framework;
 	}
 
-	private Optional<Bundle> findTestProbe(Bundle[] bundles) {
-		File file = mavenProject.getArtifact().getFile();
-		if (file != null) {
-			for (Bundle bundle : bundles) {
-				if (new File(bundle.getLocation()).equals(file)) {
-					return Optional.of(bundle);
-				}
+	private List<String> buildArguments() {
+		List<String> arguments = new ArrayList<>();
+		arguments.add("execute");
+		if (disableBanner) {
+			arguments.add("--disable-banner");
+		}
+		if (selectClass != null) {
+			for (String clz : selectClass) {
+				arguments.add("--select-class");
+				arguments.add(clz);
 			}
 		}
-		return Optional.empty();
-	}
-
-	private void printBundleInfo(Bundle[] bundles, Consumer<? super CharSequence> consumer) {
-		consumer.accept("============ Bundles ==================");
-		Comparator<Bundle> bySymbolicName = Comparator.comparing(Bundle::getSymbolicName,
-				String.CASE_INSENSITIVE_ORDER);
-		Comparator<Bundle> byState = Comparator.comparingInt(Bundle::getState);
-		Arrays.stream(bundles).sorted(byState.thenComparing(bySymbolicName)).forEachOrdered(bundle -> {
-			String state = toBundleState(bundle.getState());
-			consumer.accept(state + " | " + bundle.getSymbolicName() + " (" + bundle.getVersion() + ") at "
-					+ bundle.getLocation());
-		});
-
-	}
-
-	private static String toBundleState(int state) {
-		return switch (state) {
-		case Bundle.ACTIVE -> "ACTIVE   ";
-		case Bundle.INSTALLED -> "INSTALLED";
-		case Bundle.RESOLVED -> "RESOLVED ";
-		case Bundle.STARTING -> "STARTING ";
-		case Bundle.STOPPING -> "STOPPING ";
-		default -> String.valueOf(state);
-		};
-	}
-
-	private void setStartLevels(Bundle[] bundles) {
-		for (Bundle bundle : bundles) {
-			BundleWiring wiring = bundle.adapt(BundleWiring.class);
-			if (wiring != null) {
-				List<BundleWire> providedWires = wiring.getProvidedWires("osgi.extender");
-				if (providedWires.isEmpty()) {
-					continue;
-				}
-				getLog().debug("Found extender bundle " + bundle);
-				BundleStartLevel startLevel = bundle.adapt(BundleStartLevel.class);
-				startLevel.setStartLevel(extenderStartLevel);
-				if (startExtender) {
-					try {
-						bundle.start();
-					} catch (BundleException e) {
-						getLog().debug("Extender bundle " + bundle + " can not be started!", e);
-					}
-				}
+		if (selectMethod != null) {
+			for (String method : selectMethod) {
+				arguments.add("--select-method");
+				arguments.add(method);
 			}
 		}
+		if (selectPackage != null) {
+			for (String pkg : selectPackage) {
+				arguments.add("--select-package");
+				arguments.add(pkg);
+			}
+		}
+		if (selectModule != null) {
+			for (String module : selectModule) {
+				arguments.add("--select-module");
+				arguments.add(module);
+			}
+		}
+		if (selectResource != null) {
+			for (String resource : selectResource) {
+				arguments.add("--select-resource");
+				arguments.add(resource);
+			}
+		}
+		if (selectUri != null) {
+			for (String uri : selectUri) {
+				arguments.add("--select-uri");
+				arguments.add(uri);
+			}
+		}
+		if (scanClasspath) {
+			arguments.add("--scan-classpath");
+			arguments.add(mavenProject.getArtifact().getFile().getAbsolutePath());
+		}
+		if (includeClassname != null) {
+			arguments.add("--include-classname");
+			arguments.add(includeClassname);
+		}
+		if (excludeClassname != null) {
+			arguments.add("--exclude-classname");
+			arguments.add(excludeClassname);
+		}
+		if (includePackage != null) {
+			for (String pkg : includePackage) {
+				arguments.add("--include-package");
+				arguments.add(pkg);
+			}
+		}
+		if (excludePackage != null) {
+			for (String pkg : excludePackage) {
+				arguments.add("--exclude-package");
+				arguments.add(pkg);
+			}
+		}
+		if (includeEngine != null) {
+			for (String engine : includeEngine) {
+				arguments.add("--include-engine");
+				arguments.add(engine);
+			}
+		}
+		if (excludeEngine != null) {
+			for (String engine : excludeEngine) {
+				arguments.add("--exclude-engine");
+				arguments.add(engine);
+			}
+		}
+		if (includeTag != null) {
+			for (String tag : includeTag) {
+				arguments.add("--include-tag");
+				arguments.add(tag);
+			}
+		}
+		if (excludeTag != null) {
+			for (String tag : excludeTag) {
+				arguments.add("--exclude-tag");
+				arguments.add(tag);
+			}
+		}
+		if (config != null) {
+			for (Entry<String, String> entry : config.entrySet()) {
+				arguments.add("--config");
+				arguments.add(String.format("%s=%s", entry.getKey(), entry.getValue()));
+			}
+		}
+		if (details != null) {
+			arguments.add("--details");
+			arguments.add(details);
+		}
+		if (detailsTheme != null) {
+			arguments.add("--details-theme");
+			arguments.add(detailsTheme);
+		}
+		if (singleColor) {
+			arguments.add("--single-color");
+		}
+		arguments.add("--reports-dir");
+		arguments.add(reportsDir.getAbsolutePath());
+		if (failIfNoTests) {
+			arguments.add("--fail-if-no-tests");
+		}
+		return arguments;
 	}
 
-	private Optional<ToolProvider> findToolProvider(Bundle testprobe, Bundle[] bundles) {
-		for (Bundle bundle : bundles) {
-			if (bundle == testprobe) {
-				continue;
-			}
-			try {
-				URL resource = bundle.getResource("META-INF/services/java.util.spi.ToolProvider");
-				if (resource != null) {
-					getLog().debug("Checking " + bundle + " for toolprovider...");
-					BundleWiring wiring = bundle.adapt(BundleWiring.class);
-					if (wiring == null) {
-						return Optional.empty();
-					}
-					ServiceLoader<ToolProvider> sl = ServiceLoader.load(ToolProvider.class, wiring.getClassLoader());
-					Optional<ToolProvider> provider = StreamSupport.stream(sl.spliterator(), false)
-							.filter(p -> p.name().equals(JUNIT_TOOLPROVIDER_NAME)).findFirst();
-					if (provider.isPresent()) {
-						getLog().debug("--> found one: " + provider.get());
-						return provider;
-					}
-				}
-			} catch (Exception e) {
-				// can't use it then!
-			}
-		}
-		return Optional.empty();
-	}
-
-	private void executeTestWithTestProbe(Bundle bundle, ToolProvider junit, Bundle[] bundles)
-			throws MojoFailureException, MojoExecutionException {
-		Thread thread = Thread.currentThread();
-		ClassLoader loader = thread.getContextClassLoader();
-		try {
-			thread.setContextClassLoader(new SPIBundleClassLoader(bundle, bundles, getLog()::debug));
-			List<String> arguments = new ArrayList<>();
-			arguments.add("execute");
-			if (disableBanner) {
-				arguments.add("--disable-banner");
-			}
-			if (selectClass != null) {
-				for (String clz : selectClass) {
-					arguments.add("--select-class");
-					arguments.add(clz);
-				}
-			}
-			if (selectMethod != null) {
-				for (String method : selectMethod) {
-					arguments.add("--select-method");
-					arguments.add(method);
-				}
-			}
-			if (selectPackage != null) {
-				for (String pkg : selectPackage) {
-					arguments.add("--select-package");
-					arguments.add(pkg);
-				}
-			}
-			if (selectModule != null) {
-				for (String module : selectModule) {
-					arguments.add("--select-module");
-					arguments.add(module);
-				}
-			}
-			if (selectResource != null) {
-				for (String resource : selectResource) {
-					arguments.add("--select-resource");
-					arguments.add(resource);
-				}
-			}
-			if (selectUri != null) {
-				for (String uri : selectUri) {
-					arguments.add("--select-uri");
-					arguments.add(uri);
-				}
-			}
-			if (scanClasspath) {
-				arguments.add("--scan-classpath");
-				arguments.add(mavenProject.getArtifact().getFile().getAbsolutePath());
-			}
-			if (includeClassname != null) {
-				arguments.add("--include-classname");
-				arguments.add(includeClassname);
-			}
-			if (excludeClassname != null) {
-				arguments.add("--exclude-classname");
-				arguments.add(excludeClassname);
-			}
-			if (includePackage != null) {
-				for (String pkg : includePackage) {
-					arguments.add("--include-package");
-					arguments.add(pkg);
-				}
-			}
-			if (excludePackage != null) {
-				for (String pkg : excludePackage) {
-					arguments.add("--exclude-package");
-					arguments.add(pkg);
-				}
-			}
-			if (includeEngine != null) {
-				for (String engine : includeEngine) {
-					arguments.add("--include-engine");
-					arguments.add(engine);
-				}
-			}
-			if (excludeEngine != null) {
-				for (String engine : excludeEngine) {
-					arguments.add("--exclude-engine");
-					arguments.add(engine);
-				}
-			}
-			if (includeTag != null) {
-				for (String tag : includeTag) {
-					arguments.add("--include-tag");
-					arguments.add(tag);
-				}
-			}
-			if (excludeTag != null) {
-				for (String tag : excludeTag) {
-					arguments.add("--exclude-tag");
-					arguments.add(tag);
-				}
-			}
-			if (config != null) {
-				for (Entry<String, String> entry : config.entrySet()) {
-					arguments.add("--config");
-					arguments.add(String.format("%s=%s", entry.getKey(), entry.getValue()));
-				}
-			}
-			if (details != null) {
-				arguments.add("--details");
-				arguments.add(details);
-			}
-			if (detailsTheme != null) {
-				arguments.add("--details-theme");
-				arguments.add(detailsTheme);
-			}
-			if (singleColor) {
-				arguments.add("--single-color");
-			}
-			arguments.add("--reports-dir");
-			arguments.add(reportsDir.getAbsolutePath());
-			if (failIfNoTests) {
-				arguments.add("--fail-if-no-tests");
-			}
-			int exitCode = junit.run(System.out, System.err, arguments.toArray(String[]::new));
-			if (exitCode == 0) {
-				return;
-			}
-			if (exitCode == 2) {
-				throw new MojoFailureException("No tests found!");
-			}
-			if (exitCode == 1) {
-				throw new MojoFailureException("There are test failures");
-			}
-			throw new MojoExecutionException("Tool execution failed with exit code " + exitCode);
-		} finally {
-			thread.setContextClassLoader(loader);
-		}
-	}
-
-	private Map<String, String> getFrameworkProperties(Path workDir) {
-		Map<String, String> map = new LinkedHashMap<>();
-		map.put("osgi.configuration.area", workDir.resolve("configuration").toAbsolutePath().toString());
-		map.put("osgi.instance.area", workDir.resolve("data").toAbsolutePath().toString());
-		map.put("osgi.compatibility.bootdelegation", "true");
-		map.put("osgi.classloader.copy.natives", "true");
-		map.put("osgi.framework.useSystemProperties", "false");
-		map.put("osgi.clean", "true");
-		if (frameworkProperties != null) {
-			map.putAll(frameworkProperties);
-		}
-		return map;
-	}
-
-	private static boolean isFragment(Bundle bundle) {
-		BundleRevisions bundleRevisions = bundle.adapt(BundleRevisions.class);
-		List<BundleRevision> revisions = bundleRevisions.getRevisions();
-		if (revisions.isEmpty()) {
-			return false;
-		}
-		return (revisions.get(0).getTypes() & BundleRevision.TYPE_FRAGMENT) != 0;
-	}
-
-	private static Optional<Bundle> getHost(Bundle bundle) {
-		BundleWiring wiring = bundle.adapt(BundleWiring.class);
-		if (wiring == null) {
-			return Optional.empty();
-		}
-		List<BundleWire> hostWires = wiring.getRequiredWires(HostNamespace.HOST_NAMESPACE);
-		if (hostWires == null) {
-			return Optional.empty();
-		}
-		return hostWires.stream().map(wire -> wire.getProvider().getBundle()).filter(Objects::nonNull).findFirst();
-	}
 
 }

--- a/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformRunner.java
+++ b/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformRunner.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.testing.plugin;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.spi.ToolProvider;
+import java.util.stream.StreamSupport;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.namespace.HostNamespace;
+import org.osgi.framework.startlevel.BundleStartLevel;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleRevisions;
+import org.osgi.framework.wiring.BundleWire;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.framework.wiring.FrameworkWiring;
+
+/**
+ * Encapsulates the code that actually runs inside the OSGi framework.
+ */
+public class JUnitPlatformRunner implements Serializable, Function<BundleContext, JUnitPlatformRunnerResult> {
+
+	private static final String JUNIT_TOOLPROVIDER_NAME = "junit";
+
+	private String[] bundleLocations;
+	private int applicationStartLevel;
+	private int extenderStartLevel;
+	private boolean startExtender;
+	private long startupTimout;
+	private boolean printBundles;
+	private String artifactLocation;
+	private String[] runnerArguments;
+
+	public JUnitPlatformRunner(Collection<Path> bundlesToInstall, Path projectArtifact, int applicationStartLevel,
+			int extenderStartLevel, boolean startExtender, long startupTimout, boolean printBundles,
+			List<String> runnerArguments) {
+		this.runnerArguments = runnerArguments.toArray(String[]::new);
+		this.artifactLocation = projectArtifact.toAbsolutePath().toString();
+		this.applicationStartLevel = applicationStartLevel;
+		this.extenderStartLevel = extenderStartLevel;
+		this.startExtender = startExtender;
+		this.startupTimout = startupTimout;
+		this.printBundles = printBundles;
+		bundleLocations = bundlesToInstall.stream()
+				.filter(p -> !p.getFileName().toString().startsWith("org.eclipse.osgi"))
+				.map(p -> p.toAbsolutePath().toString()).toArray(String[]::new);
+	}
+
+	@Override
+	public JUnitPlatformRunnerResult apply(BundleContext bundleContext) {
+		Bundle framework = bundleContext.getBundle(0);
+		FrameworkWiring wiring = framework.adapt(FrameworkWiring.class);
+		FrameworkStartLevel startLevel = framework.adapt(FrameworkStartLevel.class);
+		startLevel.setInitialBundleStartLevel(applicationStartLevel);
+		JUnitPlatformRunnerResult result = new JUnitPlatformRunnerResult();
+		result.debug("Install Bundles ...");
+		List<Bundle> bundles = new ArrayList<>();
+		for (String loc : bundleLocations) {
+			Path path = Path.of(loc);
+			try {
+				Bundle bundle = bundleContext.installBundle(path.toString(), Files.newInputStream(path));
+				result.debug("Installed " + bundle);
+				bundles.add(bundle);
+			} catch (BundleException | IOException e) {
+				result.debug(path.getFileName() + ": " + e);
+			}
+		}
+		result.debug("Resolve bundles...");
+		wiring.resolveBundles(bundles);
+		setStartLevels(bundles, result);
+		CountDownLatch latch = new CountDownLatch(1);
+		startLevel.setStartLevel(applicationStartLevel, new FrameworkListener() {
+
+			@Override
+			public void frameworkEvent(FrameworkEvent event) {
+				latch.countDown();
+			}
+		});
+		try {
+			if (!latch.await(startupTimout, TimeUnit.SECONDS)) {
+				return result.failure("Framework did not reached the required startlevel in time!");
+			}
+		} catch (InterruptedException e) {
+			return result.setException(e);
+		}
+		printBundleInfo(bundles, printBundles ? result::info : result::debug);
+		Optional<Bundle> testProbe = findTestProbe(bundles);
+		if (testProbe.isEmpty()) {
+			return result.failure("Testprobe not found in Framework");
+		}
+		Bundle testBundle = testProbe.get();
+		Optional<ToolProvider> toolProvider = findToolProvider(testBundle, bundles, result);
+		if (toolProvider.isEmpty()) {
+			return result.failure(
+					"No compatible tool provider for junit make sure to have defined a matching junit-platform-console in your pom!");
+		}
+		if (isFragment(testBundle)) {
+			Optional<Bundle> host = getHost(testBundle);
+			if (host.isEmpty()) {
+				return result.failure(						"Testprobe is a fragment but not attached to any host bundle");	
+			}
+			testBundle = host.get();
+		}
+		try {
+			testBundle.start();
+		} catch (BundleException e) {
+			return result.setException(
+					new JUnitPlatformFailureException("Testprobe " + testBundle + " can not be started!", e));
+		}
+		Thread thread = Thread.currentThread();
+		ClassLoader loader = thread.getContextClassLoader();
+		try {
+			thread.setContextClassLoader(new SPIBundleClassLoader(testBundle, bundles, result::debug));
+			return result.setExitCode(toolProvider.get().run(System.out, System.err, runnerArguments));
+		} finally {
+			thread.setContextClassLoader(loader);
+		}
+	}
+
+
+	private void setStartLevels(List<Bundle> bundles, JUnitPlatformRunnerResult result) {
+		for (Bundle bundle : bundles) {
+			BundleWiring wiring = bundle.adapt(BundleWiring.class);
+			if (wiring != null) {
+				List<BundleWire> providedWires = wiring.getProvidedWires("osgi.extender");
+				if (providedWires.isEmpty()) {
+					continue;
+				}
+				result.debug("Found extender bundle " + bundle);
+				BundleStartLevel startLevel = bundle.adapt(BundleStartLevel.class);
+				startLevel.setStartLevel(extenderStartLevel);
+				if (startExtender) {
+					try {
+						bundle.start();
+					} catch (BundleException e) {
+						result.debug("Extender bundle " + bundle + " can not be started: " + e);
+					}
+				}
+			}
+		}
+	}
+
+	private static boolean isFragment(Bundle bundle) {
+		BundleRevisions bundleRevisions = bundle.adapt(BundleRevisions.class);
+		List<BundleRevision> revisions = bundleRevisions.getRevisions();
+		if (revisions.isEmpty()) {
+			return false;
+		}
+		return (revisions.get(0).getTypes() & BundleRevision.TYPE_FRAGMENT) != 0;
+	}
+
+	private static Optional<Bundle> getHost(Bundle bundle) {
+		BundleWiring wiring = bundle.adapt(BundleWiring.class);
+		if (wiring == null) {
+			return Optional.empty();
+		}
+		List<BundleWire> hostWires = wiring.getRequiredWires(HostNamespace.HOST_NAMESPACE);
+		if (hostWires == null) {
+			return Optional.empty();
+		}
+		return hostWires.stream().map(wire -> wire.getProvider().getBundle()).filter(Objects::nonNull).findFirst();
+	}
+
+	private Optional<Bundle> findTestProbe(List<Bundle> bundles) {
+		for (Bundle bundle : bundles) {
+			if (artifactLocation.equals(bundle.getLocation())) {
+				return Optional.of(bundle);
+			}
+		}
+		return Optional.empty();
+	}
+
+	private void printBundleInfo(List<Bundle> bundles, Consumer<String> consumer) {
+		consumer.accept("============ Bundles ==================");
+		Comparator<Bundle> bySymbolicName = Comparator.comparing(Bundle::getSymbolicName,
+				String.CASE_INSENSITIVE_ORDER);
+		Comparator<Bundle> byState = Comparator.comparingInt(Bundle::getState);
+		bundles.stream().sorted(byState.thenComparing(bySymbolicName)).forEachOrdered(bundle -> {
+			String state = toBundleState(bundle.getState());
+			consumer.accept(state + " | " + bundle.getSymbolicName() + " (" + bundle.getVersion() + ") at "
+					+ bundle.getLocation());
+		});
+
+	}
+
+	private static String toBundleState(int state) {
+		return switch (state) {
+		case Bundle.ACTIVE -> "ACTIVE   ";
+		case Bundle.INSTALLED -> "INSTALLED";
+		case Bundle.RESOLVED -> "RESOLVED ";
+		case Bundle.STARTING -> "STARTING ";
+		case Bundle.STOPPING -> "STOPPING ";
+		default -> String.valueOf(state);
+		};
+	}
+
+	private Optional<ToolProvider> findToolProvider(Bundle testprobe, List<Bundle> bundles,
+			JUnitPlatformRunnerResult result) {
+		for (Bundle bundle : bundles) {
+			if (bundle == testprobe) {
+				continue;
+			}
+			try {
+				URL resource = bundle.getResource("META-INF/services/java.util.spi.ToolProvider");
+				if (resource != null) {
+					result.debug("Checking " + bundle + " for toolprovider...");
+					BundleWiring wiring = bundle.adapt(BundleWiring.class);
+					if (wiring == null) {
+						return Optional.empty();
+					}
+					ServiceLoader<ToolProvider> sl = ServiceLoader.load(ToolProvider.class, wiring.getClassLoader());
+					Optional<ToolProvider> provider = StreamSupport.stream(sl.spliterator(), false)
+							.filter(p -> p.name().equals(JUNIT_TOOLPROVIDER_NAME)).findFirst();
+					if (provider.isPresent()) {
+						result.debug("--> found one: " + provider.get());
+						return provider;
+					}
+				}
+			} catch (Exception e) {
+				result.debug("Can't check " + bundle + ": " + e);
+			}
+		}
+		return Optional.empty();
+	}
+
+}

--- a/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformRunnerResult.java
+++ b/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformRunnerResult.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.testing.plugin;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class JUnitPlatformRunnerResult implements Serializable {
+
+	private List<String> debugMessages = new ArrayList<>();
+	private List<String> infoMessages = new ArrayList<>();
+	private Exception exception;
+
+	public void debug(String debugMessage) {
+		debugMessages.add(debugMessage);
+	}
+
+	public void info(String debugMessage) {
+		infoMessages.add(debugMessage);
+	}
+
+	public JUnitPlatformRunnerResult setException(Exception exception) {
+		this.exception = exception;
+		return this;
+	}
+
+	public JUnitPlatformRunnerResult failure(String message) {
+		return setException(new JUnitPlatformFailureException(message));
+	}
+
+	public JUnitPlatformRunnerResult setExitCode(int exitCode) {
+		if (exitCode == 0) {
+			return this;
+		}
+		if (exitCode == 2) {
+			return failure("No tests found!");
+		}
+		if (exitCode == 1) {
+			return failure("There are test failures");
+		}
+		return failure("Tool execution failed with exit code " + exitCode);
+	}
+
+	public Stream<String> debugMessages() {
+		return debugMessages.stream();
+	}
+
+	public Stream<String> infoMessages() {
+		return infoMessages.stream();
+	}
+
+	public Exception getException() {
+		return exception;
+	}
+
+}

--- a/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/SPIBundleClassLoader.java
+++ b/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/SPIBundleClassLoader.java
@@ -39,11 +39,11 @@ class SPIBundleClassLoader extends ClassLoader {
 
 	private static final String META_INF_SERVICES = "META-INF/services/";
 	private Bundle bundle;
-	private Consumer<? super CharSequence> logger;
-	private Bundle[] bundles;
+	private Consumer<String> logger;
+	private List<Bundle> bundles;
 	private Map<String, List<SPIMapping>> mappings = new ConcurrentHashMap<>();
 
-	public SPIBundleClassLoader(Bundle bundle, Bundle[] bundles, Consumer<? super CharSequence> logger) {
+	public SPIBundleClassLoader(Bundle bundle, List<Bundle> bundles, Consumer<String> logger) {
 		this.bundle = bundle;
 		this.bundles = bundles;
 		this.logger = logger;


### PR DESCRIPTION
Currently we only support executing tests inside an embedded OSGi framework with not additional environment but we likely want to supported a forked mode or special eclipse applications ones (e.g. the UIHarness).

This now creates a new generic API for launching a framework and execute some code inside it allowing also better separation of concerns and less code in the mojo itself.