### PR TITLE
Add skipAssembling parameter to assemble-repository goal

### DIFF
--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
@@ -302,6 +302,12 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
     @Parameter(defaultValue = "repository.xml")
     private String repositoryFileName;
 
+    /**
+     * Whether or not to skip assembling the repository. False by default.
+     */
+    @Parameter(property = "p2.repository.assemble.skip", defaultValue = "false")
+    private boolean skip;
+
     @Component
     private RepositoryReferenceTool repositoryReferenceTool;
 
@@ -319,6 +325,9 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            return;
+        }
         File destination = getAssemblyRepositoryLocation();
         try (var locking = fileLockService.lockVirtually(destination)) {
             destination.mkdirs();


### PR DESCRIPTION
A skipAssembling parameter for the assemble-repository goal of the tycho-p2-repository-plugin can be useful when building products, whose repository is not used further.

See https://tycho.eclipseprojects.io/doc/latest/tycho-p2-repository-plugin/assemble-repository-mojo.html