### PR TITLE
Create a new tycho-dependency-tools-plugin:usage mojos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ requirements.txt
 
 ## Tools downloaded for testing
 actionlint
+# Test cache files
+tycho-core/http/
+tycho-core/https/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -105,6 +105,37 @@ Tycho now supports calling this tool from CLI (e.g. `mvn org.eclipse.tycho:tycho
 </plugin>
 ```
 
+### new `tycho-dependency-tools:usage` mojo to analyze target platform dependency usage
+
+Managing target platform dependencies can be challenging, especially when it comes to identifying which dependencies are actually needed versus which can be removed.
+The new `tycho-dependency-tools:usage` mojo helps solve this problem by analyzing the actual usage of dependencies from target platform definitions across all projects in the reactor.
+
+This mojo compares the content of target definitions against what is actually used in your projects, making it easy to:
+- Identify unused dependencies that can be safely removed
+- See which dependencies are used directly versus indirectly (through transitive dependencies)
+- Understand the relationship between target platform units and the projects that use them
+
+You can run it from the command line:
+
+```bash
+mvn org.eclipse.tycho.extras:tycho-dependency-tools-plugin:6.0.0-SNAPSHOT:usage
+```
+
+The mojo supports two report layouts:
+- **tree** (default): Organizes units by target file and location with a hierarchical view
+- **simple**: One-line-per-unit format
+
+You can switch layouts using the `usage.layout` property:
+
+```bash
+mvn org.eclipse.tycho.extras:tycho-dependency-tools-plugin:6.0.0-SNAPSHOT:usage -Dusage.layout=simple
+```
+
+For more detailed output showing which projects use each dependency, add the `verbose` flag:
+
+```bash
+mvn org.eclipse.tycho.extras:tycho-dependency-tools-plugin:6.0.0-SNAPSHOT:usage -Dverbose=true
+```
 
 ### Migration Guide 5.x > 6.x
 

--- a/tycho-extras/tycho-dependency-tools-plugin/pom.xml
+++ b/tycho-extras/tycho-dependency-tools-plugin/pom.xml
@@ -39,6 +39,17 @@
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.13.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/ReportLayout.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/ReportLayout.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.extras.pde.usage;
+
+import java.util.function.Consumer;
+
+/**
+ * Defines the layout strategy for formatting usage reports.
+ */
+interface ReportLayout {
+    /**
+     * Generates and outputs the usage report using this layout.
+     * 
+     * @param report the usage report data to format
+     * @param verbose TODO
+     * @param reportConsumer consumer that receives formatted report lines
+     */
+    void generateReport(UsageReport report, boolean verbose, Consumer<String> reportConsumer);
+}

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/SimpleUsageReportLayout.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/SimpleUsageReportLayout.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.extras.pde.usage;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.tycho.targetplatform.TargetDefinition;
+
+/**
+ * Simple one-line-per-unit report layout (original format).
+ */
+@Component(role = ReportLayout.class, hint = "simple")
+final class SimpleUsageReportLayout implements ReportLayout {
+
+    @Override
+    public void generateReport(UsageReport report, boolean verbose, Consumer<String> reportConsumer) {
+        reportConsumer.accept("###### DEPENDENCIES USAGE REPORT #######");
+        reportConsumer.accept("Your build uses " + report.usedUnits.size() + " dependencies.");
+        reportConsumer.accept("Your build uses " + report.getTargetFilesCount() + " target file(s).");
+        report.getTargetFiles().forEach(targetFile -> {
+            reportConsumer.accept(targetFile.getOrigin() + " contains "
+                    + report.getTargetDefinitionContent(targetFile).query(QueryUtil.ALL_UNITS, null).toSet().size()
+                    + " units from " + targetFile.getLocations().size() + " locations");
+            
+            // Show if this target is referenced by other targets
+            if (report.targetReferences.containsKey(targetFile)) {
+                List<TargetDefinition> referencedBy = report.targetReferences.get(targetFile);
+                String referencingTargets = referencedBy.stream()
+                        .map(TargetDefinition::getOrigin)
+                        .collect(Collectors.joining(", "));
+                reportConsumer.accept("  Referenced in: " + referencingTargets);
+            }
+            
+            // Show target references (targets that this target references)
+            for (TargetDefinition.Location location : targetFile.getLocations()) {
+                if (location instanceof TargetDefinition.TargetReferenceLocation refLoc) {
+                    String refUri = refLoc.getUri();
+                    // Determine if the referenced target is used
+                    boolean isUsed = report.isReferencedTargetUsed(refUri);
+                    String status = isUsed ? "USED" : "UNUSED";
+                    reportConsumer.accept("  References: " + refUri + " [" + status + "]");
+                }
+            }
+        });
+
+        // Only report on root units (defined directly in target files)
+        Set<IInstallableUnit> allUnits = report.providedBy.keySet();
+        Set<IInstallableUnit> rootUnits = allUnits.stream().filter(report::isRootUnit).collect(Collectors.toSet());
+
+        // Track which units have been covered by reporting their parent
+        Set<IInstallableUnit> reportedUnits = new HashSet<>();
+
+        for (IInstallableUnit unit : rootUnits) {
+            // Skip if this unit was already covered by a parent report
+            if (reportedUnits.contains(unit)) {
+                continue;
+            }
+
+            String by = report.getProvidedBy(unit);
+
+            if (report.usedUnits.contains(unit)) {
+                // Unit is directly used - report it and mark all its children as reported
+                List<String> list = report.projectUsage.entrySet().stream()
+                        .filter(entry -> entry.getValue().contains(unit)).map(project -> project.getKey().getId())
+                        .toList();
+                reportConsumer.accept("The unit " + unit + " is used by " + list.size()
+                        + " projects and currently provided by " + by);
+
+                // Mark this unit and all its transitive dependencies as reported
+                reportedUnits.add(unit);
+                reportedUnits.addAll(report.getAllChildren(unit));
+            } else if (report.isUsedIndirectly(unit)) {
+                // Unit is indirectly used (one of its dependencies is used but not the unit itself)
+                String chain = report.getIndirectUsageChain(unit);
+                reportConsumer.accept("The unit " + unit + " is INDIRECTLY used through: " + chain
+                        + " and currently provided by " + by);
+
+                // Mark this unit and all its transitive dependencies as reported
+                reportedUnits.add(unit);
+                reportedUnits.addAll(report.getAllChildren(unit));
+            } else {
+                // Unit and all its dependencies are unused
+                reportConsumer.accept("The unit " + unit + " is UNUSED and currently provided by " + by);
+
+                // Mark this unit and all its transitive dependencies as reported
+                // (so we don't report them separately as unused)
+                reportedUnits.add(unit);
+                reportedUnits.addAll(report.getAllChildren(unit));
+            }
+        }
+    }
+}

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/TargetDefinitionResolver.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/TargetDefinitionResolver.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.extras.pde.usage;
+
+import java.net.URI;
+
+import org.eclipse.tycho.targetplatform.TargetDefinition;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
+
+public interface TargetDefinitionResolver {
+
+    TargetDefinition getTargetDefinition(URI uri);
+
+    TargetDefinitionContent fetchContent(TargetDefinition definition);
+
+}

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/TreeUsageReportLayout.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/TreeUsageReportLayout.java
@@ -1,0 +1,584 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.extras.pde.usage;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.tycho.targetplatform.TargetDefinition;
+
+/**
+ * Tree-structured report layout that organizes units by target file and location.
+ */
+@Component(role = ReportLayout.class, hint = "tree")
+final class TreeUsageReportLayout implements ReportLayout {
+
+    private final int lineWrapLimit;
+    
+    /**
+     * Synthetic JRE unit ID that should be filtered from reports
+     */
+    private static final String SYNTHETIC_JRE_UNIT_ID = "a.jre.javase";
+
+    /**
+     * Creates a tree layout with the specified line wrap limit.
+     * 
+     * @param lineWrapLimit
+     *            maximum line length before wrapping (default 200)
+     */
+    public TreeUsageReportLayout(int lineWrapLimit) {
+        this.lineWrapLimit = lineWrapLimit;
+    }
+
+    /**
+     * Creates a tree layout with default line wrap limit of 200 characters.
+     */
+    public TreeUsageReportLayout() {
+        this(200);
+    }
+
+    @Override
+    public void generateReport(UsageReport report, boolean verbose, Consumer<String> reportConsumer) {
+        reportConsumer.accept("###### DEPENDENCIES USAGE REPORT #######");
+        reportConsumer.accept("Your build uses " + report.usedUnits.size() + " dependencies.");
+        reportConsumer.accept("Your build uses " + report.getTargetFilesCount() + " target file(s).");
+        reportConsumer.accept("");
+
+        // Group units by target file and location
+        Map<TargetDefinition, Map<String, List<UnitInfo>>> targetStructure = buildTargetStructure(report);
+
+        // Only report on root units (defined directly in target files)
+        Set<IInstallableUnit> allUnits = report.providedBy.keySet();
+        Set<IInstallableUnit> rootUnits = allUnits.stream().filter(report::isRootUnit).collect(Collectors.toSet());
+
+        // Track which units have been covered by reporting their parent
+        Set<IInstallableUnit> reportedUnits = new HashSet<>();
+        
+        // Track shortest paths for each used unit (for deduplication)
+        Map<IInstallableUnit, List<IInstallableUnit>> shortestPaths = computeShortestPaths(report, rootUnits);
+
+        // Generate tree output for each target file
+        for (TargetDefinition targetFile : targetStructure.keySet().stream()
+                .sorted(Comparator.comparing(TargetDefinition::getOrigin)).toList()) {
+            reportConsumer.accept("Target: " + targetFile.getOrigin());
+            int totalUnits = report.getTargetDefinitionContent(targetFile).query(QueryUtil.ALL_UNITS, null).toSet().size();
+            reportConsumer.accept(
+                    "  Total units: " + totalUnits + " from " + targetFile.getLocations().size() + " locations");
+            
+            // Show if this target is referenced by other targets
+            if (report.targetReferences.containsKey(targetFile)) {
+                List<TargetDefinition> referencedBy = report.targetReferences.get(targetFile);
+                String referencingTargets = referencedBy.stream()
+                        .map(TargetDefinition::getOrigin)
+                        .collect(Collectors.joining(", "));
+                reportConsumer.accept("  Referenced in: " + referencingTargets);
+            }
+            
+            // Show target references (targets that this target references)
+            for (TargetDefinition.Location location : targetFile.getLocations()) {
+                if (location instanceof TargetDefinition.TargetReferenceLocation refLoc) {
+                    String refUri = refLoc.getUri();
+                    // Determine if the referenced target is used
+                    boolean isUsed = report.isReferencedTargetUsed(refUri);
+                    String status = isUsed ? "USED" : "UNUSED";
+                    reportConsumer.accept("  References: " + refUri + " [" + status + "]");
+                }
+            }
+
+            Map<String, List<UnitInfo>> locations = targetStructure.get(targetFile);
+
+            // Sort locations by unique project count (highest to lowest)
+            List<String> sortedLocations = sortLocationsByProjectCount(locations, report);
+
+            for (String location : sortedLocations) {
+                List<UnitInfo> units = locations.get(location);
+
+                // Filter to only include root units from this location
+                List<UnitInfo> rootUnitsInLocation = units.stream()
+                        .filter(ui -> rootUnits.contains(ui.unit))
+                        .filter(ui -> !reportedUnits.contains(ui.unit))
+                        // Filter out synthetic JRE units
+                        .filter(ui -> !ui.unit.getId().equals(SYNTHETIC_JRE_UNIT_ID))
+                        .toList();
+
+                if (rootUnitsInLocation.isEmpty()) {
+                    continue;
+                }
+
+                // Count unique projects for this location
+                Set<String> locationProjects = countUniqueProjects(rootUnitsInLocation, report);
+                
+                reportConsumer.accept("  Location: " + wrapLine(location, "    ", lineWrapLimit) + 
+                        " (" + locationProjects.size() + " project" + (locationProjects.size() == 1 ? "" : "s") + ")");
+
+                // Sort root units by usage count (most used to least used)
+                List<UnitInfo> sortedUnits = sortUnitsByUsage(rootUnitsInLocation, report);
+
+                for (UnitInfo unitInfo : sortedUnits) {
+                    IInstallableUnit unit = unitInfo.unit;
+
+                    // Skip if already reported
+                    if (reportedUnits.contains(unit)) {
+                        continue;
+                    }
+
+                    // Determine usage status
+                    if (report.usedUnits.contains(unit)) {
+                        // USED status - include project count in brackets
+                        List<String> projects = report.projectUsage.entrySet().stream()
+                                .filter(entry -> entry.getValue().contains(unit))
+                                .map(project -> project.getKey().getId()).toList();
+                        String status = "USED (" + projects.size() + " project" + (projects.size() == 1 ? "" : "s") + ")";
+                        String unitLine = "    • " + formatUnit(unit) + " [" + status + "]";
+                        reportConsumer.accept(unitLine);
+                        
+                        // If verbose, display the project IDs
+                        if (verbose) {
+                            displayProjectList(projects, reportConsumer, "      ");
+                        }
+                    } else if (hasUsedChildrenExcludingJRE(unit, report)) {
+                        // INDIRECTLY USED status - show as tree
+                        // Note: We use hasUsedChildrenExcludingJRE instead of report.isUsedIndirectly
+                        // because we need to filter out synthetic JRE dependencies. Units that only
+                        // depend on JRE units should show as UNUSED, not INDIRECTLY USED.
+                        
+                        // Special handling for features
+                        boolean isFeature = unit.getId().endsWith(".feature.group");
+                        boolean pathContainsFeature = pathToUsedChildContainsFeature(unit, report, shortestPaths);
+                        
+                        String status = (isFeature && !pathContainsFeature) ? "USED" : "INDIRECTLY USED";
+                        String unitLine = "    • " + formatUnit(unit) + " [" + status + "]";
+                        reportConsumer.accept(unitLine);
+                        
+                        // Display indirect usage chain as a tree structure
+                        displayIndirectUsageTree(unit, report, reportConsumer, reportedUnits, shortestPaths, verbose);
+                    } else {
+                        // UNUSED status
+                        String unitLine = "    • " + formatUnit(unit) + " [UNUSED]";
+                        reportConsumer.accept(unitLine);
+                        reportConsumer.accept("      Can potentially be removed");
+                    }
+
+                    // Mark this unit and all its transitive dependencies as reported
+                    reportedUnits.add(unit);
+                    reportedUnits.addAll(report.getAllChildren(unit));
+                }
+            }
+
+            reportConsumer.accept("");
+        }
+    }
+
+    /**
+     * Wraps a line to fit within the specified limit, continuing on the next line with the
+     * specified indent.
+     */
+    private String wrapLine(String text, String indent, int limit) {
+        if (text.length() + indent.length() <= limit) {
+            return text;
+        }
+
+        StringBuilder result = new StringBuilder();
+        String[] parts = text.split(" ");
+        StringBuilder currentLine = new StringBuilder();
+
+        for (String part : parts) {
+            if (currentLine.length() > 0 && currentLine.length() + part.length() + 1 + indent.length() > limit) {
+                // Start a new line
+                if (result.length() > 0) {
+                    result.append("\n").append(indent);
+                }
+                result.append(currentLine);
+                currentLine = new StringBuilder();
+            }
+
+            if (currentLine.length() > 0) {
+                currentLine.append(" ");
+            }
+            currentLine.append(part);
+        }
+
+        // Append the last line
+        if (currentLine.length() > 0) {
+            if (result.length() > 0) {
+                result.append("\n").append(indent);
+            }
+            result.append(currentLine);
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Formats a unit for display, handling special cases like feature groups.
+     */
+    private String formatUnit(IInstallableUnit unit) {
+        String id = unit.getId();
+        String version = unit.getVersion().toString();
+        
+        if (id.endsWith(".feature.group")) {
+            // Remove .feature.group suffix and add (feature) label
+            String baseId = id.substring(0, id.length() - ".feature.group".length());
+            return baseId + " " + version + " (feature)";
+        }
+        
+        return id + " " + version;
+    }
+    
+    /**
+     * Checks if a unit has used children (excluding JRE units).
+     */
+    private boolean hasUsedChildrenExcludingJRE(IInstallableUnit unit, UsageReport report) {
+        Set<IInstallableUnit> allChildren = report.getAllChildren(unit);
+        return allChildren.stream()
+                .filter(report.usedUnits::contains)
+                .anyMatch(child -> !child.getId().equals(SYNTHETIC_JRE_UNIT_ID));
+    }
+    
+    /**
+     * Checks if the path from this unit to any used child contains another feature.
+     */
+    private boolean pathToUsedChildContainsFeature(IInstallableUnit unit, UsageReport report,
+            Map<IInstallableUnit, List<IInstallableUnit>> shortestPaths) {
+        Set<IInstallableUnit> allChildren = report.getAllChildren(unit);
+        Set<IInstallableUnit> usedChildren = allChildren.stream()
+                .filter(report.usedUnits::contains)
+                .filter(child -> !child.getId().equals(SYNTHETIC_JRE_UNIT_ID))
+                .collect(Collectors.toSet());
+        
+        for (IInstallableUnit usedChild : usedChildren) {
+            List<IInstallableUnit> path = shortestPaths.get(usedChild);
+            if (path != null && path.size() > 0 && path.get(0).equals(unit)) {
+                // Check if any intermediate node in the path is a feature
+                for (int i = 1; i < path.size() - 1; i++) {
+                    if (path.get(i).getId().endsWith(".feature.group")) {
+                        return true;
+                    }
+                }
+            } else {
+                // Fallback: compute path
+                path = report.findPathBetween(unit, usedChild);
+                for (int i = 1; i < path.size() - 1; i++) {
+                    if (path.get(i).getId().endsWith(".feature.group")) {
+                        return true;
+                    }
+                }
+            }
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Displays a list of projects with optional limit.
+     */
+    private void displayProjectList(List<String> projects, Consumer<String> reportConsumer, String indent) {
+        int maxProjects = 5;
+        int displayCount = Math.min(projects.size(), maxProjects);
+        
+        for (int i = 0; i < displayCount; i++) {
+            reportConsumer.accept(indent + "└─ " + projects.get(i));
+        }
+        
+        if (projects.size() > maxProjects) {
+            int remaining = projects.size() - maxProjects;
+            reportConsumer.accept(indent + "└─ ... and " + remaining + " more ...");
+        }
+    }
+
+    /**
+     * Displays the indirect usage chain as a tree structure.
+     */
+    private void displayIndirectUsageTree(IInstallableUnit unit, UsageReport report, Consumer<String> reportConsumer,
+            Set<IInstallableUnit> reportedUnits, Map<IInstallableUnit, List<IInstallableUnit>> shortestPaths, 
+            boolean verbose) {
+        Set<IInstallableUnit> allChildren = report.getAllChildren(unit);
+        Set<IInstallableUnit> usedChildren = allChildren.stream()
+                .filter(report.usedUnits::contains)
+                // Filter out synthetic JRE units
+                .filter(child -> !child.getId().equals(SYNTHETIC_JRE_UNIT_ID))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        
+        if (usedChildren.isEmpty()) {
+            return;
+        }
+        
+        // Find the shortest path to any used child that hasn't been reported yet
+        IInstallableUnit targetChild = null;
+        List<IInstallableUnit> shortestPath = null;
+        
+        for (IInstallableUnit usedChild : usedChildren) {
+            // Skip if already reported
+            if (reportedUnits.contains(usedChild)) {
+                continue;
+            }
+            
+            // Use the pre-computed shortest path if available
+            List<IInstallableUnit> path = shortestPaths.get(usedChild);
+            if (path != null && path.size() > 0 && path.get(0).equals(unit)) {
+                // This path starts from our unit
+                if (shortestPath == null || path.size() < shortestPath.size()) {
+                    shortestPath = path;
+                    targetChild = usedChild;
+                }
+            } else {
+                // Fallback: compute path
+                path = report.findPathBetween(unit, usedChild);
+                if (shortestPath == null || path.size() < shortestPath.size()) {
+                    shortestPath = path;
+                    targetChild = usedChild;
+                }
+            }
+        }
+        
+        if (shortestPath == null || shortestPath.size() <= 1) {
+            return;
+        }
+        
+        // Display the shortest path as a tree (skip first element as it's the unit itself)
+        for (int i = 1; i < shortestPath.size(); i++) {
+            IInstallableUnit pathUnit = shortestPath.get(i);
+            
+            // Skip synthetic JRE units
+            if (pathUnit.getId().equals(SYNTHETIC_JRE_UNIT_ID)) {
+                continue;
+            }
+            
+            boolean isLast = (i == shortestPath.size() - 1);
+            
+            // Create the tree connector with proper indentation
+            StringBuilder indentBuilder = new StringBuilder("      ");
+            for (int j = 1; j < i; j++) {
+                indentBuilder.append("   ");
+            }
+            String indent = indentBuilder.toString();
+            String connector = "└─";
+            
+            String line = indent + connector + " " + formatUnit(pathUnit);
+            
+            // If this is the last node and it's used, add project count
+            if (isLast && report.usedUnits.contains(pathUnit)) {
+                List<String> projects = report.projectUsage.entrySet().stream()
+                        .filter(entry -> entry.getValue().contains(pathUnit))
+                        .map(project -> project.getKey().getId()).toList();
+                line += " (" + projects.size() + " project" + (projects.size() == 1 ? "" : "s") + ")";
+                reportConsumer.accept(line);
+                
+                // If verbose, display the project IDs
+                if (verbose) {
+                    String projectIndent = indent + "   ";
+                    displayProjectList(projects, reportConsumer, projectIndent);
+                }
+            } else {
+                reportConsumer.accept(line);
+            }
+        }
+    }
+
+    /**
+     * Builds a structure mapping target files to locations to units.
+     */
+    private Map<TargetDefinition, Map<String, List<UnitInfo>>> buildTargetStructure(UsageReport report) {
+        Map<TargetDefinition, Map<String, List<UnitInfo>>> structure = new LinkedHashMap<>();
+
+        // Iterate through all units and organize by target and location
+        for (Map.Entry<IInstallableUnit, Set<UsageReport.TargetDefinitionLocationReference>> entry : report.providedBy
+                .entrySet()) {
+            IInstallableUnit unit = entry.getKey();
+
+            for (UsageReport.TargetDefinitionLocationReference ref : entry.getValue()) {
+                TargetDefinition targetFile = ref.file();
+                String location = ref.location();
+
+                Map<String, List<UnitInfo>> locations = structure.computeIfAbsent(targetFile,
+                        k -> new LinkedHashMap<>());
+                List<UnitInfo> units = locations.computeIfAbsent(location, k -> new ArrayList<>());
+
+                // Only add root units (those with no parent in the dependency tree)
+                if (ref.parent() == null) {
+                    units.add(new UnitInfo(unit, ref.parent()));
+                }
+            }
+        }
+
+        return structure;
+    }
+
+    /**
+     * Computes the shortest path from any root unit to each used unit.
+     * This is used to deduplicate units that appear in multiple chains.
+     */
+    private Map<IInstallableUnit, List<IInstallableUnit>> computeShortestPaths(UsageReport report,
+            Set<IInstallableUnit> rootUnits) {
+        Map<IInstallableUnit, List<IInstallableUnit>> shortestPaths = new HashMap<>();
+
+        for (IInstallableUnit usedUnit : report.usedUnits) {
+            // Skip synthetic JRE units
+            if (usedUnit.getId().equals(SYNTHETIC_JRE_UNIT_ID)) {
+                continue;
+            }
+
+            // Find shortest path from any root to this used unit
+            List<IInstallableUnit> shortestPath = null;
+
+            for (IInstallableUnit rootUnit : rootUnits) {
+                // Skip synthetic JRE units
+                if (rootUnit.getId().equals(SYNTHETIC_JRE_UNIT_ID)) {
+                    continue;
+                }
+
+                // Check if this root can reach the used unit
+                Set<IInstallableUnit> children = report.getAllChildren(rootUnit);
+                if (children.contains(usedUnit) || rootUnit.equals(usedUnit)) {
+                    List<IInstallableUnit> path = report.findPathBetween(rootUnit, usedUnit);
+                    if (shortestPath == null || path.size() < shortestPath.size()) {
+                        shortestPath = path;
+                    }
+                }
+            }
+
+            if (shortestPath != null) {
+                shortestPaths.put(usedUnit, shortestPath);
+            }
+        }
+
+        return shortestPaths;
+    }
+
+    /**
+     * Sorts locations by the number of unique projects using units from that location.
+     * Locations with more projects are listed first.
+     */
+    private List<String> sortLocationsByProjectCount(Map<String, List<UnitInfo>> locations, UsageReport report) {
+        Map<String, Integer> locationProjectCounts = new HashMap<>();
+
+        for (Map.Entry<String, List<UnitInfo>> entry : locations.entrySet()) {
+            String location = entry.getKey();
+            List<UnitInfo> units = entry.getValue();
+
+            Set<String> uniqueProjects = countUniqueProjects(units, report);
+            locationProjectCounts.put(location, uniqueProjects.size());
+        }
+
+        // Sort by project count (descending), then by name
+        return locationProjectCounts.entrySet().stream()
+                .sorted(Comparator.<Map.Entry<String, Integer>>comparingInt(Map.Entry::getValue).reversed()
+                        .thenComparing(Map.Entry::getKey))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    /**
+     * Counts unique projects that use any of the given units or their transitive dependencies.
+     */
+    private Set<String> countUniqueProjects(List<UnitInfo> units, UsageReport report) {
+        Set<String> uniqueProjects = new HashSet<>();
+
+        for (UnitInfo unitInfo : units) {
+            IInstallableUnit unit = unitInfo.unit;
+
+            // Skip synthetic JRE units
+            if (unit.getId().equals(SYNTHETIC_JRE_UNIT_ID)) {
+                continue;
+            }
+
+            // Add projects using this unit
+            if (report.usedUnits.contains(unit)) {
+                report.projectUsage.entrySet().stream()
+                        .filter(entry -> entry.getValue().contains(unit))
+                        .forEach(entry -> uniqueProjects.add(entry.getKey().getId()));
+            }
+
+            // Add projects using any transitive dependency
+            Set<IInstallableUnit> children = report.getAllChildren(unit);
+            for (IInstallableUnit child : children) {
+                if (report.usedUnits.contains(child)) {
+                    report.projectUsage.entrySet().stream()
+                            .filter(entry -> entry.getValue().contains(child))
+                            .forEach(entry -> uniqueProjects.add(entry.getKey().getId()));
+                }
+            }
+        }
+
+        return uniqueProjects;
+    }
+
+    /**
+     * Sorts units by usage count (most used to least used, then unused).
+     */
+    private List<UnitInfo> sortUnitsByUsage(List<UnitInfo> units, UsageReport report) {
+        return units.stream()
+                .sorted((ui1, ui2) -> {
+                    IInstallableUnit u1 = ui1.unit;
+                    IInstallableUnit u2 = ui2.unit;
+
+                    // Get usage counts
+                    int count1 = getUsageCount(u1, report);
+                    int count2 = getUsageCount(u2, report);
+
+                    // Sort by count descending (most used first)
+                    if (count1 != count2) {
+                        return Integer.compare(count2, count1);
+                    }
+
+                    // If counts are equal, sort by unit name
+                    return u1.toString().compareTo(u2.toString());
+                })
+                .toList();
+    }
+
+    /**
+     * Gets the number of projects using this unit (directly or indirectly).
+     */
+    private int getUsageCount(IInstallableUnit unit, UsageReport report) {
+        Set<String> projects = new HashSet<>();
+
+        // Direct usage
+        if (report.usedUnits.contains(unit)) {
+            report.projectUsage.entrySet().stream()
+                    .filter(entry -> entry.getValue().contains(unit))
+                    .forEach(entry -> projects.add(entry.getKey().getId()));
+        }
+
+        // Indirect usage through children
+        Set<IInstallableUnit> children = report.getAllChildren(unit);
+        for (IInstallableUnit child : children) {
+            if (report.usedUnits.contains(child)) {
+                report.projectUsage.entrySet().stream()
+                        .filter(entry -> entry.getValue().contains(child))
+                        .forEach(entry -> projects.add(entry.getKey().getId()));
+            }
+        }
+
+        return projects.size();
+    }
+
+    private static class UnitInfo {
+        final IInstallableUnit unit;
+        final IInstallableUnit parent;
+
+        UnitInfo(IInstallableUnit unit, IInstallableUnit parent) {
+            this.unit = unit;
+            this.parent = parent;
+        }
+    }
+}

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/UsageMojo.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/UsageMojo.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.extras.pde.usage;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.tycho.DependencyArtifacts;
+import org.eclipse.tycho.ExecutionEnvironment;
+import org.eclipse.tycho.TargetEnvironment;
+import org.eclipse.tycho.core.TargetPlatformConfiguration;
+import org.eclipse.tycho.core.TychoProjectManager;
+import org.eclipse.tycho.core.ee.impl.StandardEEResolutionHints;
+import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
+import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
+import org.eclipse.tycho.p2maven.repository.P2RepositoryManager;
+import org.eclipse.tycho.p2resolver.TargetDefinitionResolverService;
+import org.eclipse.tycho.targetplatform.TargetDefinition;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
+import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
+
+/**
+ * This mojos compares the actual content of the target against what is used in the projects to
+ * allow for getting rid of seldom or unused dependencies
+ * 
+ * Example <code>org.eclipse.tycho.extras:tycho-dependency-tools-plugin:6.0.0-SNAPSHOT:usage</code>
+ */
+@Mojo(name = "usage", defaultPhase = LifecyclePhase.NONE, requiresProject = true, threadSafe = true, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME, aggregator = true)
+public class UsageMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "tree", property = "usage.layout")
+    private String layout;
+
+    @Parameter(property = "verbose")
+    private boolean verbose;
+
+    @Component
+    private TychoProjectManager projectManager;
+
+    @Component
+    private MavenSession mavenSession;
+
+    @Component
+    private LegacySupport legacySupport;
+
+    @Component
+    private P2RepositoryManager repositoryManager;
+
+    @Component
+    private TargetDefinitionResolverService definitionResolverService;
+
+    @Component
+    private IProvisioningAgent agent;
+
+    @Component
+    private Map<String, ReportLayout> layouts;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        ReportLayout reportLayout = Objects.requireNonNull(layouts.get(layout),
+                "The layout " + layout + " can not be found");
+        Log log = getLog();
+        log.info("Scan reactor for dependencies...");
+        List<MavenProject> projects = mavenSession.getProjects();
+        UsageReport usageReport = new UsageReport();
+        for (MavenProject project : projects) {
+            Set<IInstallableUnit> projectUnits = projectManager.getDependencyArtifacts(project)
+                    .map(DependencyArtifacts::getNonReactorUnits).stream().flatMap(Collection::stream).filter(iu -> {
+                        if (iu.getId().endsWith(".source")) {
+                            return false;
+                        }
+                        if (iu.getId().endsWith(".feature.jar")) {
+                            return false;
+                        }
+                        return true;
+                    }).collect(Collectors.toSet());
+            usageReport.projectUsage.put(project, projectUnits);
+            usageReport.usedUnits.addAll(projectUnits);
+            TargetPlatformConfiguration tpconfig = projectManager.getTargetPlatformConfiguration(project);
+            List<TargetDefinitionFile> targets = tpconfig.getTargets();
+            ExecutionEnvironment specification = projectManager.getExecutionEnvironmentConfiguration(project)
+                    .getFullSpecification();
+            TargetDefinitionResolver targetDefinitionResolver = new TargetDefinitionResolver() {
+                @Override
+                public TargetDefinition getTargetDefinition(URI uri) {
+                    return TargetDefinitionFile.read(uri);
+                }
+
+                @Override
+                public TargetDefinitionContent fetchContent(TargetDefinition definition) {
+                    return definitionResolverService.getTargetDefinitionContent(definition,
+                            List.of(TargetEnvironment.getRunningEnvironment()),
+                            new StandardEEResolutionHints(specification), IncludeSourceMode.ignore,
+                            ReferencedRepositoryMode.include, agent);
+                }
+            };
+            for (TargetDefinitionFile definitionFile : targets) {
+                usageReport.analyzeLocations(definitionFile, targetDefinitionResolver,
+                        (l, e) -> log.warn("Can't analyze location " + l, e));
+            }
+        }
+        reportLayout.generateReport(usageReport, verbose, log::info);
+    }
+
+}

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/UsageReport.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/java/org/eclipse/tycho/extras/pde/usage/UsageReport.java
@@ -1,0 +1,398 @@
+package org.eclipse.tycho.extras.pde.usage;
+
+import java.net.URI;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.maven.project.MavenProject;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IRequirement;
+import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.metadata.VersionRange;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.tycho.targetplatform.TargetDefinition;
+import org.eclipse.tycho.targetplatform.TargetDefinition.InstallableUnitLocation;
+import org.eclipse.tycho.targetplatform.TargetDefinition.Location;
+import org.eclipse.tycho.targetplatform.TargetDefinition.TargetReferenceLocation;
+import org.eclipse.tycho.targetplatform.TargetDefinition.Unit;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
+
+final class UsageReport {
+    /**
+     * Maximum number of indirect usage examples to show in the report
+     */
+    private static final int MAX_INDIRECT_USAGE_EXAMPLES = 3;
+
+    /**
+     * Maps a project to the units it uses (or at least is resolved to)
+     */
+    final Map<MavenProject, Set<IInstallableUnit>> projectUsage = new HashMap<>();
+    /**
+     * A collection of units used by all projects in the reactor
+     */
+    final Set<IInstallableUnit> usedUnits = new HashSet<>();
+    /**
+     * A collection of all used target definitions in the reactor
+     */
+    private final Set<TargetDefinition> targetFiles = new HashSet<>();
+
+    /**
+     * Maps a target definition to a list of other targets where it is referenced
+     */
+    final Map<TargetDefinition, List<TargetDefinition>> targetReferences = new HashMap<>();
+    /**
+     * Maps a target definition to its actual content
+     */
+    private final Map<TargetDefinition, TargetDefinitionContent> targetFileUnits = new HashMap<>();
+    /**
+     * Maps a unit to the set of definition files this unit is defined in
+     */
+    final Map<IInstallableUnit, Set<TargetDefinitionLocationReference>> providedBy = new HashMap<>();
+
+    private final Map<IInstallableUnit, Set<IInstallableUnit>> parentMap = new HashMap<>();
+
+    private final Map<IInstallableUnit, Set<IInstallableUnit>> childMap = new HashMap<>();
+
+    private void reportProvided(IInstallableUnit iu, TargetDefinition file, String location, IInstallableUnit parent) {
+        if (parent != null) {
+            parentMap.computeIfAbsent(iu, nil -> new HashSet<>()).add(parent);
+            childMap.computeIfAbsent(parent, nil -> new HashSet<>()).add(iu);
+        }
+        providedBy.computeIfAbsent(iu, nil -> new HashSet<>())
+                .add(new TargetDefinitionLocationReference(parent, file, location));
+    }
+
+    static record TargetDefinitionLocationReference(IInstallableUnit parent, TargetDefinition file, String location) {
+
+    }
+
+    /**
+     * Returns true if this unit is a root unit (defined directly in the target file)
+     */
+    boolean isRootUnit(IInstallableUnit unit) {
+        Set<TargetDefinitionLocationReference> refs = providedBy.get(unit);
+        if (refs == null) {
+            return false;
+        }
+        return refs.stream().anyMatch(ref -> ref.parent() == null);
+    }
+
+    /**
+     * Gets all transitive children of a unit
+     */
+    Set<IInstallableUnit> getAllChildren(IInstallableUnit unit) {
+        Set<IInstallableUnit> result = new HashSet<>();
+        collectChildren(unit, result);
+        return result;
+    }
+
+    private void collectChildren(IInstallableUnit unit, Set<IInstallableUnit> result) {
+        Set<IInstallableUnit> children = childMap.get(unit);
+        if (children != null) {
+            for (IInstallableUnit child : children) {
+                if (result.add(child)) {
+                    collectChildren(child, result);
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if any child in the dependency tree of this unit is used
+     */
+    boolean hasUsedChildren(IInstallableUnit unit) {
+        Set<IInstallableUnit> allChildren = getAllChildren(unit);
+        return allChildren.stream().anyMatch(usedUnits::contains);
+    }
+
+    /**
+     * Gets the shortest path from a root unit to the target unit
+     */
+    List<IInstallableUnit> getShortestPathFromRoot(IInstallableUnit unit) {
+        // BFS to find shortest path from any root to this unit
+        Set<IInstallableUnit> visited = new HashSet<>();
+        Deque<List<IInstallableUnit>> queue = new ArrayDeque<>();
+
+        // Start from the unit itself
+        List<IInstallableUnit> initialPath = new ArrayList<>();
+        initialPath.add(unit);
+        queue.add(initialPath);
+        visited.add(unit);
+
+        List<IInstallableUnit> shortestPath = null;
+
+        while (!queue.isEmpty()) {
+            List<IInstallableUnit> currentPath = queue.poll();
+            IInstallableUnit current = currentPath.get(currentPath.size() - 1);
+
+            // Check if we've reached a root
+            if (isRootUnit(current)) {
+                if (shortestPath == null || currentPath.size() < shortestPath.size()) {
+                    shortestPath = new ArrayList<>(currentPath);
+                }
+                continue; // Keep searching for potentially shorter paths
+            }
+
+            // Explore parents
+            Set<IInstallableUnit> parents = parentMap.get(current);
+            if (parents != null) {
+                for (IInstallableUnit parent : parents) {
+                    if (!visited.contains(parent)) {
+                        visited.add(parent);
+                        List<IInstallableUnit> newPath = new ArrayList<>(currentPath);
+                        newPath.add(parent);
+                        queue.add(newPath);
+                    }
+                }
+            }
+        }
+
+        // Reverse the path so it goes from root to unit
+        if (shortestPath != null) {
+            List<IInstallableUnit> reversed = new ArrayList<>(shortestPath);
+            java.util.Collections.reverse(reversed);
+            return reversed;
+        }
+
+        return List.of(unit);
+    }
+
+    /**
+     * Returns formatted string showing where the unit is provided from, including nesting
+     */
+    String getProvidedBy(IInstallableUnit unit) {
+        Set<TargetDefinitionLocationReference> refs = providedBy.get(unit);
+        if (refs == null || refs.isEmpty()) {
+            return "unknown";
+        }
+
+        // Find the reference with the shortest path to a root
+        return refs.stream().map(ref -> {
+            StringBuilder sb = new StringBuilder();
+            sb.append(ref.file().getOrigin());
+            sb.append(" > ");
+            sb.append(ref.location());
+
+            // If this has a parent, show the nesting
+            if (ref.parent() != null) {
+                List<IInstallableUnit> path = getShortestPathFromRoot(unit);
+                if (path.size() > 1) {
+                    sb.append(" > ");
+                    sb.append(path.stream().map(IInstallableUnit::toString).collect(Collectors.joining(" > ")));
+                }
+            }
+
+            return sb.toString();
+        }).collect(Collectors.joining("; "));
+    }
+
+    /**
+     * Checks if a unit is used indirectly (used unit is a descendant, not the unit itself)
+     */
+    boolean isUsedIndirectly(IInstallableUnit unit) {
+        if (usedUnits.contains(unit)) {
+            return false; // Used directly
+        }
+        return hasUsedChildren(unit);
+    }
+
+    /**
+     * Gets the chain showing how this unit is indirectly used
+     */
+    String getIndirectUsageChain(IInstallableUnit unit) {
+        Set<IInstallableUnit> allChildren = getAllChildren(unit);
+        Set<IInstallableUnit> usedChildren = allChildren.stream().filter(usedUnits::contains)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (usedChildren.isEmpty()) {
+            return "";
+        }
+
+        // For each used child, find the shortest path from this unit to it
+        return usedChildren.stream().limit(MAX_INDIRECT_USAGE_EXAMPLES).map(usedChild -> {
+            List<IInstallableUnit> path = findPathBetween(unit, usedChild);
+            return path.stream().map(IInstallableUnit::toString).collect(Collectors.joining(" > "));
+        }).collect(Collectors.joining("; "));
+    }
+
+    /**
+     * Finds shortest path between two units using BFS
+     */
+    List<IInstallableUnit> findPathBetween(IInstallableUnit start, IInstallableUnit end) {
+        Set<IInstallableUnit> visited = new HashSet<>();
+        Deque<List<IInstallableUnit>> queue = new ArrayDeque<>();
+
+        List<IInstallableUnit> initialPath = new ArrayList<>();
+        initialPath.add(start);
+        queue.add(initialPath);
+        visited.add(start);
+
+        while (!queue.isEmpty()) {
+            List<IInstallableUnit> currentPath = queue.poll();
+            IInstallableUnit current = currentPath.get(currentPath.size() - 1);
+
+            if (current.equals(end)) {
+                return currentPath;
+            }
+
+            Set<IInstallableUnit> children = childMap.get(current);
+            if (children != null) {
+                for (IInstallableUnit child : children) {
+                    if (!visited.contains(child)) {
+                        visited.add(child);
+                        List<IInstallableUnit> newPath = new ArrayList<>(currentPath);
+                        newPath.add(child);
+                        queue.add(newPath);
+                    }
+                }
+            }
+        }
+
+        return List.of(start, end); // Fallback
+    }
+
+    void analyzeLocations(TargetDefinition definitionFile, TargetDefinitionResolver targetResolver,
+            BiConsumer<Location, RuntimeException> exceptionConsumer) {
+        if (targetFiles.add(definitionFile)) {
+            targetFileUnits.put(definitionFile, targetResolver.fetchContent(definitionFile));
+            for (Location location : definitionFile.getLocations()) {
+                try {
+                    if (location instanceof InstallableUnitLocation iu) {
+                        analyzeIULocation(definitionFile, iu);
+                    } else if (location instanceof TargetReferenceLocation ref) {
+                        TargetDefinition referenceTargetDefinition = targetResolver
+                                .getTargetDefinition(URI.create(ref.getUri()));
+                        targetReferences.computeIfAbsent(referenceTargetDefinition, nil -> new ArrayList<>())
+                                .add(definitionFile);
+                        analyzeLocations(referenceTargetDefinition, targetResolver, exceptionConsumer);
+                    }
+                } catch (RuntimeException e) {
+                    exceptionConsumer.accept(location, e);
+                }
+            }
+        }
+    }
+
+    private void analyzeIULocation(TargetDefinition file, InstallableUnitLocation location) {
+        List<? extends Unit> units = location.getUnits();
+        String ref = location.getRepositories().stream().map(r -> r.getLocation()).collect(Collectors.joining(", "));
+        TargetDefinitionContent content = targetFileUnits.get(file);
+        for (Unit unit : units) {
+            String id = unit.getId();
+            String version = unit.getVersion();
+            Optional<IInstallableUnit> found;
+            if (version == null || version.isBlank() || version.equals("0.0.0")) {
+                found = content.query(QueryUtil.createIUQuery(id), null).stream().findFirst();
+            } else if (version.startsWith("[") || version.startsWith("(")) {
+                found = content
+                        .query(QueryUtil.createLatestQuery(QueryUtil.createIUQuery(id, VersionRange.create(version))),
+                                null)
+                        .stream().findFirst();
+            } else {
+                found = content.query(QueryUtil.createIUQuery(id, Version.create(version)), null).stream().findFirst();
+            }
+            if (found.isPresent()) {
+                IInstallableUnit iu = found.get();
+                reportUsage(iu, null, file, ref, content, new HashSet<>());
+            }
+        }
+    }
+
+    private void reportUsage(IInstallableUnit iu, IInstallableUnit parent, TargetDefinition file, String location,
+            TargetDefinitionContent content, Set<IInstallableUnit> seen) {
+        if (seen.add(iu)) {
+            reportProvided(iu, file, location, parent);
+            Collection<IRequirement> requirements = iu.getRequirements();
+            Set<IInstallableUnit> units = content.query(QueryUtil.ALL_UNITS, null).toSet();
+            for (IRequirement requirement : requirements) {
+                for (IInstallableUnit provider : units) {
+                    if (provider.satisfies(requirement)) {
+                        reportUsage(provider, iu, file, location, content, seen);
+                    }
+                }
+            }
+        }
+    }
+    
+    /**
+     * Checks if any unit from a referenced target is used in any project.
+     * 
+     * @param refUri the URI of the referenced target
+     * @return true if any unit from the referenced target is used, false otherwise
+     */
+    boolean isReferencedTargetUsed(String refUri) {
+        // Find the target definition by URI
+        // The refUri might be a full file:// URI or a relative path
+        // We need to match it against the origin which might be just a filename
+        for (TargetDefinition target : targetFiles) {
+            String origin = target.getOrigin();
+            
+            // Check for exact match or if one ends with the other
+            if (origin.equals(refUri) || 
+                origin.endsWith(refUri) || 
+                refUri.endsWith(origin) ||
+                refUri.endsWith("/" + origin)) {
+                
+                // Check if any unit from this target is used
+                Set<IInstallableUnit> targetUnits = providedBy.entrySet().stream()
+                        .filter(entry -> entry.getValue().stream()
+                                .anyMatch(ref -> ref.file().equals(target)))
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toSet());
+                
+                // Check if any of these units (or their children) are used
+                for (IInstallableUnit unit : targetUnits) {
+                    if (usedUnits.contains(unit)) {
+                        return true;
+                    }
+                    Set<IInstallableUnit> children = getAllChildren(unit);
+                    if (children.stream().anyMatch(usedUnits::contains)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns a stream of all target files analyzed by this report.
+     * 
+     * @return stream of target definitions
+     */
+    Stream<TargetDefinition> getTargetFiles() {
+        return targetFiles.stream();
+    }
+
+    /**
+     * Returns the number of target files analyzed by this report.
+     * 
+     * @return the count of target files
+     */
+    int getTargetFilesCount() {
+        return targetFiles.size();
+    }
+
+    /**
+     * Returns the target definition content for the specified target definition.
+     * 
+     * @param targetDefinition the target definition to get content for
+     * @return the target definition content, or null if not found
+     */
+    TargetDefinitionContent getTargetDefinitionContent(TargetDefinition targetDefinition) {
+        return targetFileUnits.get(targetDefinition);
+    }
+
+}

--- a/tycho-extras/tycho-dependency-tools-plugin/src/test/java/org/eclipse/tycho/extras/pde/usage/TreeUsageReportLayoutTest.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/test/java/org/eclipse/tycho/extras/pde/usage/TreeUsageReportLayoutTest.java
@@ -1,0 +1,977 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tycho.extras.pde.usage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.maven.project.MavenProject;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IRequirement;
+import org.eclipse.equinox.p2.metadata.MetadataFactory;
+import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.metadata.VersionRange;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.tycho.extras.pde.usage.TreeUsageReportLayout;
+import org.eclipse.tycho.extras.pde.usage.UsageReport;
+import org.eclipse.tycho.targetplatform.TargetDefinition;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the TreeUsageReportLayout implementation.
+ */
+public class TreeUsageReportLayoutTest {
+
+    /**
+     * Tests that the tree layout generates structured output with proper indentation.
+     */
+    @Test
+    void testTreeStructure() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        
+        // Create target definition with units in different locations
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL1", Arrays.asList(unitA),
+            "LocationL2", Arrays.asList(unitB)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("my-target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitB);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark A as used
+        MavenProject project = createMockProject("project1");
+        report.usedUnits.add(unitA);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitA);
+        
+        // Collect report output using TreeLayout
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        // Verify structure
+        String fullReport = String.join("\n", reportLines);
+        
+        // Check for header
+        assertTrue(fullReport.contains("DEPENDENCIES USAGE REPORT"), "Should contain corrected header");
+        
+        // Check for tree structure
+        assertTrue(fullReport.contains("Target: my-target.target"), "Should contain target name");
+        assertTrue(fullReport.contains("Location: LocationL1"), "Should contain location L1");
+        assertTrue(fullReport.contains("Location: LocationL2"), "Should contain location L2");
+        
+        // Check for unit status indicators
+        assertTrue(fullReport.contains("[USED (1 project)]"), "Should show USED status with project count");
+        assertTrue(fullReport.contains("[UNUSED]"), "Should show UNUSED status");
+        
+        // Check for indentation (units should be indented under locations)
+        assertTrue(fullReport.contains("    • unitA"), "Units should be indented with bullet");
+    }
+    
+    /**
+     * Tests that the tree layout correctly identifies and displays indirect usage.
+     */
+    @Test
+    void testTreeIndirectUsage() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        
+        // Set up requirements: A requires B
+        IRequirement reqB = createRequirement("unitB", "1.0.0");
+        when(unitA.getRequirements()).thenReturn(Arrays.asList(reqB));
+        when(unitB.satisfies(reqB)).thenReturn(true);
+        
+        // Create target definition with unitA in LocationL
+        // analyzeLocations will discover unitB as a dependency of unitA
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL", Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitB);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark only B as used
+        report.usedUnits.add(unitB);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitB);
+        
+        // Collect report output using TreeLayout
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        // Verify indirect usage is shown
+        String fullReport = String.join("\n", reportLines);
+        assertTrue(fullReport.contains("[INDIRECTLY USED]"), "Should show INDIRECTLY USED status");
+        assertTrue(fullReport.contains("└─"), "Should show tree structure for indirect usage chain");
+    }
+    
+    /**
+     * Tests that line wrapping works correctly for long lines.
+     */
+    @Test
+    void testLineWrapping() {
+        UsageReport report = new UsageReport();
+        
+        // Create a unit with a very long repository location
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        
+        // Create target with a long location name
+        String longLocation = "https://download.eclipse.org/releases/2024-09/202409111000/plugins/repository";
+        
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            longLocation, Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        report.usedUnits.add(unitA);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitA);
+        
+        // Use a small line wrap limit to test wrapping
+        TreeUsageReportLayout layout = new TreeUsageReportLayout(80);
+        
+        List<String> reportLines = new ArrayList<>();
+        layout.generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Verify report was generated (basic check)
+        assertTrue(fullReport.contains("unitA"), "Should contain unit A");
+        assertTrue(fullReport.contains("[USED (1 project)]"), "Should show USED status with project count");
+    }
+    
+    /**
+     * Tests that multiple target files are properly separated in the output.
+     */
+    @Test
+    void testMultipleTargetFiles() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units for two different targets
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        
+        // Create two target definitions
+        Map<String, List<IInstallableUnit>> locationUnits1 = Map.of(
+            "Location1", Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef1 = createMockTargetDefinitionWithIULocations("target1.target", locationUnits1);
+        TargetDefinitionContent content1 = createMockContent(unitA);
+        TargetDefinitionResolver resolver1 = createMockResolver(targetDef1, content1);
+        
+        Map<String, List<IInstallableUnit>> locationUnits2 = Map.of(
+            "Location2", Arrays.asList(unitB)
+        );
+        TargetDefinition targetDef2 = createMockTargetDefinitionWithIULocations("target2.target", locationUnits2);
+        TargetDefinitionContent content2 = createMockContent(unitB);
+        TargetDefinitionResolver resolver2 = createMockResolver(targetDef2, content2);
+        
+        // Analyze both targets using the proper API
+        report.analyzeLocations(targetDef1, resolver1, (l, e) -> {});
+        report.analyzeLocations(targetDef2, resolver2, (l, e) -> {});
+        
+        // Mark both as used
+        MavenProject project = createMockProject("project1");
+        report.usedUnits.add(unitA);
+        report.usedUnits.add(unitB);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitA);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitB);
+        
+        // Collect report
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Verify both targets are shown
+        assertTrue(fullReport.contains("Target: target1.target"), "Should contain target1");
+        assertTrue(fullReport.contains("Target: target2.target"), "Should contain target2");
+        assertTrue(fullReport.contains("Location: Location1"), "Should contain Location1");
+        assertTrue(fullReport.contains("Location: Location2"), "Should contain Location2");
+    }
+    
+    /**
+     * Tests the new format for USED status with project count in brackets.
+     */
+    @Test
+    void testUsedFormatWithProjectCount() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit unit = createMockUnit("org.eclipse.wst.common.emf", "1.2.800.v202508180220");
+        
+        // Create target definition with unit in location
+        String location = "https://download.eclipse.org/webtools/downloads/drops/R3.39.0/R-3.39.0-20250902093744/repository/";
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(location, Arrays.asList(unit));
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark unit as used by 29 projects
+        report.usedUnits.add(unit);
+        for (int i = 1; i <= 29; i++) {
+            MavenProject project = createMockProject("project" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit);
+        }
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Verify the new format: [USED (29 projects)] instead of [USED]\n      Used by 29 project(s)
+        assertTrue(fullReport.contains("[USED (29 projects)]"), 
+            "Should show project count in brackets on same line as status");
+        assertFalse(fullReport.contains("Used by 29 project(s)"), 
+            "Should not show old format on separate line");
+    }
+    
+    /**
+     * Tests the new tree format for INDIRECTLY USED status.
+     */
+    @Test
+    void testIndirectlyUsedTreeFormat() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit unitA = createMockUnit("org.eclipse.emf.ecore.edit.feature.group", "2.17.0.v20240604-0832");
+        IInstallableUnit unitB = createMockUnit("org.eclipse.emf.edit", "2.23.0.v20250330-0741");
+        IInstallableUnit unitC = createMockUnit("org.eclipse.emf.ecore.change", "2.17.0.v20240604-0832");
+        
+        // Set up requirements: A > B > C
+        IRequirement reqB = createRequirement("org.eclipse.emf.edit", "2.23.0.v20250330-0741");
+        IRequirement reqC = createRequirement("org.eclipse.emf.ecore.change", "2.17.0.v20240604-0832");
+        when(unitA.getRequirements()).thenReturn(Arrays.asList(reqB));
+        when(unitB.getRequirements()).thenReturn(Arrays.asList(reqC));
+        when(unitB.satisfies(reqB)).thenReturn(true);
+        when(unitC.satisfies(reqC)).thenReturn(true);
+        
+        // Create target definition with unitA in location
+        String location = "https://download.eclipse.org/modeling/emf/emf/builds/release/2.43.0";
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(location, Arrays.asList(unitA));
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitB, unitC);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark unitC as used by 5 projects (makes A and B indirectly used)
+        report.usedUnits.add(unitC);
+        for (int i = 1; i <= 5; i++) {
+            MavenProject project = createMockProject("project" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitC);
+        }
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Note: Feature A shows as USED (not INDIRECTLY USED) because there's no other feature in the path
+        // This is the new behavior per requirements
+        assertTrue(fullReport.contains("[USED]"), "Should show USED status for feature without another feature in path");
+        assertTrue(fullReport.contains("└─"), "Should use tree connector");
+        assertTrue(fullReport.contains("(5 projects)"), "Should show project count on final node");
+        assertFalse(fullReport.contains("Via:"), "Should not use old 'Via:' format");
+        assertTrue(fullReport.contains("(feature)"), "Should show (feature) label for feature.group units");
+    }
+
+    /**
+     * Tests that duplicate units are not reported multiple times.
+     * A unit should only appear once even if it's in multiple dependency chains.
+     */
+    @Test
+    void testNoDuplicateUnits() {
+        UsageReport report = new UsageReport();
+        
+        // Create three root units that all lead to the same used unit
+        IInstallableUnit root1 = createMockUnit("root1", "1.0.0");
+        IInstallableUnit root2 = createMockUnit("root2", "1.0.0");
+        IInstallableUnit intermediate1 = createMockUnit("intermediate1", "1.0.0");
+        IInstallableUnit intermediate2 = createMockUnit("intermediate2", "1.0.0");
+        IInstallableUnit sharedUnit = createMockUnit("ch.qos.logback.classic", "1.5.18");
+        
+        // Set up requirements
+        IRequirement reqInt1 = createRequirement("intermediate1", "1.0.0");
+        IRequirement reqInt2 = createRequirement("intermediate2", "1.0.0");
+        IRequirement reqShared = createRequirement("ch.qos.logback.classic", "1.5.18");
+        
+        when(root1.getRequirements()).thenReturn(Arrays.asList(reqInt1));
+        when(root2.getRequirements()).thenReturn(Arrays.asList(reqInt2));
+        when(intermediate1.getRequirements()).thenReturn(Arrays.asList(reqShared));
+        when(intermediate2.getRequirements()).thenReturn(Arrays.asList(reqShared));
+        when(intermediate1.satisfies(reqInt1)).thenReturn(true);
+        when(intermediate2.satisfies(reqInt2)).thenReturn(true);
+        when(sharedUnit.satisfies(reqShared)).thenReturn(true);
+        
+        // Create target definition with root units in different locations
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "Location1", Arrays.asList(root1),
+            "Location2", Arrays.asList(root2)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(root1, root2, intermediate1, intermediate2, sharedUnit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark the shared unit as used
+        report.usedUnits.add(sharedUnit);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(sharedUnit);
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Count occurrences of the shared unit
+        long sharedUnitCount = reportLines.stream()
+                .filter(line -> line.contains("ch.qos.logback.classic"))
+                .count();
+        
+        // The shared unit should appear only once (in the shortest path)
+        assertTrue(sharedUnitCount == 1, 
+            "ch.qos.logback.classic should appear only once, but appeared " + sharedUnitCount + " times");
+    }
+
+    /**
+     * Tests that synthetic JRE units (a.jre.javase) are filtered out.
+     */
+    @Test
+    void testSyntheticJreUnitsFiltered() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit rootUnit = createMockUnit("org.eclipse.equinox.launcher", "1.7.0.v20250519-0528");
+        IInstallableUnit jreUnit = createMockUnit("a.jre.javase", "21.0.0");
+        IInstallableUnit realUnit = createMockUnit("org.eclipse.core.runtime", "3.29.0");
+        
+        // Set up requirements
+        IRequirement reqJre = createRequirement("a.jre.javase", "21.0.0");
+        IRequirement reqReal = createRequirement("org.eclipse.core.runtime", "3.29.0");
+        
+        when(rootUnit.getRequirements()).thenReturn(Arrays.asList(reqJre, reqReal));
+        when(jreUnit.satisfies(reqJre)).thenReturn(true);
+        when(realUnit.satisfies(reqReal)).thenReturn(true);
+        
+        // Create target definition with rootUnit in location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "Location1", Arrays.asList(rootUnit)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(rootUnit, jreUnit, realUnit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark both as used
+        report.usedUnits.add(jreUnit);
+        report.usedUnits.add(realUnit);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(jreUnit);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(realUnit);
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // JRE units should not appear in the report
+        assertFalse(fullReport.contains("a.jre.javase"), 
+            "Synthetic JRE unit a.jre.javase should be filtered out");
+        assertTrue(fullReport.contains("org.eclipse.core.runtime"), 
+            "Real unit should still appear in report");
+    }
+
+    /**
+     * Tests that locations are sorted by project count (highest to lowest).
+     */
+    @Test
+    void testLocationsSortedByProjectCount() {
+        UsageReport report = new UsageReport();
+        
+        // Create units in different locations with different usage counts
+        IInstallableUnit unit1 = createMockUnit("unit1", "1.0.0");
+        IInstallableUnit unit2 = createMockUnit("unit2", "1.0.0");
+        IInstallableUnit unit3 = createMockUnit("unit3", "1.0.0");
+        
+        // Create target definition with units in different locations
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationA", Arrays.asList(unit1),
+            "LocationB", Arrays.asList(unit2),
+            "LocationC", Arrays.asList(unit3)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unit1, unit2, unit3);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // LocationA: 2 projects use unit1
+        report.usedUnits.add(unit1);
+        for (int i = 1; i <= 2; i++) {
+            MavenProject project = createMockProject("projectA" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit1);
+        }
+        
+        // LocationB: 5 projects use unit2
+        report.usedUnits.add(unit2);
+        for (int i = 1; i <= 5; i++) {
+            MavenProject project = createMockProject("projectB" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit2);
+        }
+        
+        // LocationC: 3 projects use unit3
+        report.usedUnits.add(unit3);
+        for (int i = 1; i <= 3; i++) {
+            MavenProject project = createMockProject("projectC" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit3);
+        }
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        // Find the order of locations in the output
+        int indexB = -1, indexC = -1, indexA = -1;
+        for (int i = 0; i < reportLines.size(); i++) {
+            String line = reportLines.get(i);
+            if (line.contains("Location: LocationB")) indexB = i;
+            if (line.contains("Location: LocationC")) indexC = i;
+            if (line.contains("Location: LocationA")) indexA = i;
+        }
+        
+        // LocationB (5 projects) should come before LocationC (3 projects)
+        // LocationC (3 projects) should come before LocationA (2 projects)
+        assertTrue(indexB > 0 && indexC > 0 && indexA > 0, "All locations should be present");
+        assertTrue(indexB < indexC, "LocationB (5 projects) should come before LocationC (3 projects)");
+        assertTrue(indexC < indexA, "LocationC (3 projects) should come before LocationA (2 projects)");
+    }
+
+    /**
+     * Tests that root units within a location are sorted by usage count.
+     */
+    @Test
+    void testUnitsSortedByUsageCount() {
+        UsageReport report = new UsageReport();
+        
+        // Create units with different usage counts
+        IInstallableUnit unit1 = createMockUnit("unitAlpha", "1.0.0");
+        IInstallableUnit unit2 = createMockUnit("unitBeta", "1.0.0");
+        IInstallableUnit unit3 = createMockUnit("unitGamma", "1.0.0");
+        
+        String location = "LocationX";
+        
+        // Create target definition with all units in the same location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            location, Arrays.asList(unit1, unit2, unit3)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unit1, unit2, unit3);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // unitAlpha: used by 3 projects
+        report.usedUnits.add(unit1);
+        for (int i = 1; i <= 3; i++) {
+            MavenProject project = createMockProject("projectAlpha" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit1);
+        }
+        
+        // unitBeta: used by 7 projects
+        report.usedUnits.add(unit2);
+        for (int i = 1; i <= 7; i++) {
+            MavenProject project = createMockProject("projectBeta" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit2);
+        }
+        
+        // unitGamma: used by 1 project
+        report.usedUnits.add(unit3);
+        MavenProject project = createMockProject("projectGamma1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit3);
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        // Find the order of units in the output
+        int indexAlpha = -1, indexBeta = -1, indexGamma = -1;
+        for (int i = 0; i < reportLines.size(); i++) {
+            String line = reportLines.get(i);
+            if (line.contains("unitAlpha")) indexAlpha = i;
+            if (line.contains("unitBeta")) indexBeta = i;
+            if (line.contains("unitGamma")) indexGamma = i;
+        }
+        
+        // unitBeta (7 projects) should come first
+        // unitAlpha (3 projects) should come second
+        // unitGamma (1 project) should come last
+        assertTrue(indexAlpha > 0 && indexBeta > 0 && indexGamma > 0, "All units should be present");
+        assertTrue(indexBeta < indexAlpha, "unitBeta (7 projects) should come before unitAlpha (3 projects)");
+        assertTrue(indexAlpha < indexGamma, "unitAlpha (3 projects) should come before unitGamma (1 project)");
+    }
+
+    /**
+     * Tests that location includes project count in the output.
+     */
+    @Test
+    void testLocationShowsProjectCount() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit unit = createMockUnit("test.unit", "1.0.0");
+        
+        // Create target definition with unit in location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "TestLocation", Arrays.asList(unit)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        report.usedUnits.add(unit);
+        
+        // Add 3 projects using this unit
+        for (int i = 1; i <= 3; i++) {
+            MavenProject project = createMockProject("project" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit);
+        }
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Verify location shows project count
+        assertTrue(fullReport.contains("Location: TestLocation (3 projects)"), 
+            "Location should show project count");
+    }
+
+    /**
+     * Tests that feature.group units are formatted with (feature) suffix.
+     */
+    @Test
+    void testFeatureGroupFormatting() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit featureUnit = createMockUnit("org.eclipse.equinox.p2.discovery.feature.feature.group", 
+                "1.3.900.v20250616-0711");
+        
+        // Create target definition with featureUnit in location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "Location1", Arrays.asList(featureUnit)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(featureUnit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        report.usedUnits.add(featureUnit);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(featureUnit);
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Verify feature group formatting: suffix removed and (feature) added
+        assertTrue(fullReport.contains("org.eclipse.equinox.p2.discovery.feature 1.3.900.v20250616-0711 (feature)"), 
+            "Feature group should be formatted without .feature.group suffix and with (feature) label");
+        assertFalse(fullReport.contains(".feature.group"), 
+            "Should not contain .feature.group in the output");
+    }
+
+    /**
+     * Tests that indirectly used features show as [USED] when no other feature is in the path.
+     */
+    @Test
+    void testFeatureShowsAsUsedWhenIndirect() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit featureUnit = createMockUnit("org.eclipse.emf.ecore.edit.feature.group", "2.17.0.v20240604-0832");
+        IInstallableUnit bundleUnit = createMockUnit("org.eclipse.emf.ecore.edit", "2.15.0.v20240604-0832");
+        
+        // Set up requirements: feature > bundle
+        IRequirement reqBundle = createRequirement("org.eclipse.emf.ecore.edit", "2.15.0.v20240604-0832");
+        when(featureUnit.getRequirements()).thenReturn(Arrays.asList(reqBundle));
+        when(bundleUnit.satisfies(reqBundle)).thenReturn(true);
+        
+        // Create target definition with featureUnit in location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "Location1", Arrays.asList(featureUnit)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(featureUnit, bundleUnit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark only bundle as used
+        report.usedUnits.add(bundleUnit);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(bundleUnit);
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Feature should show as USED (not INDIRECTLY USED) since there's no other feature in the path
+        assertTrue(fullReport.contains("org.eclipse.emf.ecore.edit 2.17.0.v20240604-0832 (feature) [USED]"), 
+            "Feature should show as [USED] when indirectly used without another feature in path");
+        assertFalse(fullReport.contains("[INDIRECTLY USED]"), 
+            "Should not show INDIRECTLY USED for feature without another feature in path");
+    }
+
+    /**
+     * Tests that features show as [INDIRECTLY USED] when another feature is in the path.
+     */
+    @Test
+    void testFeatureShowsAsIndirectlyUsedWithFeatureInPath() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit feature1 = createMockUnit("org.eclipse.swtbot.eclipse.feature.group", "4.3.0.202506021445");
+        IInstallableUnit feature2 = createMockUnit("org.eclipse.swtbot.feature.group", "4.3.0.202506021445");
+        IInstallableUnit bundleUnit = createMockUnit("org.hamcrest.library", "2.2.0.v20230809-1000");
+        
+        // Set up requirements: feature1 > feature2 > bundle
+        IRequirement reqFeature2 = createRequirement("org.eclipse.swtbot.feature.group", "4.3.0.202506021445");
+        IRequirement reqBundle = createRequirement("org.hamcrest.library", "2.2.0.v20230809-1000");
+        when(feature1.getRequirements()).thenReturn(Arrays.asList(reqFeature2));
+        when(feature2.getRequirements()).thenReturn(Arrays.asList(reqBundle));
+        when(feature2.satisfies(reqFeature2)).thenReturn(true);
+        when(bundleUnit.satisfies(reqBundle)).thenReturn(true);
+        
+        // Create target definition with feature1 in location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "Location1", Arrays.asList(feature1)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(feature1, feature2, bundleUnit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark only bundle as used
+        report.usedUnits.add(bundleUnit);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(bundleUnit);
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Feature should show as INDIRECTLY USED since another feature is in the path
+        assertTrue(fullReport.contains("org.eclipse.swtbot.eclipse 4.3.0.202506021445 (feature) [INDIRECTLY USED]"), 
+            "Feature should show as [INDIRECTLY USED] when another feature is in path");
+    }
+
+    /**
+     * Tests verbose mode shows project IDs under used units.
+     */
+    @Test
+    void testVerboseModeShowsProjectIds() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit unit = createMockUnit("org.jdom2", "2.0.6.v20230720-0727");
+        
+        // Create target definition with unit in location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "Location1", Arrays.asList(unit)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        report.usedUnits.add(unit);
+        
+        // Add 3 projects
+        for (int i = 1; i <= 3; i++) {
+            MavenProject project = createMockProject("project" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit);
+        }
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, true, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Verify project IDs are shown in verbose mode
+        assertTrue(fullReport.contains("└─ project1"), "Should show project1 in verbose mode");
+        assertTrue(fullReport.contains("└─ project2"), "Should show project2 in verbose mode");
+        assertTrue(fullReport.contains("└─ project3"), "Should show project3 in verbose mode");
+    }
+
+    /**
+     * Tests verbose mode limits project display to 5 with "and X more" message.
+     */
+    @Test
+    void testVerboseModeLimitsProjectDisplay() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit unit = createMockUnit("org.jdom2", "2.0.6.v20230720-0727");
+        
+        // Create target definition with unit in location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "Location1", Arrays.asList(unit)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        report.usedUnits.add(unit);
+        
+        // Add 28 projects
+        for (int i = 1; i <= 28; i++) {
+            MavenProject project = createMockProject("project" + i);
+            report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unit);
+        }
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, true, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Verify only 5 projects are shown with "and 23 more" message
+        // Count how many project lines are shown
+        long projectLineCount = reportLines.stream()
+                .filter(line -> line.contains("└─ project"))
+                .filter(line -> !line.contains("more"))
+                .count();
+        
+        assertTrue(projectLineCount == 5, "Should show exactly 5 project lines, but got " + projectLineCount);
+        assertTrue(fullReport.contains("└─ ... and 23 more ..."), "Should show 'and 23 more' message");
+    }
+
+    /**
+     * Tests that units with only JRE dependencies show as UNUSED not INDIRECTLY USED.
+     */
+    @Test
+    void testUnitWithOnlyJreDependenciesShowsAsUnused() {
+        UsageReport report = new UsageReport();
+        
+        IInstallableUnit rootUnit = createMockUnit("org.eclipse.equinox.executable.feature.group", 
+                "3.8.3000.v20250801-0854");
+        IInstallableUnit jreUnit = createMockUnit("a.jre.javase", "21.0.0");
+        
+        // Set up requirements: root > jre only
+        IRequirement reqJre = createRequirement("a.jre.javase", "21.0.0");
+        when(rootUnit.getRequirements()).thenReturn(Arrays.asList(reqJre));
+        when(jreUnit.satisfies(reqJre)).thenReturn(true);
+        
+        // Create target definition with rootUnit in location
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "Location1", Arrays.asList(rootUnit)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(rootUnit, jreUnit);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark JRE unit as used (but it will be filtered)
+        report.usedUnits.add(jreUnit);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(jreUnit);
+        
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Root unit should show as UNUSED since its only child (JRE) is filtered out
+        assertTrue(fullReport.contains("org.eclipse.equinox.executable 3.8.3000.v20250801-0854 (feature) [UNUSED]"), 
+            "Unit with only JRE dependencies should show as UNUSED");
+        assertFalse(fullReport.contains("[INDIRECTLY USED]"), 
+            "Should not show INDIRECTLY USED when only JRE units are children");
+    }
+
+    // Helper methods for creating mock objects
+
+    private IInstallableUnit createMockUnit(String id, String version) {
+        IInstallableUnit unit = mock(IInstallableUnit.class);
+        when(unit.getId()).thenReturn(id);
+        when(unit.getVersion()).thenReturn(Version.create(version));
+        when(unit.toString()).thenReturn(id + "/" + version);
+        when(unit.getRequirements()).thenReturn(Arrays.asList());
+        return unit;
+    }
+
+    private IRequirement createRequirement(String id, String version) {
+        return MetadataFactory.createRequirement(
+                IInstallableUnit.NAMESPACE_IU_ID,
+                id,
+                new VersionRange(Version.create(version), true, Version.create(version), true),
+                null,
+                false,
+                false,
+                true
+        );
+    }
+
+    private TargetDefinition createMockTargetDefinition(String origin) {
+        TargetDefinition targetDef = mock(TargetDefinition.class);
+        when(targetDef.getOrigin()).thenReturn(origin);
+        when(targetDef.getLocations()).thenReturn(Arrays.asList());
+        return targetDef;
+    }
+
+    @SuppressWarnings("unchecked")
+    private TargetDefinition createMockTargetDefinitionWithIULocations(String origin, 
+            Map<String, List<IInstallableUnit>> locationUnits) {
+        TargetDefinition targetDef = mock(TargetDefinition.class);
+        when(targetDef.getOrigin()).thenReturn(origin);
+        
+        List<TargetDefinition.Location> locations = new ArrayList<>();
+        for (Map.Entry<String, List<IInstallableUnit>> entry : locationUnits.entrySet()) {
+            String locationName = entry.getKey();
+            List<IInstallableUnit> units = entry.getValue();
+            
+            TargetDefinition.InstallableUnitLocation iuLocation = mock(TargetDefinition.InstallableUnitLocation.class);
+            
+            // Create Unit mocks
+            List<TargetDefinition.Unit> unitList = new ArrayList<>();
+            for (IInstallableUnit iu : units) {
+                // Store values before stubbing to avoid nested stubbing issues
+                String unitId = iu.getId();
+                String unitVersion = iu.getVersion().toString();
+                
+                TargetDefinition.Unit unit = mock(TargetDefinition.Unit.class);
+                when(unit.getId()).thenReturn(unitId);
+                when(unit.getVersion()).thenReturn(unitVersion);
+                unitList.add(unit);
+            }
+            when(iuLocation.getUnits()).thenReturn((List) unitList);
+            
+            // Create repository mock
+            TargetDefinition.Repository repo = mock(TargetDefinition.Repository.class);
+            when(repo.getLocation()).thenReturn(locationName);
+            List<TargetDefinition.Repository> repos = Arrays.asList(repo);
+            when(iuLocation.getRepositories()).thenReturn((List) repos);
+            
+            locations.add(iuLocation);
+        }
+        
+        when(targetDef.getLocations()).thenReturn((List) locations);
+        return targetDef;
+    }
+    
+    private TargetDefinitionResolver createMockResolver(TargetDefinition target, TargetDefinitionContent content) {
+        return new TargetDefinitionResolver() {
+            @Override
+            public TargetDefinition getTargetDefinition(URI uri) {
+                return null;
+            }
+            
+            @Override
+            public TargetDefinitionContent fetchContent(TargetDefinition definition) {
+                if (definition == target) {
+                    return content;
+                }
+                return createMockContent();
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private TargetDefinitionContent createMockContent(IInstallableUnit... units) {
+        TargetDefinitionContent content = mock(TargetDefinitionContent.class);
+        Set<IInstallableUnit> unitSet = new HashSet<>(Arrays.asList(units));
+        
+        IQueryResult<IInstallableUnit> allUnitsResult = mock(IQueryResult.class);
+        when(allUnitsResult.toSet()).thenReturn(unitSet);
+        when(allUnitsResult.stream()).thenReturn(unitSet.stream());
+        
+        // Handle queries by matching against the IInstallableUnits
+        when(content.query(any(), any())).thenAnswer(invocation -> {
+            Object queryArg = invocation.getArgument(0);
+            
+            // Special case for ALL_UNITS query
+            if (queryArg == QueryUtil.ALL_UNITS) {
+                return allUnitsResult;
+            }
+            
+            // For IU queries, perform the query on our unit set
+            Set<IInstallableUnit> matchingUnits = new HashSet<>();
+            if (queryArg instanceof org.eclipse.equinox.p2.query.IQuery) {
+                org.eclipse.equinox.p2.query.IQuery<IInstallableUnit> query = 
+                    (org.eclipse.equinox.p2.query.IQuery<IInstallableUnit>) queryArg;
+                
+                // Perform the query on our unit set
+                IQueryResult<IInstallableUnit> queryResult = query.perform(unitSet.iterator());
+                matchingUnits = queryResult.toSet();
+            }
+            
+            IQueryResult<IInstallableUnit> result = mock(IQueryResult.class);
+            when(result.toSet()).thenReturn(matchingUnits);
+            when(result.stream()).thenReturn(matchingUnits.stream());
+            return result;
+        });
+        
+        return content;
+    }
+
+    private MavenProject createMockProject(String id) {
+        MavenProject project = mock(MavenProject.class);
+        when(project.getId()).thenReturn(id);
+        return project;
+    }
+}

--- a/tycho-extras/tycho-dependency-tools-plugin/src/test/java/org/eclipse/tycho/extras/pde/usage/UsageReportTest.java
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/test/java/org/eclipse/tycho/extras/pde/usage/UsageReportTest.java
@@ -1,0 +1,824 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tycho.extras.pde.usage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.maven.project.MavenProject;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IRequirement;
+import org.eclipse.equinox.p2.metadata.MetadataFactory;
+import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.metadata.VersionRange;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.tycho.extras.pde.usage.SimpleUsageReportLayout;
+import org.eclipse.tycho.extras.pde.usage.UsageReport;
+import org.eclipse.tycho.targetplatform.TargetDefinition;
+import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UsageReport} that verify high-level use cases for dependency
+ * usage reporting in target definitions. These tests mock locations and units to
+ * assert that the report text contains expected outputs without testing implementation
+ * details.
+ */
+public class UsageReportTest {
+
+    /**
+     * Tests that a unit directly used by a project is reported as "used".
+     * 
+     * <pre>
+     * Target Definition
+     *   Location L
+     *     ├─ Unit A (directly used by project)
+     * </pre>
+     */
+    @Test
+    void testDirectlyUsedUnit() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        
+        // Create target definition with unitA in LocationL
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL", Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark unit A as used
+        MavenProject project = createMockProject("project1");
+        report.usedUnits.add(unitA);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitA);
+        
+        // Verify unit A is recognized as directly used (not indirectly)
+        assertFalse(report.isUsedIndirectly(unitA), "Unit A should be directly used, not indirectly");
+        assertTrue(report.isRootUnit(unitA), "Unit A should be a root unit");
+    }
+
+    /**
+     * Tests that when a transitive dependency is used, the root unit is reported
+     * as "INDIRECTLY used" rather than unused.
+     * 
+     * <pre>
+     * Target Definition
+     *   Location L
+     *     ├─ Unit A
+     *        ├─ Requires X
+     *        ├─ Requires Y (used by project)
+     *        └─ Requires Z
+     * </pre>
+     */
+    @Test
+    void testIndirectlyUsedUnit() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitY = createMockUnit("unitY", "1.0.0");
+        
+        // Set up requirements: A requires Y
+        IRequirement reqY = createRequirement("unitY", "1.0.0");
+        when(unitA.getRequirements()).thenReturn(Arrays.asList(reqY));
+        when(unitY.satisfies(reqY)).thenReturn(true);
+        
+        // Create target definition with unitA in LocationL
+        // analyzeLocations will discover unitY as a dependency of unitA
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL", Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitY);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark only Y as used (not A)
+        report.usedUnits.add(unitY);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitY);
+        
+        // Verify A is recognized as indirectly used
+        assertTrue(report.isUsedIndirectly(unitA), "Unit A should be indirectly used because Y is used");
+        assertFalse(report.isUsedIndirectly(unitY), "Unit Y should be directly used");
+        
+        // Verify indirect usage chain is reported
+        String chain = report.getIndirectUsageChain(unitA);
+        assertTrue(chain.contains("unitA") && chain.contains("unitY"), 
+                "Indirect usage chain should show path from A to Y");
+    }
+
+    /**
+     * Tests that when no dependencies are used, only the root unit is reported
+     * as unused, not the transitive dependencies.
+     * 
+     * <pre>
+     * Target Definition
+     *   Location L
+     *     ├─ Unit A (unused)
+     *        ├─ Requires X (should not be reported separately)
+     *        ├─ Requires Y (should not be reported separately)
+     *        └─ Requires Z (should not be reported separately)
+     * </pre>
+     */
+    @Test
+    void testUnusedUnitWithUnusedDependencies() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitX = createMockUnit("unitX", "1.0.0");
+        IInstallableUnit unitY = createMockUnit("unitY", "1.0.0");
+        IInstallableUnit unitZ = createMockUnit("unitZ", "1.0.0");
+        
+        // Set up requirements: A requires X, Y, Z
+        IRequirement reqX = createRequirement("unitX", "1.0.0");
+        IRequirement reqY = createRequirement("unitY", "1.0.0");
+        IRequirement reqZ = createRequirement("unitZ", "1.0.0");
+        when(unitA.getRequirements()).thenReturn(Arrays.asList(reqX, reqY, reqZ));
+        when(unitX.satisfies(reqX)).thenReturn(true);
+        when(unitY.satisfies(reqY)).thenReturn(true);
+        when(unitZ.satisfies(reqZ)).thenReturn(true);
+        
+        // Create target definition with unitA in LocationL
+        // analyzeLocations will discover X, Y, Z as dependencies of unitA
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL", Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitX, unitY, unitZ);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Nothing is used
+        // Verify A is a root unit but X, Y, Z are not
+        assertTrue(report.isRootUnit(unitA), "Unit A should be a root unit");
+        assertFalse(report.isRootUnit(unitX), "Unit X should not be a root unit");
+        assertFalse(report.isRootUnit(unitY), "Unit Y should not be a root unit");
+        assertFalse(report.isRootUnit(unitZ), "Unit Z should not be a root unit");
+        
+        // Verify A is not indirectly used
+        assertFalse(report.isUsedIndirectly(unitA), "Unit A should not be indirectly used");
+    }
+
+    /**
+     * Tests deeper nesting where a unit requires another unit which has
+     * its own requirements.
+     * 
+     * <pre>
+     * Target Definition
+     *   Location L
+     *     ├─ Unit A
+     *        └─ Requires Unit B
+     *           ├─ Requires X (used by project)
+     *           ├─ Requires Y
+     *           └─ Requires Z
+     * </pre>
+     */
+    @Test
+    void testDeeperNesting() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        IInstallableUnit unitX = createMockUnit("unitX", "1.0.0");
+        
+        // Set up requirements: A requires B, B requires X
+        IRequirement reqB = createRequirement("unitB", "1.0.0");
+        IRequirement reqX = createRequirement("unitX", "1.0.0");
+        when(unitA.getRequirements()).thenReturn(Arrays.asList(reqB));
+        when(unitB.getRequirements()).thenReturn(Arrays.asList(reqX));
+        when(unitB.satisfies(reqB)).thenReturn(true);
+        when(unitX.satisfies(reqX)).thenReturn(true);
+        
+        // Create target definition with unitA in LocationL
+        // analyzeLocations will discover B and X as dependencies
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL", Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitB, unitX);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark only X as used
+        report.usedUnits.add(unitX);
+        MavenProject project = createMockProject("project1");
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitX);
+        
+        // Verify both A and B are indirectly used
+        assertTrue(report.isUsedIndirectly(unitA), "Unit A should be indirectly used");
+        assertTrue(report.isUsedIndirectly(unitB), "Unit B should be indirectly used");
+        
+        // Verify children collection works transitively
+        Set<IInstallableUnit> childrenOfA = report.getAllChildren(unitA);
+        assertTrue(childrenOfA.contains(unitB), "Children of A should include B");
+        assertTrue(childrenOfA.contains(unitX), "Children of A should include X (transitively)");
+    }
+
+    /**
+     * Tests that the provenance string includes proper nesting information
+     * showing the origin, location, and dependency chain.
+     * 
+     * <pre>
+     * Target Definition (my-target.target)
+     *   Location L
+     *     ├─ Unit A
+     *        └─ Requires Unit B
+     * </pre>
+     */
+    @Test
+    void testProvidedByNesting() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        
+        // Set up requirements
+        IRequirement reqB = createRequirement("unitB", "1.0.0");
+        when(unitA.getRequirements()).thenReturn(Arrays.asList(reqB));
+        when(unitB.satisfies(reqB)).thenReturn(true);
+        
+        // Create target definition with unitA in LocationL
+        // analyzeLocations will discover B as a dependency
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL", Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("my-target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitB);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Verify provenance for root unit
+        String providedByA = report.getProvidedBy(unitA);
+        assertTrue(providedByA.contains("my-target.target"), "Should contain origin");
+        assertTrue(providedByA.contains("LocationL"), "Should contain location");
+        
+        // Verify provenance for nested unit includes path
+        String providedByB = report.getProvidedBy(unitB);
+        assertTrue(providedByB.contains("my-target.target"), "Should contain origin");
+        assertTrue(providedByB.contains("LocationL"), "Should contain location");
+    }
+
+    /**
+     * Tests that the shortest path from root to a unit is correctly computed.
+     * 
+     * <pre>
+     * Target Definition
+     *   Location L
+     *     ├─ Unit A
+     *        ├─ Requires B
+     *        └─ Requires C
+     *           └─ Requires B (longer path)
+     * </pre>
+     */
+    @Test
+    void testShortestPathFromRoot() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        IInstallableUnit unitC = createMockUnit("unitC", "1.0.0");
+        
+        // Set up requirements: A requires B and C, C also requires B
+        IRequirement reqB = createRequirement("unitB", "1.0.0");
+        IRequirement reqC = createRequirement("unitC", "1.0.0");
+        when(unitA.getRequirements()).thenReturn(Arrays.asList(reqB, reqC));
+        when(unitC.getRequirements()).thenReturn(Arrays.asList(reqB));
+        when(unitB.satisfies(reqB)).thenReturn(true);
+        when(unitC.satisfies(reqC)).thenReturn(true);
+        
+        // Create target definition with unitA in LocationL
+        // analyzeLocations will discover B and C as dependencies
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL", Arrays.asList(unitA)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitB, unitC);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Get shortest path from root to B
+        List<IInstallableUnit> path = report.getShortestPathFromRoot(unitB);
+        
+        // Should be [A, B] (shortest path)
+        assertEquals(2, path.size(), "Shortest path should have 2 units");
+        assertEquals(unitA, path.get(0), "First unit should be A (root)");
+        assertEquals(unitB, path.get(1), "Second unit should be B");
+    }
+
+    /**
+     * Tests the complete report generation to ensure text output is correct.
+     * 
+     * <pre>
+     * Target Definition
+     *   Location L
+     *     ├─ Unit A (used directly)
+     *     ├─ Unit B (indirectly used via C)
+     *        └─ Requires Unit C (used)
+     *     └─ Unit D (unused)
+     * </pre>
+     */
+    @Test
+    void testReportGeneration() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        IInstallableUnit unitC = createMockUnit("unitC", "1.0.0");
+        IInstallableUnit unitD = createMockUnit("unitD", "1.0.0");
+        
+        // Set up requirements: B requires C
+        IRequirement reqC = createRequirement("unitC", "1.0.0");
+        when(unitB.getRequirements()).thenReturn(Arrays.asList(reqC));
+        when(unitC.satisfies(reqC)).thenReturn(true);
+        
+        // Create target definition with all units in LocationL
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL", Arrays.asList(unitA, unitB, unitC, unitD)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitB, unitC, unitD);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark A and C as used
+        MavenProject project = createMockProject("project1");
+        report.usedUnits.add(unitA);
+        report.usedUnits.add(unitC);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitA);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitC);
+        
+        // Collect report output
+        List<String> reportLines = new ArrayList<>();
+        new SimpleUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        // Verify report contains expected elements
+        String fullReport = String.join("\n", reportLines);
+        assertTrue(fullReport.contains("DEPENDENCIES USAGE REPORT"), "Should contain report header");
+        assertTrue(fullReport.contains("unitA") && fullReport.contains("is used by"), 
+                "Should report unitA as used");
+        assertTrue(fullReport.contains("unitB") && fullReport.contains("INDIRECTLY used"), 
+                "Should report unitB as indirectly used");
+        assertTrue(fullReport.contains("unitD") && fullReport.contains("UNUSED"), 
+                "Should report unitD as unused");
+    }
+
+    /**
+     * Tests that analyzeLocations correctly handles target definitions with references
+     * to other target files.
+     * 
+     * <pre>
+     * TargetA.target
+     *   ├─ References TargetB.target
+     *   
+     * TargetB.target
+     *   ├─ Location L
+     *      └─ Unit X (used by project)
+     * </pre>
+     */
+    @Test
+    void testTargetReferences() throws Exception {
+        UsageReport report = new UsageReport();
+        
+        // Create units
+        IInstallableUnit unitX = createMockUnit("unitX", "1.0.0");
+        
+        // Create target definitions
+        TargetDefinition targetA = createMockTargetDefinitionWithReference("targetA.target", "file:///targetB.target");
+        TargetDefinition targetB = createMockTargetDefinition("targetB.target");
+        
+        // Create content for targetB
+        TargetDefinitionContent contentB = createMockContent(unitX);
+        
+        // Create mock resolver
+        TargetDefinitionResolver resolver = new TargetDefinitionResolver() {
+            @Override
+            public TargetDefinition getTargetDefinition(URI uri) {
+                if (uri.toString().equals("file:///targetB.target")) {
+                    return targetB;
+                }
+                return null;
+            }
+            
+            @Override
+            public TargetDefinitionContent fetchContent(TargetDefinition definition) {
+                if (definition == targetB) {
+                    return contentB;
+                }
+                return createMockContent();
+            }
+        };
+        
+        // Analyze targetA which references targetB
+        report.analyzeLocations(targetA, resolver, (l, e) -> {});
+        
+        // Verify that targetB is tracked as referenced by targetA
+        assertTrue(report.targetReferences.containsKey(targetB), 
+                "targetB should be in targetReferences map");
+        assertTrue(report.targetReferences.get(targetB).contains(targetA),
+                "targetB should be referenced by targetA");
+        
+        // Verify both targets are in the targetFiles set
+        assertTrue(report.getTargetFiles().anyMatch(t -> t.equals(targetA)), "targetA should be in targetFiles");
+        assertTrue(report.getTargetFiles().anyMatch(t -> t.equals(targetB)), "targetB should be in targetFiles");
+    }
+    
+    /**
+     * Tests that the TreeUsageReportLayout correctly displays referenced target information.
+     * 
+     * <pre>
+     * TargetA.target
+     *   ├─ References TargetB.target
+     *   ├─ Location L1
+     *      └─ Unit A (used)
+     *   
+     * TargetB.target
+     *   ├─ Location L2
+     *      └─ Unit B (used)
+     * </pre>
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testReportWithTargetReferences() throws Exception {
+        UsageReport report = new UsageReport();
+        
+        // Create units
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        
+        // Create targetB with IU location
+        Map<String, List<IInstallableUnit>> locationUnitsB = Map.of(
+            "LocationL2", Arrays.asList(unitB)
+        );
+        TargetDefinition targetB = createMockTargetDefinitionWithIULocations("targetB.target", locationUnitsB);
+        TargetDefinitionContent contentB = createMockContent(unitB);
+        
+        // Create targetA with both reference to targetB and its own IU location
+        TargetDefinition targetA = mock(TargetDefinition.class);
+        when(targetA.getOrigin()).thenReturn("targetA.target");
+        
+        TargetDefinition.TargetReferenceLocation refLocation = mock(TargetDefinition.TargetReferenceLocation.class);
+        when(refLocation.getUri()).thenReturn("file:///targetB.target");
+        
+        // Add IU location for unitA
+        TargetDefinition.InstallableUnitLocation iuLocation = mock(TargetDefinition.InstallableUnitLocation.class);
+        
+        // Store values before stubbing to avoid Mockito UnfinishedStubbingException.
+        // Calling getId() and getVersion() on mocks during when() statements creates
+        // nested mock invocations that Mockito cannot handle properly.
+        String unitAId = unitA.getId();
+        String unitAVersion = unitA.getVersion().toString();
+        
+        TargetDefinition.Unit unitADef = mock(TargetDefinition.Unit.class);
+        when(unitADef.getId()).thenReturn(unitAId);
+        when(unitADef.getVersion()).thenReturn(unitAVersion);
+        when(iuLocation.getUnits()).thenReturn((List) Arrays.asList(unitADef));
+        TargetDefinition.Repository repo = mock(TargetDefinition.Repository.class);
+        when(repo.getLocation()).thenReturn("LocationL1");
+        when(iuLocation.getRepositories()).thenReturn((List) Arrays.asList(repo));
+        
+        List<TargetDefinition.Location> locationsA = new ArrayList<>();
+        locationsA.add(refLocation);
+        locationsA.add(iuLocation);
+        when(targetA.getLocations()).thenReturn((List) locationsA);
+        
+        // Create content for targetA
+        TargetDefinitionContent contentA = createMockContent(unitA);
+        
+        // Create resolver that handles both targets
+        TargetDefinitionResolver resolver = new TargetDefinitionResolver() {
+            @Override
+            public TargetDefinition getTargetDefinition(URI uri) {
+                if (uri.toString().equals("file:///targetB.target")) {
+                    return targetB;
+                }
+                return null;
+            }
+            
+            @Override
+            public TargetDefinitionContent fetchContent(TargetDefinition definition) {
+                if (definition == targetA) {
+                    return contentA;
+                } else if (definition == targetB) {
+                    return contentB;
+                }
+                return createMockContent();
+            }
+        };
+        
+        // Analyze targetA which will also analyze targetB
+        report.analyzeLocations(targetA, resolver, (l, e) -> {});
+        
+        // Mark both units as used
+        MavenProject project = createMockProject("project1");
+        report.usedUnits.add(unitA);
+        report.usedUnits.add(unitB);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitA);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitB);
+        
+        // Generate report using TreeLayout
+        List<String> reportLines = new ArrayList<>();
+        new TreeUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        String fullReport = String.join("\n", reportLines);
+        
+        // Verify targetB shows it's referenced by targetA
+        assertTrue(fullReport.contains("Referenced in: targetA.target"), 
+                "targetB should show it's referenced by targetA");
+        
+        // Verify targetA shows it references targetB with USED status
+        // Note: targetB is USED because unitB is used
+        assertTrue(fullReport.contains("References: file:///targetB.target [USED]"), 
+                "targetA should show it references targetB with USED status");
+    }
+
+    /**
+     * Tests reporting of units with shared transitive dependencies.
+     * 
+     * <pre>
+     * Location L1
+     *   ├─ Unit A
+     *      └─ Requires Unit B
+     *         ├─ Requires X (used by project)
+     *         ├─ Requires Y (used by project)
+     *         └─ Requires Z
+     * 
+     * Location L2
+     *   └─ Unit Q
+     *      ├─ Requires P
+     *      └─ Requires Y (used by project)
+     * </pre>
+     * 
+     * In this scenario, both A and Q are reported as INDIRECTLY used because they
+     * each have children (X and Y for A, Y for Q) that are used by the project.
+     * The fact that Y is provided by both units doesn't affect the indirect usage status.
+     */
+    @Test
+    void testSharedTransitiveDependency() {
+        UsageReport report = new UsageReport();
+        
+        // Create mock units for Location L1
+        IInstallableUnit unitA = createMockUnit("unitA", "1.0.0");
+        IInstallableUnit unitB = createMockUnit("unitB", "1.0.0");
+        IInstallableUnit unitX = createMockUnit("unitX", "1.0.0");
+        IInstallableUnit unitY = createMockUnit("unitY", "1.0.0");
+        IInstallableUnit unitZ = createMockUnit("unitZ", "1.0.0");
+        
+        // Create mock units for Location L2
+        IInstallableUnit unitQ = createMockUnit("unitQ", "1.0.0");
+        IInstallableUnit unitP = createMockUnit("unitP", "1.0.0");
+        
+        // Set up requirements: A requires B, B requires X, Y, Z
+        IRequirement reqB = createRequirement("unitB", "1.0.0");
+        IRequirement reqX = createRequirement("unitX", "1.0.0");
+        IRequirement reqY = createRequirement("unitY", "1.0.0");
+        IRequirement reqZ = createRequirement("unitZ", "1.0.0");
+        when(unitA.getRequirements()).thenReturn(Arrays.asList(reqB));
+        when(unitB.getRequirements()).thenReturn(Arrays.asList(reqX, reqY, reqZ));
+        when(unitB.satisfies(reqB)).thenReturn(true);
+        when(unitX.satisfies(reqX)).thenReturn(true);
+        when(unitY.satisfies(reqY)).thenReturn(true);
+        when(unitZ.satisfies(reqZ)).thenReturn(true);
+        
+        // Set up requirements: Q requires P and Y
+        IRequirement reqP = createRequirement("unitP", "1.0.0");
+        IRequirement reqYforQ = createRequirement("unitY", "1.0.0");
+        when(unitQ.getRequirements()).thenReturn(Arrays.asList(reqP, reqYforQ));
+        when(unitP.satisfies(reqP)).thenReturn(true);
+        when(unitY.satisfies(reqYforQ)).thenReturn(true);
+        
+        // Create target definition with units in two locations
+        Map<String, List<IInstallableUnit>> locationUnits = Map.of(
+            "LocationL1", Arrays.asList(unitA),
+            "LocationL2", Arrays.asList(unitQ)
+        );
+        TargetDefinition targetDef = createMockTargetDefinitionWithIULocations("target.target", locationUnits);
+        TargetDefinitionContent content = createMockContent(unitA, unitB, unitX, unitY, unitZ, unitQ, unitP);
+        TargetDefinitionResolver resolver = createMockResolver(targetDef, content);
+        
+        // Analyze the target using the proper API
+        report.analyzeLocations(targetDef, resolver, (l, e) -> {});
+        
+        // Mark X and Y as used
+        MavenProject project = createMockProject("project1");
+        report.usedUnits.add(unitX);
+        report.usedUnits.add(unitY);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitX);
+        report.projectUsage.computeIfAbsent(project, k -> new HashSet<>()).add(unitY);
+        
+        // Collect report output
+        List<String> reportLines = new ArrayList<>();
+        new SimpleUsageReportLayout().generateReport(report, false, reportLines::add);
+        
+        // Verify report contains expected elements
+        String fullReport = String.join("\n", reportLines);
+        
+        // A should be INDIRECTLY used because X and Y are used
+        assertTrue(fullReport.contains("unitA") && fullReport.contains("INDIRECTLY used"), 
+                "Unit A should be indirectly used through X and Y");
+        
+        // Q should also be INDIRECTLY used because Y is used. Any unit with used
+        // children is marked as indirectly used, regardless of whether those children
+        // are also available through other units.
+        assertTrue(fullReport.contains("unitQ") && fullReport.contains("INDIRECTLY used"), 
+                "Unit Q should be reported as INDIRECTLY used because Y is used");
+        
+        // Verify Q is a root unit
+        assertTrue(report.isRootUnit(unitQ), "Unit Q should be a root unit");
+        
+        // Verify Q is indirectly used since Y (its child) is used
+        assertTrue(report.isUsedIndirectly(unitQ), 
+                "Unit Q should be indirectly used since Y (its child) is used");
+    }
+
+    // Helper methods for creating mock objects
+
+    private IInstallableUnit createMockUnit(String id, String version) {
+        IInstallableUnit unit = mock(IInstallableUnit.class);
+        when(unit.getId()).thenReturn(id);
+        when(unit.getVersion()).thenReturn(Version.create(version));
+        when(unit.toString()).thenReturn(id + "/" + version);
+        when(unit.getRequirements()).thenReturn(Arrays.asList());
+        return unit;
+    }
+
+    private IRequirement createRequirement(String id, String version) {
+        return MetadataFactory.createRequirement(
+                IInstallableUnit.NAMESPACE_IU_ID,
+                id,
+                new VersionRange(Version.create(version), true, Version.create(version), true),
+                null,
+                false,
+                false,
+                true
+        );
+    }
+
+    private TargetDefinition createMockTargetDefinition(String origin) {
+        TargetDefinition targetDef = mock(TargetDefinition.class);
+        when(targetDef.getOrigin()).thenReturn(origin);
+        when(targetDef.getLocations()).thenReturn(Arrays.asList());
+        return targetDef;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private TargetDefinition createMockTargetDefinitionWithIULocations(String origin, 
+            Map<String, List<IInstallableUnit>> locationUnits) {
+        TargetDefinition targetDef = mock(TargetDefinition.class);
+        when(targetDef.getOrigin()).thenReturn(origin);
+        
+        List<TargetDefinition.Location> locations = new ArrayList<>();
+        for (Map.Entry<String, List<IInstallableUnit>> entry : locationUnits.entrySet()) {
+            String locationName = entry.getKey();
+            List<IInstallableUnit> units = entry.getValue();
+            
+            TargetDefinition.InstallableUnitLocation iuLocation = mock(TargetDefinition.InstallableUnitLocation.class);
+            
+            // Create Unit mocks
+            List<TargetDefinition.Unit> unitList = new ArrayList<>();
+            for (IInstallableUnit iu : units) {
+                // Store values before stubbing to avoid nested stubbing issues
+                String unitId = iu.getId();
+                String unitVersion = iu.getVersion().toString();
+                
+                TargetDefinition.Unit unit = mock(TargetDefinition.Unit.class);
+                when(unit.getId()).thenReturn(unitId);
+                when(unit.getVersion()).thenReturn(unitVersion);
+                unitList.add(unit);
+            }
+            when(iuLocation.getUnits()).thenReturn((List) unitList);
+            
+            // Create repository mock
+            TargetDefinition.Repository repo = mock(TargetDefinition.Repository.class);
+            when(repo.getLocation()).thenReturn(locationName);
+            List<TargetDefinition.Repository> repos = Arrays.asList(repo);
+            when(iuLocation.getRepositories()).thenReturn((List) repos);
+            
+            locations.add(iuLocation);
+        }
+        
+        when(targetDef.getLocations()).thenReturn((List) locations);
+        return targetDef;
+    }
+    
+    private TargetDefinitionResolver createMockResolver(TargetDefinition target, TargetDefinitionContent content) {
+        return new TargetDefinitionResolver() {
+            @Override
+            public TargetDefinition getTargetDefinition(URI uri) {
+                return null;
+            }
+            
+            @Override
+            public TargetDefinitionContent fetchContent(TargetDefinition definition) {
+                if (definition == target) {
+                    return content;
+                }
+                return createMockContent();
+            }
+        };
+    }
+    
+    @SuppressWarnings("unchecked")
+    private TargetDefinition createMockTargetDefinitionWithReference(String origin, String refUri) {
+        TargetDefinition targetDef = mock(TargetDefinition.class);
+        when(targetDef.getOrigin()).thenReturn(origin);
+        
+        TargetDefinition.TargetReferenceLocation refLocation = mock(TargetDefinition.TargetReferenceLocation.class);
+        when(refLocation.getUri()).thenReturn(refUri);
+        
+        List<TargetDefinition.Location> locations = new ArrayList<>();
+        locations.add(refLocation);
+        when(targetDef.getLocations()).thenReturn((List) locations);
+        return targetDef;
+    }
+
+    @SuppressWarnings("unchecked")
+    private TargetDefinitionContent createMockContent(IInstallableUnit... units) {
+        TargetDefinitionContent content = mock(TargetDefinitionContent.class);
+        Set<IInstallableUnit> unitSet = new HashSet<>(Arrays.asList(units));
+        
+        IQueryResult<IInstallableUnit> allUnitsResult = mock(IQueryResult.class);
+        when(allUnitsResult.toSet()).thenReturn(unitSet);
+        when(allUnitsResult.stream()).thenReturn(unitSet.stream());
+        
+        // Handle queries by matching against the IInstallableUnits
+        when(content.query(any(), any())).thenAnswer(invocation -> {
+            Object queryArg = invocation.getArgument(0);
+            
+            // Special case for ALL_UNITS query
+            if (queryArg == QueryUtil.ALL_UNITS) {
+                return allUnitsResult;
+            }
+            
+            // For IU queries, perform the query on our unit set
+            Set<IInstallableUnit> matchingUnits = new HashSet<>();
+            if (queryArg instanceof org.eclipse.equinox.p2.query.IQuery) {
+                org.eclipse.equinox.p2.query.IQuery<IInstallableUnit> query = 
+                    (org.eclipse.equinox.p2.query.IQuery<IInstallableUnit>) queryArg;
+                
+                // Perform the query on our unit set
+                IQueryResult<IInstallableUnit> queryResult = query.perform(unitSet.iterator());
+                matchingUnits = queryResult.toSet();
+            }
+            
+            IQueryResult<IInstallableUnit> result = mock(IQueryResult.class);
+            when(result.toSet()).thenReturn(matchingUnits);
+            when(result.stream()).thenReturn(matchingUnits.stream());
+            return result;
+        });
+        
+        return content;
+    }
+
+    private MavenProject createMockProject(String id) {
+        MavenProject project = mock(MavenProject.class);
+        when(project.getId()).thenReturn(id);
+        return project;
+    }
+}

