### PR TITLE
Implement a forked OSGi container for the testframework

### DIFF
--- a/demo/testing/junit-platform/test/pom.xml
+++ b/demo/testing/junit-platform/test/pom.xml
@@ -26,9 +26,15 @@
 					</execution>
 				</executions>
 				<configuration>
+					<!-- if you want a forked JVM for test instead -->
+					<!-- <launchType>forked</launchType> -->
+					
 					<!-- Sometimes it can be handy to print all bundles that are part of the test framework -->
 					<!-- <printBundles>true</printBundles> -->
-					
+					  
+					<!-- To see debug messages of the internals, will also be printed with -X -->
+					<!--  <printDebug>true</printDebug> -->
+					 
 					<!-- Scan classpath can be disabled if other discovery is wanted -->
 					<!-- <scanClasspath>false</scanClasspath> -->
 					

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/DemoTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/DemoTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -26,6 +27,7 @@ import java.util.Dictionary;
 import java.util.List;
 import java.util.jar.JarFile;
 
+import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
 import org.eclipse.osgi.service.resolver.BundleDescription;
@@ -106,8 +108,17 @@ public class DemoTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testTychoJunitPlatformDemo() throws Exception {
-		Verifier verifier = runDemo("testing/junit-platform/");
-		verifier.verifyTextInLog("1 tests found");
+		// test with default embedded container...
+		runDemo("testing/junit-platform/").verifyTextInLog("1 tests found");
+		// test with the forked mode
+		runDemo("testing/junit-platform/", "-Djunit-platform.launchType=forked").verifyTextInLog("1 tests found");
+		// test that it fails
+		try {
+			runDemo("testing/junit-platform/", "-Djunit-platform.launchType=unknown");
+			fail();
+		} catch (VerificationException e) {
+			assertTrue(e.getMessage().contains("Launch type 'unknown' is not available"));
+		}
 	}
 
 	@Test

