### PR TITLE
[tycho 5] Fix version filtering regression in update-target mojo

### DIFF
--- a/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/MavenLocationUpdater.java
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/java/org/eclipse/tycho/versionbump/MavenLocationUpdater.java
@@ -121,7 +121,9 @@ public class MavenLocationUpdater {
 
     DefaultVersionsHelper getHelper(UpdateTargetMojo context) throws MojoExecutionException {
         RuleService ruleService = new RulesServiceBuilder().withWagonMap(wagonMap).withServerId("serverId")
-                .withLog(context.getLog()).withMavenSession(context.getMavenSession()).build();
+                .withLog(context.getLog()).withMavenSession(context.getMavenSession())
+                .withRulesUri(context.getMavenRulesUri()).withRuleSet(context.getMavenRuleSet())
+                .withIgnoredVersions(context.getMavenIgnoredVersions()).build();
         PomHelper pomHelper = new PomHelper(artifactFactory,
                 new VersionsExpressionEvaluator(context.getMavenSession(), context.getMojoExecution()));
         return new DefaultVersionsHelper.Builder().withPomHelper(pomHelper).withArtifactFactory(artifactFactory)


### PR DESCRIPTION
## Problem

The `update-target` mojo was incorrectly including alpha, beta, milestone, and RC versions when updating Maven dependencies in target files, despite having version filtering rules configured.

This regression was reported in [eclipse-platform/eclipse.platform.releng.aggregator#3607](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3607), where the automated dependency update workflow started picking up unwanted pre-release versions like:
- `org.slf4j:slf4j-api:2.1.0-alpha1` (instead of staying at 2.0.17)
- `org.junit.jupiter:junit-jupiter-api:6.1.0-M1` (instead of staying at 6.0.2)
- `jakarta.activation:jakarta.activation-api:2.2.0-M1` (instead of staying at 2.1.4)

## Root Cause

In commit dfbbd4302 ("Code changes for versions 2.20.1"), the `MavenLocationUpdater.getHelper()` method was refactored to work with the new `versions-maven-plugin` 2.20.1 API.

During this refactoring, three critical configuration methods were inadvertently removed:
- `.withRulesUri(context.getMavenRulesUri())`
- `.withRuleSet(context.getMavenRuleSet())`
- `.withIgnoredVersions(context.getMavenIgnoredVersions())`

The versions-maven-plugin 2.20.1 changed its API structure:
- **Old API**: Rules were configured on `DefaultVersionsHelper.Builder`
- **New API**: Rules must be configured on `RulesServiceBuilder`

The refactoring correctly moved to the new builder pattern but missed transferring these configuration calls.

## Solution

This PR adds the missing configuration methods to `RulesServiceBuilder` in the `getHelper()` method:

```java
RuleService ruleService = new RulesServiceBuilder()
    .withWagonMap(wagonMap)
    .withServerId("serverId")
    .withLog(context.getLog())
    .withMavenSession(context.getMavenSession())
    .withRulesUri(context.getMavenRulesUri())      // ← Restored
    .withRuleSet(context.getMavenRuleSet())        // ← Restored
    .withIgnoredVersions(context.getMavenIgnoredVersions())  // ← Restored
    .build();
```

This ensures that version filtering rules (such as the regex pattern `.+[-.](?i:alpha|beta|M|RC)\d*$` used by eclipse-platform) are properly applied when looking up artifact versions.

## Testing

Manually tested with the eclipse-platform project configuration and confirmed that:
- With Tycho 5.0.1: Only stable versions are selected ✅
- With Tycho 5.0.2-SNAPSHOT (before fix): Alpha/milestone versions are incorrectly selected ❌
- With Tycho 5.0.2-SNAPSHOT (after fix): Only stable versions are selected ✅