--- a/tycho-its/projects/dependency-tools.usage/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/dependency-tools.usage/bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Test Bundle
+Bundle-SymbolicName: test.bundle
+Bundle-Version: 0.0.1.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.core.runtime;bundle-version="3.0.0"

--- a/tycho-its/projects/dependency-tools.usage/bundle/build.properties
+++ b/tycho-its/projects/dependency-tools.usage/bundle/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/dependency-tools.usage/bundle/platform.target
+++ b/tycho-its/projects/dependency-tools.usage/bundle/platform.target
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="Simple Target Platform" sequenceNumber="1">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2023-03"/>
+			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/dependency-tools.usage/bundle/pom.xml
+++ b/tycho-its/projects/dependency-tools.usage/bundle/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>tycho-its-project.dependency-tools.usage</groupId>
+		<artifactId>parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>test.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>platform.target</file>
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/projects/dependency-tools.usage/pom.xml
+++ b/tycho-its/projects/dependency-tools.usage/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project.dependency-tools.usage</groupId>
+	<artifactId>parent</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>bundle</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/DependencyToolsPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/DependencyToolsPluginTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.version.TychoVersion;
+import org.junit.Test;
+
+public class DependencyToolsPluginTest extends AbstractTychoIntegrationTest {
+
+    @Test
+    public void testUsage() throws Exception {
+        Verifier verifier = getVerifier("dependency-tools.usage", false, true);
+        // First build the project to ensure dependencies are resolved
+        verifier.executeGoal("verify");
+        verifier.verifyErrorFreeLog();
+        
+        // Now execute the usage goal via CLI
+        verifier.executeGoal("org.eclipse.tycho.extras:tycho-dependency-tools-plugin:" 
+                + TychoVersion.getTychoVersion() + ":usage");
+        verifier.verifyErrorFreeLog();
+        
+        // Verify the log contains expected output
+        verifier.verifyTextInLog("Scan reactor for dependencies...");
+        verifier.verifyTextInLog("DEPENDENCIES USAGE REPORT");
+        verifier.verifyTextInLog("Target:");
+        
+        // Verify that unit status is shown
+        verifier.verifyTextInLog("USED");
+    }
+}


### PR DESCRIPTION
Often it could be interesting to know what is actually used inside a build as while the project evolves maybe things in the target are only there for historic reasons.

This now adds a new mojo that accomplish the task of printing a summary about what all is used in the build.