### PR TITLE
Move away of macos-13 in GHAs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Set up Java

--- a/.github/workflows/verify-platform3.yml
+++ b/.github/workflows/verify-platform3.yml
@@ -19,7 +19,7 @@ jobs:
         config: 
           - { name: Linux, os: ubuntu-latest, native: gtk.linux.x86_64 }
           - { name: Windows, os: windows-latest, native: win32.win32.x86_64 }
-          - { name: MacOS x86, os: macos-13, native: cocoa.macosx.x86_64 }
+          - { name: MacOS x86, os: macos-15-intel, native: cocoa.macosx.x86_64 }
           - { name: MacOS ARM, os: macos-latest, native: cocoa.macosx.aarch64 }
     name: Verify ${{ matrix.config.name }}
     steps:

--- a/tycho-its/projects/resolver.nativeCode/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.nativeCode/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: nativeCodeConsumer
 Bundle-SymbolicName: nativeCodeConsumer
 Bundle-Version: 1.0.0
-Require-Bundle: com.sun.jna;bundle-version="[4.5.0,5.0.0)"
+Require-Bundle: com.sun.jna;bundle-version="[5.0,6.0)"
 Bundle-ActivationPolicy: lazy

--- a/tycho-its/projects/resolver.nativeCode/pom.xml
+++ b/tycho-its/projects/resolver.nativeCode/pom.xml
@@ -11,7 +11,7 @@
     <repository>
       <id>repository</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository</url>
+      <url>https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.38.0</url>
     </repository>
   </repositories>
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO240includeLaunchers/IncludeLaunchersTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO240includeLaunchers/IncludeLaunchersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2011 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2025 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,9 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.ArchUtils;
 import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.arch.Processor;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
@@ -36,7 +38,12 @@ public class IncludeLaunchersTest extends AbstractTychoIntegrationTest {
 		File binaryDir = new File(targetdir, "repository/binary/");
 		String executable;
 		if (SystemUtils.IS_OS_MAC) {
-			executable = "includedLauncher.executable.cocoa.macosx.x86_64_1.0.0";
+			Processor cpu = ArchUtils.getProcessor();
+			if (cpu.isAarch64() && cpu.is64Bit()) {
+				executable = "includedLauncher.executable.cocoa.macosx.aarch64_1.0.0";
+			} else {
+				executable = "includedLauncher.executable.cocoa.macosx.x86_64_1.0.0";
+			}
 		} else if (SystemUtils.IS_OS_WINDOWS) {
 			executable = "includedLauncher.executable.win32.win32.x86_64_1.0.0";
 		} else {


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/13046 these are unsupported now .