### PR TITLE
Do not return on first found target file

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -433,7 +433,6 @@ public class DefaultTargetPlatformConfigurationReader {
                 File target = basedir.resolve(file).toFile();
                 if (TargetDefinitionFile.isTargetFile(target)) {
                     result.addTarget(target);
-                    return;
                 } else {
                     result.addLazyTargetFile(() -> {
                         if (TargetDefinitionFile.isTargetFile(target)) {


### PR DESCRIPTION
Currently if more than a target <file> is given it depends on the order if Tycho possibly ignores some content because it returns from the method on the first found target file.

This now removes the return to allow the configuration from being fully parsed.