### PR TITLE
Add class-level Javadoc to WrapMojo

### DIFF
--- a/tycho-wrap-plugin/src/main/java/org/eclipse/tycho/wrap/WrapMojo.java
+++ b/tycho-wrap-plugin/src/main/java/org/eclipse/tycho/wrap/WrapMojo.java
@@ -41,6 +41,17 @@ import aQute.bnd.print.JarPrinter;
 import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.Version;
 
+/**
+ * This mojos allows creating OSGi jars by specifying an arbitrary input and output, 
+ * some <a href="https://bnd.bndtools.org/chapters/160-jars.html">bnd instructions</a> 
+ * and (optionally) attach the result to the maven project.
+ * 
+ * This has the advantage that projects are able to publish 
+ * two "flavors" of their artifact: a plain one and an OSGi-fied one 
+ * that could help to convince projects to provide such things as 
+ * it has zero influence to their build and ways how they build artifacts.
+ * 
+ */
 @Mojo(name = "wrap", requiresProject = true, threadSafe = true, defaultPhase = LifecyclePhase.PACKAGE)
 public class WrapMojo extends AbstractMojo {
 


### PR DESCRIPTION
Introduced a Javadoc comment describing the purpose and advantages of the WrapMojo class, including its ability to create OSGi jars with bnd instructions and support for publishing both plain and OSGi-fied artifacts.
Added a link to [bnd tutorial for wrapping jars](https://bnd.bndtools.org/chapters/160-jars.html)

Hope that this then appears on https://tycho.eclipseprojects.io/doc/main/tycho-wrap-plugin/wrap-mojo.html

Wording taken from https://github.com/eclipse-tycho/tycho/blob/tycho-5.0.0/RELEASE_NOTES.md#new-wrap-mojo