--- a/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/ForkedFrameworkLauncher.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/ForkedFrameworkLauncher.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.osgi.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.ProcessBuilder.Redirect;
+import java.net.ServerSocket;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.osgi.OSGiFramework;
+import org.eclipse.tycho.osgi.OSGiFrameworkLauncher;
+import org.eclipse.tycho.osgi.impl.ForkedFrameworkMain.SocketCommandChannel;
+import org.osgi.framework.connect.ConnectFrameworkFactory;
+import org.osgi.framework.launch.Framework;
+
+/**
+ * The {@link ForkedFrameworkLauncher} launches a framework in a new JVM process
+ */
+@Component(role = OSGiFrameworkLauncher.class, hint = "forked")
+public class ForkedFrameworkLauncher implements OSGiFrameworkLauncher {
+
+    @Override
+    public OSGiFramework launchFramework(MavenProject project, Map<String, String> properties) throws IOException {
+        Path workDir = EmbeddedFrameworkLauncher.prepareWorkdir(project, properties);
+        Map<String, String> map = EmbeddedFrameworkLauncher.createProperties(properties, workDir);
+        Path path = getJavaExecutable();
+        ServerSocket serverSocket = new ServerSocket(0);
+        List<String> commandline = new ArrayList<>();
+        commandline.add(path.toAbsolutePath().toString()); // java executable
+        commandline.add("-cp");
+        commandline.add(getClasspathFor(ForkedFrameworkMain.class, //our jar itself...
+                EmbeddedFrameworkLauncher.getFrameworkFactory(ConnectFrameworkFactory.class).getClass(), //osgi impl
+                Framework.class // API
+        ));
+        commandline.add(ForkedFrameworkMain.class.getName());
+        commandline.add(Integer.toString(serverSocket.getLocalPort()));
+        ProcessBuilder pb = new ProcessBuilder(commandline);
+        pb.redirectOutput(Redirect.INHERIT);
+        pb.redirectError(Redirect.INHERIT);
+        Process process = pb.start();
+        process.onExit().thenRun(() -> {
+            try {
+                serverSocket.close();
+            } catch (IOException e) {
+            }
+        });
+        return new ForkedOSGiFramework(process, map, new SocketCommandChannel(serverSocket.accept()));
+    }
+
+    private String getClasspathFor(Class<?>... classes) throws IOException {
+        Set<String> cp = new LinkedHashSet<>();
+        for (Class<?> clz : classes) {
+            cp.add(getJarFor(clz));
+        }
+        return cp.stream().collect(Collectors.joining(File.pathSeparator));
+    }
+
+    static String getJarFor(Class<?> marker) throws IOException {
+        try {
+            return new File(marker.getProtectionDomain().getCodeSource().getLocation().toURI()).getAbsolutePath();
+        } catch (URISyntaxException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private Path getJavaExecutable() throws IOException {
+        String property = System.getProperties().getProperty("java.home");
+        if (property == null) {
+            throw new IOException("java home not defined");
+        }
+        Path javaHome = Path.of(property);
+        Path java = javaHome.resolve("bin/java");
+        if (Files.isRegularFile(java)) {
+            return java;
+        }
+        Path javaExe = javaHome.resolve("bin/java.exe");
+        if (Files.isRegularFile(javaExe)) {
+            return javaExe;
+        }
+        throw new IOException("No java executable found in " + javaHome);
+    }
+
+}

--- a/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/ForkedFrameworkMain.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/ForkedFrameworkMain.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.osgi.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Method;
+import java.net.Socket;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.connect.ConnectFrameworkFactory;
+import org.osgi.framework.launch.Framework;
+
+class ForkedFrameworkMain {
+
+    public enum Command {
+        CLOSE, RUN;
+    }
+
+    public static void main(String[] args) throws Exception {
+        try (Socket socket = new Socket((String) null, Integer.parseInt(args[0]));
+                SocketCommandChannel channel = new SocketCommandChannel(socket)) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> frameworkProperties = (Map<String, String>) channel.readObject();
+            ConnectFrameworkFactory factory = ServiceLoader
+                    .load(ConnectFrameworkFactory.class, ForkedFrameworkMain.class.getClassLoader()).findFirst()
+                    .orElseThrow(() -> new IOException("No FrameworkFactory found on classpath"));
+            ForkedModuleConnector moduleConnector = new ForkedModuleConnector();
+            Framework framework = factory.newFramework(frameworkProperties, moduleConnector);
+            try {
+                framework.init();
+            } catch (BundleException e) {
+                throw new IOException("Initialize the framework failed!", e);
+            }
+            try {
+                framework.start();
+            } catch (BundleException e) {
+                throw new IOException("Start the framework failed!", e);
+            }
+            while (true) {
+                Command command = channel.readCommand();
+                if (command == Command.CLOSE) {
+                    System.exit(0);
+                }
+                if (command == Command.RUN) {
+                    String jarName = new String(channel.readPayload());
+                    byte[] classData = channel.readPayload();
+                    try {
+                        Bundle bundle = moduleConnector.getBundle(jarName, framework);
+                        try (ObjectInputStream stream = new ObjectInputStream(new ByteArrayInputStream(classData)) {
+                            protected java.lang.Class<?> resolveClass(java.io.ObjectStreamClass desc)
+                                    throws IOException, ClassNotFoundException {
+                                return bundle.loadClass(desc.getName());
+                            };
+                        }) {
+                            Object object = stream.readObject();
+                            Method method = object.getClass().getMethod("apply", Object.class);
+                            Object invoke = method.invoke(object, bundle.getBundleContext());
+                            if (invoke == null) {
+                                channel.sendPayload(new byte[0]);
+                            } else {
+                                channel.sendObject(invoke);
+                            }
+                        }
+                    } catch (Exception e) {
+                        channel.sendObject(e);
+                    }
+                }
+            }
+        }
+    }
+
+    public static final class SocketCommandChannel implements Closeable {
+
+        private final Socket socket;
+        private final DataOutputStream output;
+        private final DataInputStream input;
+        private final Command[] commands = Command.values();
+
+        public SocketCommandChannel(Socket socket) throws IOException {
+            this.socket = socket;
+            output = new DataOutputStream(socket.getOutputStream());
+            input = new DataInputStream(socket.getInputStream());
+        }
+
+        public Object readObject() throws IOException {
+            try (ObjectInputStream stream = new ObjectInputStream(new ByteArrayInputStream(readPayload()))) {
+                try {
+                    return stream.readObject();
+                } catch (ClassNotFoundException e) {
+                    throw new IOException(e);
+                }
+            }
+        }
+
+        public void sendObject(Object object) throws IOException {
+            try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    ObjectOutputStream stream = new ObjectOutputStream(out)) {
+                stream.writeObject(object);
+                stream.flush();
+                stream.close();
+                sendPayload(out.toByteArray());
+            }
+        }
+
+        public void sendCommand(Command command) throws IOException {
+            output.writeInt(command.ordinal());
+        }
+
+        public void flush() {
+            try {
+                output.flush();
+            } catch (IOException e) {
+            }
+        }
+
+        public void sendPayload(byte[] payload) throws IOException {
+            output.writeInt(payload.length);
+            output.write(payload);
+        }
+
+        public Command readCommand() throws IOException {
+            int cmd = input.readInt();
+            return commands[cmd];
+        }
+
+        public byte[] readPayload() throws IOException {
+            int length = input.readInt();
+            return input.readNBytes(length);
+        }
+
+        @Override
+        public void close() {
+            try {
+                sendCommand(Command.CLOSE);
+            } catch (IOException e) {
+            }
+            try {
+                output.close();
+            } catch (IOException e) {
+            }
+            try {
+                input.close();
+            } catch (IOException e) {
+            }
+            try {
+                socket.close();
+            } catch (IOException e) {
+            }
+        }
+
+    }
+
+}

