### PR TITLE
Make Target Environments Unique during target platform parsing

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/DependencyResolver.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.core;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
@@ -42,7 +42,7 @@ public interface DependencyResolver {
      */
     public DependencyArtifacts resolveDependencies(MavenSession session, MavenProject project,
             TargetPlatform targetPlatform, DependencyResolverConfiguration resolverConfiguration,
-            List<TargetEnvironment> environments);
+            Collection<TargetEnvironment> environments);
 
     public void injectDependenciesIntoMavenModel(MavenProject project, TychoProject projectType,
             DependencyArtifacts resolvedDependencies, DependencyArtifacts testDepedencyArtifacts, Logger logger);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +45,15 @@ import org.eclipse.tycho.core.resolver.shared.ReferencedRepositoryMode;
 import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
 import org.eclipse.tycho.targetplatform.TargetPlatformFilter;
 
+/**
+ * Configuration for target platform resolution in Tycho builds.
+ * <p>
+ * This class encapsulates all configuration options related to target platform resolution,
+ * including target environments, target definition files, execution environments, dependency
+ * resolution settings, and filters. It serves as the central configuration point for how Tycho
+ * resolves and constructs the target platform for a build.
+ * </p>
+ */
 public class TargetPlatformConfiguration implements DependencyResolverConfiguration {
 
     public enum BREEHeaderSelectionPolicy {
@@ -94,7 +104,7 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     private String resolver;
 
-    private List<TargetEnvironment> environments = new ArrayList<>();
+    private Collection<TargetEnvironment> environments = new LinkedHashSet<>();
     private List<TargetEnvironment> filteredEnvironments = new ArrayList<>();
 
     private boolean implicitTargetEnvironment = true;
@@ -131,13 +141,15 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     private List<Xpp3Dom> xmlFragments = new ArrayList<>();
 
     /**
-     * Returns the list of configured target environments, or the running environment if no
-     * environments have been specified explicitly.
+     * Returns the collection of configured target environments, or the running environment if no
+     * environments have been specified explicitly. The returned collection maintains insertion
+     * order and contains no duplicates.
      * 
+     * @return the configured target environments
      * @see #isImplicitTargetEnvironment()
      */
-    public List<TargetEnvironment> getEnvironments() {
-        return environments;
+    public Collection<TargetEnvironment> getEnvironments() {
+        return List.copyOf(environments);
     }
 
     public String getTargetPlatformResolver() {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/AbstractP2Mojo.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/AbstractP2Mojo.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.maven;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -63,7 +63,7 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
         return qualifier;
     }
 
-    protected List<TargetEnvironment> getEnvironments() {
+    protected Collection<TargetEnvironment> getEnvironments() {
         return projectManager.getTargetPlatformConfiguration(project).getEnvironments();
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractTychoProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractTychoProject.java
@@ -155,7 +155,7 @@ public abstract class AbstractTychoProject implements TychoProject {
         }
 
         // all specified
-        List<TargetEnvironment> environments = configuration.getEnvironments();
+        Collection<TargetEnvironment> environments = configuration.getEnvironments();
         return environments.toArray(new TargetEnvironment[environments.size()]);
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -218,7 +218,7 @@ public class EquinoxResolver implements DependenciesResolver {
 
         TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
         //FIXME formally we should resolve the configuration for ALL declared environments!
-        TargetEnvironment environment = configuration.getEnvironments().get(0);
+        TargetEnvironment environment = configuration.getEnvironments().iterator().next();
         logger.debug("Using TargetEnvironment " + environment.toFilterExpression() + " to create resolver properties");
         Properties properties = computeMergedProperties(project.adapt(MavenProject.class), mavenSession);
         return getPlatformProperties(properties, mavenSession, environment, ee);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/metadata/DependencyMetadataGenerator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/metadata/DependencyMetadataGenerator.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.metadata;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.IDependencyMetadata;
@@ -28,6 +28,6 @@ public interface DependencyMetadataGenerator {
     /**
      * Generates dependency-only artifact metadata
      */
-    public IDependencyMetadata generateMetadata(IArtifactFacade artifact, List<TargetEnvironment> environments,
+    public IDependencyMetadata generateMetadata(IArtifactFacade artifact, Collection<TargetEnvironment> environments,
             OptionalResolutionAction optionalAction, PublisherOptions options);
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/publisher/AbstractMetadataGenerator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/publisher/AbstractMetadataGenerator.java
@@ -13,6 +13,7 @@
 package org.eclipse.tycho.p2.publisher;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
@@ -38,17 +39,17 @@ import org.eclipse.tycho.BuildProperties;
 import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.IDependencyMetadata.DependencyMetadataType;
-import org.eclipse.tycho.helper.StatusTool;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.helper.StatusTool;
 import org.eclipse.tycho.p2.metadata.PublisherOptions;
 
 public abstract class AbstractMetadataGenerator {
 
     private IProgressMonitor monitor = new NullProgressMonitor();
 
-    protected DependencyMetadata generateMetadata(IArtifactFacade artifact, List<TargetEnvironment> environments,
+    protected DependencyMetadata generateMetadata(IArtifactFacade artifact, Collection<TargetEnvironment> environments,
             IPublisherInfo publisherInfo, OptionalResolutionAction optionalAction, PublisherOptions options) {
         for (IPublisherAdvice advice : getPublisherAdvice(artifact, options)) {
             publisherInfo.addAdvice(advice);
@@ -59,7 +60,7 @@ public abstract class AbstractMetadataGenerator {
     }
 
     protected abstract List<IPublisherAction> getPublisherActions(IArtifactFacade artifact,
-            List<TargetEnvironment> environments, OptionalResolutionAction optionalAction);
+            Collection<TargetEnvironment> environments, OptionalResolutionAction optionalAction);
 
     protected abstract List<IPublisherAdvice> getPublisherAdvice(IArtifactFacade artifact, PublisherOptions options);
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/target/facade/TargetPlatformConfigurationStub.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/target/facade/TargetPlatformConfigurationStub.java
@@ -15,6 +15,7 @@ package org.eclipse.tycho.p2.target.facade;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,7 +30,7 @@ import org.eclipse.tycho.targetplatform.TargetPlatformFilter;
 // TODO 412416 add an TargetPlatformConfiguration interface with only getters, and add implementation backed by the POM configuration
 public class TargetPlatformConfigurationStub {
 
-    private List<TargetEnvironment> environments;
+    private Collection<TargetEnvironment> environments;
     private final List<TargetPlatformFilter> iuFilters = new ArrayList<>();
 
     private final Set<MavenRepositoryLocation> repositories = new LinkedHashSet<>();
@@ -42,11 +43,11 @@ public class TargetPlatformConfigurationStub {
         // TODO Auto-generated constructor stub
     }
 
-    public void setEnvironments(List<TargetEnvironment> environments) {
+    public void setEnvironments(Collection<TargetEnvironment> environments) {
         this.environments = environments;
     }
 
-    public List<TargetEnvironment> getEnvironments() {
+    public Collection<TargetEnvironment> getEnvironments() {
         return environments;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/BuildContext.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/BuildContext.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.tools;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.eclipse.tycho.BuildDirectory;
 import org.eclipse.tycho.ReactorProjectIdentities;
@@ -23,7 +23,7 @@ public class BuildContext {
 
     private final String qualifier;
 
-    private final List<TargetEnvironment> environments;
+    private final Collection<TargetEnvironment> environments;
 
     /**
      * Creates a new <code>BuildContext</code> instance.
@@ -37,7 +37,7 @@ public class BuildContext {
      * @throws IllegalArgumentException
      *             if no target environment has been specified
      */
-    public BuildContext(ReactorProjectIdentities project, String qualifier, List<TargetEnvironment> environments)
+    public BuildContext(ReactorProjectIdentities project, String qualifier, Collection<TargetEnvironment> environments)
             throws IllegalArgumentException {
         if (environments.isEmpty()) {
             throw new IllegalArgumentException("List of target environments must not be empty");
@@ -69,7 +69,7 @@ public class BuildContext {
      * @return the list of {@link TargetEnvironment} to be addressed; never <code>null</code> or
      *         empty
      */
-    public List<TargetEnvironment> getEnvironments() {
+    public Collection<TargetEnvironment> getEnvironments() {
         return environments;
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/PublisherActionRunner.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/PublisherActionRunner.java
@@ -13,7 +13,6 @@
 package org.eclipse.tycho.p2.tools.publisher;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.codehaus.plexus.logging.Logger;
 import org.eclipse.core.runtime.IStatus;
@@ -34,11 +33,11 @@ import org.eclipse.tycho.helper.StatusTool;
 public class PublisherActionRunner {
 
     private IMetadataRepository contextIUs;
-    private List<TargetEnvironment> environments;
+    private Collection<TargetEnvironment> environments;
     private Logger logger;
 
-    public PublisherActionRunner(IMetadataRepository contextInstallableUnits, List<TargetEnvironment> environments,
-            Logger logger) {
+    public PublisherActionRunner(IMetadataRepository contextInstallableUnits,
+            Collection<TargetEnvironment> environments, Logger logger) {
         this.contextIUs = contextInstallableUnits;
         this.environments = environments;
         this.logger = logger;

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/facade/PublisherServiceFactory.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/publisher/facade/PublisherServiceFactory.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.tools.publisher.facade;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.eclipse.tycho.Interpolator;
 import org.eclipse.tycho.ReactorProject;
@@ -31,9 +31,9 @@ public interface PublisherServiceFactory {
      * @return A new {@link PublisherService} instance.
      */
     // TODO separate publishers per artifact type
-    PublisherService createPublisher(ReactorProject project, List<TargetEnvironment> environments);
+    PublisherService createPublisher(ReactorProject project, Collection<TargetEnvironment> environments);
 
-    PublishProductTool createProductPublisher(ReactorProject project, List<TargetEnvironment> environments,
+    PublishProductTool createProductPublisher(ReactorProject project, Collection<TargetEnvironment> environments,
             String buildQualifier, Interpolator interpolator);
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/AbstractResolutionStrategy.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/AbstractResolutionStrategy.java
@@ -15,7 +15,6 @@ package org.eclipse.tycho.p2resolver;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -55,7 +54,7 @@ public abstract class AbstractResolutionStrategy {
         return resolve(getEffectiveFilterProperties(environment), monitor);
     }
 
-    public Collection<IInstallableUnit> multiPlatformResolve(List<TargetEnvironment> environments,
+    public Collection<IInstallableUnit> multiPlatformResolve(Collection<TargetEnvironment> environments,
             IProgressMonitor monitor) throws ResolverException {
         Set<IInstallableUnit> result = new LinkedHashSet<>();
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/DefaultDependencyMetadataGenerator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/DefaultDependencyMetadataGenerator.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import java.util.List;
+import java.util.Collection;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -35,7 +35,7 @@ public class DefaultDependencyMetadataGenerator extends P2GeneratorImpl implemen
     }
 
     @Override
-    public DependencyMetadata generateMetadata(IArtifactFacade artifact, List<TargetEnvironment> environments,
+    public DependencyMetadata generateMetadata(IArtifactFacade artifact, Collection<TargetEnvironment> environments,
             OptionalResolutionAction optionalAction, PublisherOptions options) {
         PublisherInfo publisherInfo = new PublisherInfo();
         publisherInfo.setArtifactOptions(IPublisherInfo.A_NO_MD5);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/InstallableUnitResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/InstallableUnitResolver.java
@@ -56,7 +56,7 @@ public class InstallableUnitResolver {
     private Boolean includeAllEnvironments = null;
     private Boolean includeSource = null;
 
-    private List<TargetEnvironment> environments;
+    private Collection<TargetEnvironment> environments;
 
     private ExecutionEnvironmentResolutionHints executionEnvironment;
 
@@ -66,7 +66,7 @@ public class InstallableUnitResolver {
 
     private IncludeSourceMode sourceMode;
 
-    public InstallableUnitResolver(List<TargetEnvironment> environments,
+    public InstallableUnitResolver(Collection<TargetEnvironment> environments,
             ExecutionEnvironmentResolutionHints executionEnvironment, IncludeSourceMode sourceMode,
             MavenLogger logger) {
         this.environments = environments;

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2DependencyResolver.java
@@ -158,7 +158,7 @@ public class P2DependencyResolver implements DependencyResolver, Initializable {
             //Target projects do not have any (initial) dependency metadata
         } else {
             TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
-            List<TargetEnvironment> environments = configuration.getEnvironments();
+            Collection<TargetEnvironment> environments = configuration.getEnvironments();
             Collection<IDependencyMetadata> metadataMap = getDependencyMetadata(session, project, environments,
                     OptionalResolutionAction.OPTIONAL);
             Map<DependencyMetadataType, Set<IInstallableUnit>> typeMap = new TreeMap<>();
@@ -177,7 +177,7 @@ public class P2DependencyResolver implements DependencyResolver, Initializable {
     }
 
     protected Collection<IDependencyMetadata> getDependencyMetadata(final MavenSession session,
-            final MavenProject project, final List<TargetEnvironment> environments,
+            final MavenProject project, final Collection<TargetEnvironment> environments,
             final OptionalResolutionAction optionalAction) {
         final ReactorProject reactorProject = DefaultReactorProject.adapt(project);
         final File artifactLocation = (File) reactorProject
@@ -247,7 +247,7 @@ public class P2DependencyResolver implements DependencyResolver, Initializable {
             TargetPlatformConfiguration configuration) {
         // 'this' project should obey optionalDependencies configuration
 
-        final List<TargetEnvironment> environments = configuration.getEnvironments();
+        final Collection<TargetEnvironment> environments = configuration.getEnvironments();
         final OptionalResolutionAction optionalAction = configuration.getDependencyResolverConfiguration()
                 .getOptionalResolutionAction();
         Collection<IDependencyMetadata> dependencyMetadata = getDependencyMetadata(session, project, environments,
@@ -317,7 +317,7 @@ public class P2DependencyResolver implements DependencyResolver, Initializable {
     @Override
     public DependencyArtifacts resolveDependencies(final MavenSession session, final MavenProject project,
             TargetPlatform targetPlatform, DependencyResolverConfiguration resolverConfiguration,
-            List<TargetEnvironment> environments) {
+            Collection<TargetEnvironment> environments) {
         Objects.requireNonNull(targetPlatform);
         TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
@@ -18,6 +18,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -254,8 +255,8 @@ public class P2GeneratorImpl extends AbstractMetadataGenerator implements P2Gene
     }
 
     @Override
-    protected List<IPublisherAction> getPublisherActions(IArtifactFacade artifact, List<TargetEnvironment> environments,
-            OptionalResolutionAction optionalAction) {
+    protected List<IPublisherAction> getPublisherActions(IArtifactFacade artifact,
+            Collection<TargetEnvironment> environments, OptionalResolutionAction optionalAction) {
 
         if (!dependenciesOnly && optionalAction != null) {
             throw new IllegalArgumentException();

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PublisherServiceFactoryImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/PublisherServiceFactoryImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
@@ -47,7 +47,7 @@ public class PublisherServiceFactoryImpl implements PublisherServiceFactory {
     private Logger logger;
 
     @Override
-    public PublisherService createPublisher(ReactorProject project, List<TargetEnvironment> environments) {
+    public PublisherService createPublisher(ReactorProject project, Collection<TargetEnvironment> environments) {
         P2TargetPlatform targetPlatform = targetPlatformService.getTargetPlatform(project)
                 .filter(P2TargetPlatform.class::isInstance).map(P2TargetPlatform.class::cast)
                 .orElseThrow(() -> new IllegalStateException("Target platform is missing"));
@@ -58,7 +58,7 @@ public class PublisherServiceFactoryImpl implements PublisherServiceFactory {
     }
 
     @Override
-    public PublishProductTool createProductPublisher(ReactorProject project, List<TargetEnvironment> environments,
+    public PublishProductTool createProductPublisher(ReactorProject project, Collection<TargetEnvironment> environments,
             String buildQualifier, Interpolator interpolator) {
         P2TargetPlatform targetPlatform = targetPlatformService.getTargetPlatform(project)
                 .filter(P2TargetPlatform.class::isInstance).map(P2TargetPlatform.class::cast)
@@ -71,7 +71,7 @@ public class PublisherServiceFactoryImpl implements PublisherServiceFactory {
     }
 
     private PublisherActionRunner getPublisherRunnerForProject(P2TargetPlatform targetPlatform,
-            List<TargetEnvironment> environments) {
+            Collection<TargetEnvironment> environments) {
         return new PublisherActionRunner(targetPlatform.getMetadataRepository(), environments, logger);
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/SlicerResolutionStrategy.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/SlicerResolutionStrategy.java
@@ -15,7 +15,6 @@ package org.eclipse.tycho.p2resolver;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -86,7 +85,7 @@ public class SlicerResolutionStrategy extends AbstractSlicerResolutionStrategy {
     }
 
     @Override
-    public Collection<IInstallableUnit> multiPlatformResolve(List<TargetEnvironment> environments,
+    public Collection<IInstallableUnit> multiPlatformResolve(Collection<TargetEnvironment> environments,
             IProgressMonitor monitor) throws ResolverException {
         if (ignoreFilters) {
             // short cut: properties would ignored for each single resolution, so resolve just once

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/SourcesBundleDependencyMetadataGenerator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/SourcesBundleDependencyMetadataGenerator.java
@@ -14,6 +14,7 @@
 package org.eclipse.tycho.p2resolver;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
@@ -24,7 +25,6 @@ import org.eclipse.equinox.p2.publisher.IPublisherAction;
 import org.eclipse.equinox.p2.publisher.IPublisherAdvice;
 import org.eclipse.equinox.p2.publisher.IPublisherInfo;
 import org.eclipse.equinox.p2.publisher.PublisherInfo;
-import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.tycho.BuildPropertiesParser;
@@ -39,6 +39,7 @@ import org.eclipse.tycho.p2.metadata.PublisherOptions;
 import org.eclipse.tycho.p2.publisher.AbstractMetadataGenerator;
 import org.eclipse.tycho.p2.publisher.DependencyMetadata;
 import org.eclipse.tycho.p2.publisher.DownloadStatsAdvice;
+import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 import org.osgi.framework.BundleException;
 
 @Component(role = DependencyMetadataGenerator.class, hint = DependencyMetadataGenerator.SOURCE_BUNDLE)
@@ -52,14 +53,14 @@ public class SourcesBundleDependencyMetadataGenerator extends AbstractMetadataGe
     private BuildPropertiesParser buildPropertiesParser;
 
     @Override
-    public DependencyMetadata generateMetadata(IArtifactFacade artifact, List<TargetEnvironment> environments,
+    public DependencyMetadata generateMetadata(IArtifactFacade artifact, Collection<TargetEnvironment> environments,
             OptionalResolutionAction optionalAction, PublisherOptions options) {
         return super.generateMetadata(artifact, environments, new PublisherInfo(), optionalAction, options);
     }
 
     @Override
-    protected List<IPublisherAction> getPublisherActions(IArtifactFacade artifact, List<TargetEnvironment> environments,
-            OptionalResolutionAction optionalAction) {
+    protected List<IPublisherAction> getPublisherActions(IArtifactFacade artifact,
+            Collection<TargetEnvironment> environments, OptionalResolutionAction optionalAction) {
         ArrayList<IPublisherAction> actions = new ArrayList<>();
 
         String id = artifact.getArtifactId();

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolver.java
@@ -89,7 +89,7 @@ public final class TargetDefinitionResolver {
 
     private final MavenLogger logger;
 
-    private final List<TargetEnvironment> environments;
+    private final Collection<TargetEnvironment> environments;
 
     private final ExecutionEnvironmentResolutionHints executionEnvironment;
 
@@ -99,7 +99,7 @@ public final class TargetDefinitionResolver {
 
     private ReferencedRepositoryMode referencedRepositoryMode;
 
-    public TargetDefinitionResolver(List<TargetEnvironment> environments,
+    public TargetDefinitionResolver(Collection<TargetEnvironment> environments,
             ExecutionEnvironmentResolutionHints executionEnvironment, IncludeSourceMode includeSourceMode,
             ReferencedRepositoryMode referencedRepositoryMode, MavenContext mavenContext,
             MavenTargetLocationFactory mavenDependenciesResolver, TargetDefinitionVariableResolver varResolver) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverService.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverService.java
@@ -17,6 +17,7 @@
 package org.eclipse.tycho.p2resolver;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -62,7 +63,7 @@ public class TargetDefinitionResolverService {
     }
 
     public TargetDefinitionContent getTargetDefinitionContent(TargetDefinition definition,
-            List<TargetEnvironment> environments, ExecutionEnvironmentResolutionHints jreIUs,
+            Collection<TargetEnvironment> environments, ExecutionEnvironmentResolutionHints jreIUs,
             IncludeSourceMode includeSourceMode, ReferencedRepositoryMode referencedRepositoryMode,
             IProvisioningAgent agent) {
         ResolutionArguments arguments = new ResolutionArguments(definition, environments, jreIUs, includeSourceMode,
@@ -141,13 +142,13 @@ public class TargetDefinitionResolverService {
     private static final class ResolutionArguments {
 
         final TargetDefinition definition;
-        final List<TargetEnvironment> environments;
+        final Collection<TargetEnvironment> environments;
         final ExecutionEnvironmentResolutionHints jreIUs;
         final IProvisioningAgent agent;
         private IncludeSourceMode includeSourceMode;
         private ReferencedRepositoryMode referencedRepositoryMode;
 
-        public ResolutionArguments(TargetDefinition definition, List<TargetEnvironment> environments,
+        public ResolutionArguments(TargetDefinition definition, Collection<TargetEnvironment> environments,
                 ExecutionEnvironmentResolutionHints jreIUs, IncludeSourceMode includeSourceMode,
                 ReferencedRepositoryMode repositoryMode, IProvisioningAgent agent) {
             this.definition = definition;

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/copiedfromp2/MirrorApplication.java
@@ -58,7 +58,7 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
     private static final String MIRROR_MODE = "metadataOrArtifacts"; //$NON-NLS-1$
 
     protected SlicingOptions slicingOptions = new SlicingOptions();
-    protected List<TargetEnvironment> environments = new ArrayList<>();
+    protected Collection<TargetEnvironment> environments = new ArrayList<>();
 
     private URI baseline;
     private String comparatorID;
@@ -482,7 +482,7 @@ public class MirrorApplication extends AbstractApplication implements IApplicati
         return slicer;
     }
 
-    public void setEnvironments(List<TargetEnvironment> environments) {
+    public void setEnvironments(Collection<TargetEnvironment> environments) {
         this.environments = environments;
     }
 

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/AbstractProductMojo.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/AbstractProductMojo.java
@@ -13,6 +13,7 @@
 package org.eclipse.tycho.plugins.p2.director;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.maven.execution.MavenSession;
@@ -42,8 +43,8 @@ abstract class AbstractProductMojo extends AbstractMojo {
      * <p>
      * If the project contains more than one product file, you need to choose for which ones you
      * want to create distribution archives. If you choose to install more than one product, you
-     * need to specify the <code>attachId</code> (which becomes a part of the classifier) to make the
-     * classifiers unique. Example:
+     * need to specify the <code>attachId</code> (which becomes a part of the classifier) to make
+     * the classifiers unique. Example:
      * 
      * <pre>
      * &lt;plugin&gt;
@@ -101,9 +102,9 @@ abstract class AbstractProductMojo extends AbstractMojo {
      * <li><code>rootFolder</code> - The path where the installed product shall be stored in the
      * archive, e.g. "eclipse". By default, the product is stored in the archive root.</li>
      * <li><code>rootFolders</code> - OS-specific installation root folders, overriding
-     * <code>rootFolder</code>. Allowed children are <code>&lt;macosx&gt;</code>, <code>&lt;win32&gt;</code>,
-     * <code>&lt;linux&gt;</code> and <code>&lt;freebsd&gt;</code> or any other OS supported by p2. Since
-     * 0.18.0</li>
+     * <code>rootFolder</code>. Allowed children are <code>&lt;macosx&gt;</code>,
+     * <code>&lt;win32&gt;</code>, <code>&lt;linux&gt;</code> and <code>&lt;freebsd&gt;</code> or
+     * any other OS supported by p2. Since 0.18.0</li>
      * </ul>
      * 
      */
@@ -154,7 +155,7 @@ abstract class AbstractProductMojo extends AbstractMojo {
         return null;
     }
 
-    List<TargetEnvironment> getEnvironments() {
+    Collection<TargetEnvironment> getEnvironments() {
         TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
         return configuration.getEnvironments();
     }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -153,19 +153,19 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     private String debugOptions;
 
     /**
-     * (JUnit 4.8+ only) Groups/categories for this test (comma-separated).
-     * Only classes/methods/etc decorated with one of the group/category specified here will be
-     * included in test run, if specified. This parameter requires JUnit 4.8 or higher, as the
-     * {@code @Category} annotation was introduced in JUnit 4.8.
+     * (JUnit 4.8+ only) Groups/categories for this test (comma-separated). Only classes/methods/etc
+     * decorated with one of the group/category specified here will be included in test run, if
+     * specified. This parameter requires JUnit 4.8 or higher, as the {@code @Category} annotation
+     * was introduced in JUnit 4.8.
      */
     @Parameter(property = "groups")
     private String groups;
 
     /**
-     * (JUnit 4.8+ only) Excluded groups/categories (comma-separated). Any
-     * methods/classes/etc with one of the groups/categories specified in this list will
-     * specifically not be run. This parameter requires JUnit 4.8 or higher, as the
-     * {@code @Category} annotation was introduced in JUnit 4.8.
+     * (JUnit 4.8+ only) Excluded groups/categories (comma-separated). Any methods/classes/etc with
+     * one of the groups/categories specified in this list will specifically not be run. This
+     * parameter requires JUnit 4.8 or higher, as the {@code @Category} annotation was introduced in
+     * JUnit 4.8.
      */
     @Parameter(property = "excludedGroups")
     private String excludedGroups;
@@ -379,8 +379,8 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     private boolean trimStackTrace;
 
     /**
-     * Supports values "classes"/"methods"/"both" to run in separate threads,
-     * as controlled by threadCount.
+     * Supports values "classes"/"methods"/"both" to run in separate threads, as controlled by
+     * threadCount.
      *
      * @since 0.16.0
      */
@@ -396,9 +396,8 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     private boolean perCoreThreadCount;
 
     /**
-     * The attribute thread-count allows you to specify how many threads should
-     * be allocated for this execution. Only makes sense to use in conjunction with the parallel
-     * parameter.
+     * The attribute thread-count allows you to specify how many threads should be allocated for
+     * this execution. Only makes sense to use in conjunction with the parallel parameter.
      *
      * @since 0.16.0
      */
@@ -406,9 +405,9 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
     private int threadCount = -1;
 
     /**
-     * Indicates that the thread pool will be unlimited. The parallel parameter
-     * and the actual number of classes/methods will decide. Setting this to "true" effectively
-     * disables perCoreThreadCount and threadCount.
+     * Indicates that the thread pool will be unlimited. The parallel parameter and the actual
+     * number of classes/methods will decide. Setting this to "true" effectively disables
+     * perCoreThreadCount and threadCount.
      *
      * @since 0.16.0
      */
@@ -689,8 +688,8 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
             workingDir.mkdirs();
             installationBuilder.setWorkingDir(workingDir);
             installationBuilder.setDestination(work);
-            List<TargetEnvironment> list = getTestTargetEnvironments();
-            TargetEnvironment testEnvironment = list.get(0);
+            Collection<TargetEnvironment> list = getTestTargetEnvironments();
+            TargetEnvironment testEnvironment = list.iterator().next();
             installationBuilder.setTargetEnvironment(testEnvironment);
             getLog().info("Provisioning with environment " + testEnvironment + "...");
             return installationBuilder.install();

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -22,6 +22,7 @@ package org.eclipse.tycho.surefire;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -413,9 +414,9 @@ public abstract class AbstractTestMojo extends AbstractMojo {
         return "%s;%s=\"%s\"".formatted(hostSymbolicName, Constants.BUNDLE_VERSION_ATTRIBUTE, hostVersion);
     }
 
-    protected List<TargetEnvironment> getTestTargetEnvironments() {
+    protected Collection<TargetEnvironment> getTestTargetEnvironments() {
         TargetPlatformConfiguration configuration = projectManager.getTargetPlatformConfiguration(project);
-        List<TargetEnvironment> targetEnvironments = configuration.getEnvironments();
+        Collection<TargetEnvironment> targetEnvironments = configuration.getEnvironments();
         TargetEnvironment runningEnvironment = TargetEnvironment.getRunningEnvironment();
         for (TargetEnvironment targetEnvironment : targetEnvironments) {
             if (targetEnvironment.equals(runningEnvironment)) {


### PR DESCRIPTION
Currently in some cases (e.g. aggregation of configuration through profiles) it can happen that a duplicate Target Environments show up in the target configuration.

THis not only leads to items resolved multiple times but can also break the materialize-products mojo that assumes isololation of product build in parallel build by (distinct) Target Environments