### PR TITLE
Add missing version-ranges to implicit imports of tycho.surefire.junit5

### DIFF
--- a/tycho-surefire/org.eclipse.tycho.surefire.junit5/bnd.bnd
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit5/bnd.bnd
@@ -3,11 +3,11 @@
 # Automatic-Module-Name: part from that the content in this bin: undle is only used to bootstrap
 # surefire and we include all we need foro that as it does not comply with OSGi rules.
 Import-Package: \
- org.junit.platform.launcher, \
- org.junit.jupiter.api, \
- org.junit.jupiter.engine, \
- org.junit.platform.suite.api, \
- org.junit.platform.suite.engine;status=INTERNAL, \
+ org.junit.platform.launcher;version="[1,2)", \
+ org.junit.jupiter.api;version="[5,6)", \
+ org.junit.jupiter.engine;version="[5,6)", \
+ org.junit.platform.suite.api;version="[1,2)", \
+ org.junit.platform.suite.engine;status=INTERNAL;version="[1,2)", \
  java.*
 Fragment-Host: org.eclipse.tycho.surefire.osgibooter
 # The JUnit Runner is still compatible with Java 1.8, as all included upstream dependencies are.


### PR DESCRIPTION
Without them Junit-6 bundles are automatically added to the test-runtime, even if the tested project actually only depends on junit-5 packages/bundles.
The only way to prevent it, was to add implicitly required platform and engine bundles explicitly to the test projects.