### PR TITLE
Fix GHA settings.xml

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,12 +1,18 @@
-<server>
-  <id>central</id>
-  <configuration>
-    <httpConfiguration>
-      <all>
-        <connectionTimeout>120000</connectionTimeout>
-        <readTimeout>120000</readTimeout>
-      </all>
-    </httpConfiguration>
-  </configuration>
-</server>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<servers>
+		<server>
+			<id>central</id>
+			<configuration>
+				<httpConfiguration>
+					<all>
+						<connectionTimeout>120000</connectionTimeout>
+						<readTimeout>120000</readTimeout>
+					</all>
+				</httpConfiguration>
+			</configuration>
+		</server>
+	</servers>
+</settings>
 


### PR DESCRIPTION
Removes annoying warning in each GHA output:
```
Warning:
Warning:  Some problems were encountered while building the effective
settings
Warning:  Expected root element 'settings' but found 'server' (position:
START_TAG seen <server>... @1:9)  @
/home/runner/work/tycho/tycho/tycho/.github/settings.xml, line 1, column
9
```