--- a/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/ForkedModuleConnector.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/ForkedModuleConnector.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.osgi.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
+import org.osgi.framework.connect.ConnectContent;
+import org.osgi.framework.connect.ConnectContent.ConnectEntry;
+import org.osgi.framework.connect.ConnectModule;
+import org.osgi.framework.connect.ModuleConnector;
+import org.osgi.framework.launch.Framework;
+
+/**
+ * This module connector currently do nothing else as replicate a default OSGi-Framework behavior
+ */
+class ForkedModuleConnector implements ModuleConnector {
+
+    private Map<String, ConnectModule> modules = new ConcurrentHashMap<>();
+    private Map<String, Bundle> bundles = new ConcurrentHashMap<>();
+
+    public ForkedModuleConnector() {
+    }
+
+    @Override
+    public void initialize(File storage, Map<String, String> configuration) {
+
+    }
+
+    @Override
+    public Optional<ConnectModule> connect(String location) throws BundleException {
+        return Optional.ofNullable(modules.get(location));
+    }
+
+    @Override
+    public Optional<BundleActivator> newBundleActivator() {
+        return Optional.empty();
+    }
+
+    public Bundle getBundle(String jarName, Framework framework) throws BundleException {
+        String id = "fork-" + jarName;
+        Bundle bundle = bundles.get(id);
+        if (bundle != null) {
+            return bundle;
+        }
+        Map<String, String> header = new HashMap<>();
+        header.put(Constants.BUNDLE_SYMBOLICNAME, id);
+        header.put(Constants.BUNDLE_VERSION, "1.0.0");
+        header.put(Constants.DYNAMICIMPORT_PACKAGE, "*");
+        modules.put(id, new TempBundle(new File(jarName), header));
+        Bundle installBundle = framework.getBundleContext().installBundle(id);
+        bundles.put(id, installBundle);
+        installBundle.start();
+        return installBundle;
+    }
+
+    private static final class TempBundle extends ZipBundle {
+
+        private Map<String, String> header;
+
+        public TempBundle(File location, Map<String, String> header) {
+            super(location);
+            this.header = header;
+        }
+
+        @Override
+        public Optional<Map<String, String>> getHeaders() {
+            return Optional.of(header);
+        }
+
+        @Override
+        public Optional<ClassLoader> getClassLoader() {
+            return Optional.empty();
+        }
+
+    }
+
+    private static abstract class ZipBundle implements ConnectModule, ConnectContent {
+
+        private JarFile jarFile;
+        private final File location;
+
+        public ZipBundle(File location) {
+            this.location = location;
+        }
+
+        @Override
+        public ConnectContent getContent() throws IOException {
+            return this;
+        }
+
+        @Override
+        public Iterable<String> getEntries() throws IOException {
+            if (jarFile == null) {
+                return Collections.emptyList();
+            }
+            return jarFile.stream().map(JarEntry::getName).toList();
+        }
+
+        @Override
+        public Optional<ConnectEntry> getEntry(String path) {
+            if (jarFile == null) {
+                return Optional.empty();
+            }
+            final ZipEntry entry = jarFile.getEntry(path);
+            if (entry == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new ZipConnectEntry(jarFile, entry));
+        }
+
+        @Override
+        public void open() throws IOException {
+            if (jarFile == null && location != null) {
+                jarFile = new JarFile(location);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (jarFile != null) {
+                try {
+                    jarFile.close();
+                } finally {
+                    jarFile = null;
+                }
+            }
+        }
+
+    }
+
+    private static final class ZipConnectEntry implements ConnectEntry {
+
+        private ZipEntry entry;
+        private JarFile jarFile;
+
+        public ZipConnectEntry(JarFile jarFile, ZipEntry entry) {
+            this.jarFile = jarFile;
+            this.entry = entry;
+        }
+
+        @Override
+        public String getName() {
+            return entry.getName();
+        }
+
+        @Override
+        public long getContentLength() {
+            return entry.getSize();
+        }
+
+        @Override
+        public long getLastModified() {
+            return entry.getTime();
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return jarFile.getInputStream(entry);
+        }
+
+    }
+
+}

--- a/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/ForkedOSGiFramework.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/osgi/impl/ForkedOSGiFramework.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *    
+ */
+package org.eclipse.tycho.osgi.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.eclipse.tycho.osgi.OSGiFramework;
+import org.eclipse.tycho.osgi.impl.ForkedFrameworkMain.Command;
+import org.eclipse.tycho.osgi.impl.ForkedFrameworkMain.SocketCommandChannel;
+import org.osgi.framework.BundleContext;
+
+class ForkedOSGiFramework implements OSGiFramework {
+
+    private Process process;
+    private SocketCommandChannel channel;
+    private Map<String, String> properties;
+
+    ForkedOSGiFramework(Process process, Map<String, String> properties, SocketCommandChannel channel)
+            throws IOException {
+        this.process = process;
+        this.properties = properties;
+        this.channel = channel;
+        channel.sendObject(properties);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <Action extends Function<BundleContext, R> & Serializable, R extends Serializable> R runInFramework(
+            Action action) throws IOException {
+        channel.sendCommand(Command.RUN);
+        channel.sendPayload(ForkedFrameworkLauncher.getJarFor(action.getClass()).getBytes());
+        channel.sendObject(action);
+        channel.flush();
+        byte[] payload = channel.readPayload();
+        if (payload.length == 0) {
+            return null;
+        }
+        try (ObjectInputStream stream = new ObjectInputStream(new ByteArrayInputStream(payload)) {
+            protected java.lang.Class<?> resolveClass(java.io.ObjectStreamClass desc)
+                    throws IOException, ClassNotFoundException {
+                try {
+                    return action.getClass().getClassLoader().loadClass(desc.getName());
+                } catch (ClassNotFoundException e) {
+                    return super.resolveClass(desc);
+                }
+            }
+        }) {
+            try {
+                Object object = stream.readObject();
+                if (object instanceof RuntimeException rte) {
+                    throw rte;
+                }
+                if (object instanceof IOException ioe) {
+                    throw ioe;
+                }
+                if (object instanceof Exception ex) {
+                    throw new IOException(ex);
+                }
+                return (R) object;
+            } catch (ClassNotFoundException e) {
+                throw new IOException(e);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        channel.close();
+        process.destroy();
+        try {
+            if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        } catch (InterruptedException e) {
+        }
+    }
+
+}

--- a/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformMojo.java
+++ b/tycho-test-plugin/src/main/java/org/eclipse/tycho/testing/plugin/JUnitPlatformMojo.java
@@ -216,6 +216,9 @@ public class JUnitPlatformMojo extends AbstractMojo {
 	@Parameter
 	private boolean printBundles;
 
+	@Parameter
+	private boolean printDebug;
+
 	@Parameter(property = "junit-platform.skip")
 	private boolean skip;
 
@@ -262,6 +265,8 @@ public class JUnitPlatformMojo extends AbstractMojo {
 		runnerResult.infoMessages().forEach(log::info);
 		if (log.isDebugEnabled()) {
 			runnerResult.debugMessages().forEach(log::debug);
+		} else if (printDebug) {
+			runnerResult.debugMessages().forEach(log::info);
 		}
 		Exception exception = runnerResult.getException();
 		if (exception == null) {


### PR DESCRIPTION
Currently we only offer an embedded OSGi framework, while this is good for a large range of tests it is sometimes needed to have more isolation using a forked JVM.

This now adds a new option "forked" to be used if forking the framework is desired.