### PR TITLE
added capability to override existing manifest in bundles

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
+++ b/tycho-core/src/main/java/org/eclipse/m2e/pde/target/shared/MavenBundleWrapper.java
@@ -103,6 +103,8 @@ public class MavenBundleWrapper {
      * @param syncContextFactory
      *            the sync context factory to acquire exclusive access to the wrapped artifact and
      *            its dependencies
+     * @param ignoreExistingMetadata
+     *            if true, the manifest file is forced to be overridden
      * @return the wrapped artifact
      * @throws Exception
      *             if wrapping the artifact fails for any reason
@@ -110,7 +112,7 @@ public class MavenBundleWrapper {
     public static WrappedBundle getWrappedArtifact(Artifact artifact,
             Function<DependencyNode, Properties> instructionsLookup, List<RemoteRepository> repositories,
             RepositorySystem repoSystem, RepositorySystemSession repositorySession,
-            SyncContextFactory syncContextFactory) throws Exception {
+            SyncContextFactory syncContextFactory, boolean ignoreExistingMetadata) throws Exception {
         CollectRequest collectRequest = new CollectRequest();
         collectRequest.setRoot(new Dependency(artifact, null));
         collectRequest.setRepositories(repositories);
@@ -149,7 +151,7 @@ public class MavenBundleWrapper {
             });
             syncContext.acquire(lockList, null);
             Map<DependencyNode, WrappedBundle> visited = new HashMap<>();
-            WrappedBundle wrappedNode = getWrappedNode(node, instructionsLookup, visited);
+            WrappedBundle wrappedNode = getWrappedNode(node, instructionsLookup, visited, ignoreExistingMetadata);
             for (WrappedBundle wrap : visited.values()) {
                 wrap.getJar().ifPresent(jar -> jar.close());
             }
@@ -158,8 +160,8 @@ public class MavenBundleWrapper {
     }
 
     private static WrappedBundle getWrappedNode(DependencyNode node,
-            Function<DependencyNode, Properties> instructionsLookup, Map<DependencyNode, WrappedBundle> visited)
-            throws Exception {
+            Function<DependencyNode, Properties> instructionsLookup, Map<DependencyNode, WrappedBundle> visited,
+            boolean ignoreExistingMetadata) throws Exception {
         WrappedBundle wrappedNode = visited.get(node);
         if (wrappedNode != null) {
             return wrappedNode;
@@ -197,7 +199,7 @@ public class MavenBundleWrapper {
                                     "Artifact " + node.getArtifact() + " can not be read as a jar file"))));
             return wrappedNode;
         }
-        if (isValidOSGi(jar.getManifest())) {
+        if (!ignoreExistingMetadata && isValidOSGi(jar.getManifest())) {
             // already a bundle!
             visited.put(node,
                     wrappedNode = new WrappedBundle(node, List.of(), null, originalFile.toPath(), jar, List.of()));
@@ -206,7 +208,7 @@ public class MavenBundleWrapper {
         List<DependencyNode> children = node.getChildren();
         List<WrappedBundle> depends = new ArrayList<>();
         for (DependencyNode child : children) {
-            depends.add(getWrappedNode(child, instructionsLookup, visited));
+            depends.add(getWrappedNode(child, instructionsLookup, visited, false));
         }
         WrappedBundle wrappedNodeAfterVisit = visited.get(node);
         if (wrappedNodeAfterVisit != null) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/MavenTargetDefinitionContent.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/MavenTargetDefinitionContent.java
@@ -39,6 +39,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
 import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.DependencyNode;
@@ -200,7 +201,28 @@ public class MavenTargetDefinitionContent implements TargetDefinitionContent {
                     symbolicName = bundleDescription != null ? bundleDescription.getSymbolicName() : null;
                     bundleVersion = bundleDescription != null ? bundleDescription.getVersion().toString() : null;
                     IInstallableUnit unit;
-                    if (symbolicName == null) {
+                    Function<DependencyNode, Properties> instructionsLookup = node -> instructionsMap.getOrDefault(
+                            getKey(node.getArtifact()), instructionsMap.getOrDefault("", defaultProperties));
+
+                    if (location.ignoreExistingMetadata()) {
+                        String overrideError = OverridePreconditionChecker.checkOverridePreconditions(symbolicName,
+                                instructionsMap, location.getIncludeDependencyDepth(), location.getRoots());
+                        if (overrideError != null) {
+                            throw new TargetDefinitionResolutionException(
+                                    "Artifact " + debugString + " could not be overriden. Reason: " + overrideError);
+                        }
+                        try {
+                            BundleGenerationResult bundleGenerationResult = generateBundle(instructionsLookup,
+                                    mavenArtifact, mavenSession, repositorySystem, collector, syncContextFactory,
+                                    mavenDependency, true);
+                            unit = bundleGenerationResult.unit();
+                            symbolicName = bundleGenerationResult.wrappedArtifact().getWrappedBsn();
+                            bundleVersion = bundleGenerationResult.wrappedArtifact().getWrappedVersion();
+                        } catch (Exception e) {
+                            throw new TargetDefinitionResolutionException("Artifact " + debugString + " of location "
+                                    + location + " could not be wrapped as a bundle", e);
+                        }
+                    } else if (symbolicName == null) { // missing manifest
                         if (location.getMissingManifestStrategy() == MissingManifestStrategy.IGNORE) {
                             logger.info("Ignoring " + debugString
                                     + " as it is not a bundle and MissingManifestStrategy is set to ignore for this location");
@@ -211,56 +233,16 @@ public class MavenTargetDefinitionContent implements TargetDefinitionContent {
                                     + " is not a bundle and MissingManifestStrategy is set to error for this location");
                         }
                         try {
-                            Function<DependencyNode, Properties> instructionsLookup = node -> instructionsMap
-                                    .getOrDefault(getKey(node.getArtifact()),
-                                            instructionsMap.getOrDefault("", defaultProperties));
-                            WrappedBundle wrappedBundle = MavenBundleWrapper.getWrappedArtifact(
-                                    new DefaultArtifact(mavenArtifact.getGroupId(), mavenArtifact.getArtifactId(),
-                                            mavenArtifact.getClassifier(), mavenArtifact.getPackagingType(),
-                                            mavenArtifact.getVersion()),
-                                    instructionsLookup, collector.getEffectiveRepositories(), repositorySystem,
-                                    mavenSession.getRepositorySession(), syncContextFactory);
-                            List<ProcessingMessage> directErrors = wrappedBundle.messages(false)
-                                    .filter(msg -> msg.type() == ProcessingMessage.Type.ERROR).toList();
-                            if (directErrors.isEmpty()) {
-                                wrappedBundle.messages(true).map(ProcessingMessage::message)
-                                        .forEach(msg -> logger.warn(debugString + ": " + msg));
-                            } else {
-                                String error = directErrors.stream().map(ProcessingMessage::message)
-                                        .collect(Collectors.joining(System.lineSeparator()));
-                                String hint = String.format(
-                                        "You can exclude it by adding <exclude>%s</exclude> to your location",
-                                        debugString);
-                                throw new RuntimeException(
-                                        String.format("Dependency %s of %s can not be wrapped: %s%s%s", debugString,
-                                                mavenDependency, error, System.lineSeparator().repeat(2), hint));
-                            }
-                            File file = wrappedBundle.getFile().get().toFile();
-                            BundleDescription description = BundlesAction.createBundleDescription(file);
-                            WrappedArtifact wrappedArtifact = new WrappedArtifact(file, mavenArtifact,
-                                    mavenArtifact.getClassifier(), description.getSymbolicName(),
-                                    description.getVersion().toString(), null);
-                            logger.info(debugString + " is wrapped as a bundle with bundle symbolic name "
-                                    + wrappedArtifact.getWrappedBsn());
-                            logger.info(wrappedArtifact.getReferenceHint());
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("The following manifest was generated for this artifact:\r\n"
-                                        + wrappedArtifact.getGeneratedManifest());
-                            }
-                            // Maven artifact info for wrapped bundles have to be stored in separate fields
-                            Map<String, String> mavenProperties = new HashMap<>();
-                            mavenProperties.put(TychoConstants.PROP_WRAPPED_GROUP_ID, mavenArtifact.getGroupId());
-                            mavenProperties.put(TychoConstants.PROP_WRAPPED_ARTIFACT_ID, mavenArtifact.getArtifactId());
-                            mavenProperties.put(TychoConstants.PROP_WRAPPED_VERSION, mavenArtifact.getVersion());
-                            mavenProperties.put(TychoConstants.PROP_WRAPPED_CLASSIFIER, mavenArtifact.getClassifier());
-                            unit = publish(description, file, new MavenPropertiesAdvice(mavenProperties));
-                            symbolicName = wrappedArtifact.getWrappedBsn();
-                            bundleVersion = wrappedArtifact.getWrappedVersion();
+                            BundleGenerationResult bundleGenerationResult = generateBundle(instructionsLookup,
+                                    mavenArtifact, mavenSession, repositorySystem, collector, syncContextFactory,
+                                    mavenDependency, false);
+                            unit = bundleGenerationResult.unit();
+                            symbolicName = bundleGenerationResult.wrappedArtifact().getWrappedBsn();
+                            bundleVersion = bundleGenerationResult.wrappedArtifact().getWrappedVersion();
                         } catch (Exception e) {
                             throw new TargetDefinitionResolutionException("Artifact " + debugString + " of location "
                                     + location + " could not be wrapped as a bundle", e);
                         }
-
                     } else {
                         unit = publish(bundleDescription, bundleLocation, mavenArtifact);
                     }
@@ -348,6 +330,53 @@ public class MavenTargetDefinitionContent implements TargetDefinitionContent {
             }
         }
         FeaturePublisher.publishFeatures(features, repositoryContent::put, artifactRepository, logger);
+    }
+
+    private BundleGenerationResult generateBundle(Function<DependencyNode, Properties> instructionsLookup,
+            IArtifactFacade mavenArtifact, MavenSession mavenSession, RepositorySystem repositorySystem,
+            MavenDependencyCollector collector, SyncContextFactory syncContextFactory, MavenDependency mavenDependency,
+            boolean overrideManifest) throws Exception {
+
+        String debugString = asDebugString(mavenArtifact);
+        MavenLogger logger = mavenContext.getLogger();
+        WrappedBundle wrappedBundle = MavenBundleWrapper.getWrappedArtifact(
+                new DefaultArtifact(mavenArtifact.getGroupId(), mavenArtifact.getArtifactId(),
+                        mavenArtifact.getClassifier(), mavenArtifact.getPackagingType(), mavenArtifact.getVersion()),
+                instructionsLookup, collector.getEffectiveRepositories(), repositorySystem,
+                mavenSession.getRepositorySession(), syncContextFactory, overrideManifest);
+        List<ProcessingMessage> directErrors = wrappedBundle.messages(false)
+                .filter(msg -> msg.type() == ProcessingMessage.Type.ERROR).toList();
+        if (directErrors.isEmpty()) {
+            wrappedBundle.messages(true).map(ProcessingMessage::message)
+                    .forEach(msg -> logger.warn(debugString + ": " + msg));
+        } else {
+            String error = directErrors.stream().map(ProcessingMessage::message)
+                    .collect(Collectors.joining(System.lineSeparator()));
+            String hint = String.format("You can exclude it by adding <exclude>%s</exclude> to your location",
+                    debugString);
+            throw new RuntimeException(String.format("Dependency %s of %s can not be wrapped: %s%s%s", debugString,
+                    mavenDependency, error, System.lineSeparator().repeat(2), hint));
+        }
+        File file = wrappedBundle.getFile().get().toFile();
+        BundleDescription description = BundlesAction.createBundleDescription(file);
+        WrappedArtifact wrappedArtifact = new WrappedArtifact(file, mavenArtifact, mavenArtifact.getClassifier(),
+                description.getSymbolicName(), description.getVersion().toString(), null);
+        logger.info(
+                debugString + " is wrapped as a bundle with bundle symbolic name " + wrappedArtifact.getWrappedBsn());
+        logger.info(wrappedArtifact.getReferenceHint());
+        if (logger.isDebugEnabled()) {
+            logger.debug("The following manifest was generated for this artifact:\r\n"
+                    + wrappedArtifact.getGeneratedManifest());
+        }
+        // Maven artifact info for wrapped bundles have to be stored in separate fields
+        Map<String, String> mavenProperties = new HashMap<>();
+        mavenProperties.put(TychoConstants.PROP_WRAPPED_GROUP_ID, mavenArtifact.getGroupId());
+        mavenProperties.put(TychoConstants.PROP_WRAPPED_ARTIFACT_ID, mavenArtifact.getArtifactId());
+        mavenProperties.put(TychoConstants.PROP_WRAPPED_VERSION, mavenArtifact.getVersion());
+        mavenProperties.put(TychoConstants.PROP_WRAPPED_CLASSIFIER, mavenArtifact.getClassifier());
+        IInstallableUnit unit = publish(description, file, new MavenPropertiesAdvice(mavenProperties));
+
+        return new BundleGenerationResult(wrappedArtifact, unit);
     }
 
     private List<RemoteRepository> getRepos(MavenSession mavenSession) {
@@ -485,6 +514,10 @@ public class MavenTargetDefinitionContent implements TargetDefinitionContent {
     }
 
     private static record ResolvedMavenArtifacts(Collection<AetherArtifactFacade> facades, Artifact root) {
+
+    }
+
+    record BundleGenerationResult(WrappedArtifact wrappedArtifact, IInstallableUnit unit) {
 
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/OverridePreconditionChecker.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/OverridePreconditionChecker.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik GmbH. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.tycho.core.resolver;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.tycho.targetplatform.TargetDefinition.MavenDependency;
+import org.eclipse.tycho.targetplatform.TargetDefinition.MavenGAVLocation.DependencyDepth;
+
+public class OverridePreconditionChecker {
+
+    private static final String CONST_BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
+
+    /**
+     * Validates preconditions for using override instructions on a bundle.
+     *
+     * @param originalSymbolicName
+     *            the bundle symbolic name from the original manifest; may be {@code null} if the
+     *            artifact is not a bundle
+     * @param instructionsMap
+     *            map of instruction sets; must contain exactly one entry with a symbolic name
+     *            different from {@code originalSymbolicName}
+     * @param dependencyDepth
+     *            the dependency depth; must be {@link DependencyDepth#NONE}
+     * @param roots
+     *            the root dependencies of the current location
+     * @return an error message if any precondition fails, otherwise {@code null}
+     */
+    public static String checkOverridePreconditions(String originalSymbolicName,
+            Map<String, Properties> instructionsMap, DependencyDepth dependencyDepth,
+            Collection<MavenDependency> roots) {
+        if (dependencyDepth != DependencyDepth.NONE) {
+            return "The dependency depth must be none!";
+        }
+        if (originalSymbolicName == null) {
+            return "The artifact is no bundle.";
+        }
+        if (roots.size() != 1) {
+            return "The location must contain exactly one root dependency.";
+        }
+        if (instructionsMap.size() != 1) {
+            return "The location must contain exactly one bnd instruction which must contain a symbolic name that differs from the original one.";
+        }
+        Properties properties = instructionsMap.values().iterator().next();
+        if (!isSymbolicNameDefinedAndDiffers(properties, originalSymbolicName)) {
+            return " The symbolic name in the bnd instructions must be defined and differ from the original one.";
+        }
+        return null;
+    }
+
+    private static boolean isSymbolicNameDefinedAndDiffers(Properties properties, String originalSymbolicName) {
+        if (properties == null) {
+            return false;
+        }
+        Object definedSymbolicName = properties.get(CONST_BUNDLE_SYMBOLIC_NAME);
+        return definedSymbolicName != null && !definedSymbolicName.equals(originalSymbolicName);
+    }
+
+}

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/OverridePreconditionCheckerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/OverridePreconditionCheckerTest.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vector Informatik GmbH. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.tycho.core.resolver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.tycho.IArtifactFacade;
+import org.eclipse.tycho.targetplatform.TargetDefinition.MavenDependency;
+import org.eclipse.tycho.targetplatform.TargetDefinition.MavenGAVLocation.DependencyDepth;
+import org.junit.Test;
+
+public class OverridePreconditionCheckerTest {
+
+    private static final String ORIGINAL = "com.example.original";
+    private static final String OVERRIDE = "com.example.override";
+    private static final Collection<MavenDependency> ROOTS = Collections.singletonList(null);
+
+    @Test
+    public void testDependencyDepthDiretIsRejected() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, singleInstruction(OVERRIDE),
+                DependencyDepth.DIRECT, ROOTS);
+        assertEquals("The dependency depth must be none!", result);
+    }
+
+    @Test
+    public void testDependencyDepthNullIsRejected() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, singleInstruction(OVERRIDE),
+                null, ROOTS);
+        assertEquals("The dependency depth must be none!", result);
+    }
+
+    @Test
+    public void testOriginalSymbolicNameNullIsRejected() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(null, singleInstruction(OVERRIDE),
+                DependencyDepth.NONE, ROOTS);
+        assertEquals("The artifact is no bundle.", result);
+    }
+
+    @Test
+    public void testRootsEmptyIsRejected() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, singleInstruction(OVERRIDE),
+                DependencyDepth.NONE, Collections.emptyList());
+        assertEquals("The location must contain exactly one root dependency.", result);
+    }
+
+    @Test
+    public void testRootsMultipleIsRejected() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, singleInstruction(OVERRIDE),
+                DependencyDepth.NONE, Arrays.asList(new TestMavenDependency(), new TestMavenDependency()));
+        assertEquals("The location must contain exactly one root dependency.", result);
+    }
+
+    @Test
+    public void testInstructionsMapEmptyIsRejected() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, Map.of(), DependencyDepth.NONE,
+                ROOTS);
+        assertEquals(
+                "The location must contain exactly one bnd instruction which must contain a symbolic name that differs from the original one.",
+                result);
+    }
+
+    @Test
+    public void testInstructionsMapWithMultipleEntriesIsRejected() {
+        Map<String, Properties> instructions = new HashMap<>();
+        instructions.put("a", propertiesWithSymbolicName(OVERRIDE));
+        instructions.put("b", propertiesWithSymbolicName("com.example.other"));
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, instructions,
+                DependencyDepth.NONE, ROOTS);
+        assertEquals(
+                "The location must contain exactly one bnd instruction which must contain a symbolic name that differs from the original one.",
+                result);
+    }
+
+    @Test
+    public void testNullPropertiesIsRejected() {
+        Map<String, Properties> instructions = new HashMap<>();
+        instructions.put("a", null);
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, instructions,
+                DependencyDepth.NONE, ROOTS);
+        assertEquals(" The symbolic name in the bnd instructions must be defined and differ from the original one.",
+                result);
+    }
+
+    @Test
+    public void testMissingSymbolicNameIsRejected() {
+        Map<String, Properties> instructions = new HashMap<>();
+        instructions.put("a", new Properties());
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, instructions,
+                DependencyDepth.NONE, ROOTS);
+        assertEquals(" The symbolic name in the bnd instructions must be defined and differ from the original one.",
+                result);
+    }
+
+    @Test
+    public void testSameSymbolicNameIsRejected() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, singleInstruction(ORIGINAL),
+                DependencyDepth.NONE, ROOTS);
+        assertEquals(" The symbolic name in the bnd instructions must be defined and differ from the original one.",
+                result);
+    }
+
+    @Test
+    public void testDifferentSymbolicNameIsAccepted() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, singleInstruction(OVERRIDE),
+                DependencyDepth.NONE, ROOTS);
+        assertNull(result);
+    }
+
+    @Test
+    public void testSymbolicNameWithWhitespaceIsAccepted() {
+        String result = OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL,
+                singleInstruction("  " + OVERRIDE + "  "), DependencyDepth.NONE, ROOTS);
+        assertNull(result);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullInstructionsMapThrows() {
+        OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, null, DependencyDepth.NONE, ROOTS);
+    }
+
+    private static Map<String, Properties> singleInstruction(String symbolicName) {
+        Map<String, Properties> instructions = new HashMap<>();
+        instructions.put("bnd", propertiesWithSymbolicName(symbolicName));
+        return instructions;
+    }
+
+    private static Properties propertiesWithSymbolicName(String symbolicName) {
+        Properties properties = new Properties();
+        properties.put("Bundle-SymbolicName", symbolicName);
+        return properties;
+    }
+
+    private static class TestMavenDependency implements MavenDependency {
+
+        @Override
+        public String getGroupId() {
+            return null;
+        }
+
+        @Override
+        public String getArtifactId() {
+            return null;
+        }
+
+        @Override
+        public String getVersion() {
+            return null;
+        }
+
+        @Override
+        public String getArtifactType() {
+            return null;
+        }
+
+        @Override
+        public String getClassifier() {
+            return null;
+        }
+
+        @Override
+        public boolean isIgnored(IArtifactFacade artifact) {
+            return false;
+        }
+
+    }
+}

--- a/tycho-its/projects/target.maven-rewriteManifest-noInstruction/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven-rewriteManifest-noInstruction/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: test.bundle
+Bundle-Version: 0.0.1.qualifier
+Automatic-Module-Name: test.bundle
+Require-Bundle: commons-io2

--- a/tycho-its/projects/target.maven-rewriteManifest-noInstruction/build.properties
+++ b/tycho-its/projects/target.maven-rewriteManifest-noInstruction/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/target.maven-rewriteManifest-noInstruction/pom.xml
+++ b/tycho-its/projects/target.maven-rewriteManifest-noInstruction/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <!--
+    Copyright (c) 2012 SAP AG All rights reserved. This program
+    and the accompanying materials are made available under the terms of
+    the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at https://www.eclipse.org/legal/epl-v10.html
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>issue-1133</groupId>
+	<artifactId>test.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>test.target</file>
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/projects/target.maven-rewriteManifest-noInstruction/src/test/bundle/TestClass.java
+++ b/tycho-its/projects/target.maven-rewriteManifest-noInstruction/src/test/bundle/TestClass.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package test.bundle;
+
+public class TestClass {
+	public static void main(String[] args) {
+	}
+}

--- a/tycho-its/projects/target.maven-rewriteManifest-noInstruction/test.target
+++ b/tycho-its/projects/target.maven-rewriteManifest-noInstruction/test.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="test">
+	<locations>
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="false" missingManifest="error" ignoreExistingMetadata="true" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+					<version>2.11.0</version>
+				</dependency>
+			</dependencies>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/target.maven-rewriteManifest/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/target.maven-rewriteManifest/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: test.bundle
+Bundle-Version: 0.0.1.qualifier
+Automatic-Module-Name: test.bundle
+Require-Bundle: org.mockito.mockito-core2,
+ org.mockito.mockito-core2.source

--- a/tycho-its/projects/target.maven-rewriteManifest/build.properties
+++ b/tycho-its/projects/target.maven-rewriteManifest/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/target.maven-rewriteManifest/pom.xml
+++ b/tycho-its/projects/target.maven-rewriteManifest/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <!--
+    Copyright (c) 2012 SAP AG All rights reserved. This program
+    and the accompanying materials are made available under the terms of
+    the Eclipse Public License v1.0 which accompanies this distribution,
+    and is available at https://www.eclipse.org/legal/epl-v10.html
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>issue-1133</groupId>
+	<artifactId>test.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>test.target</file>
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/projects/target.maven-rewriteManifest/src/test/bundle/TestClass.java
+++ b/tycho-its/projects/target.maven-rewriteManifest/src/test/bundle/TestClass.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package test.bundle;
+
+public class TestClass {
+	public static void main(String[] args) {
+	}
+}

--- a/tycho-its/projects/target.maven-rewriteManifest/test.target
+++ b/tycho-its/projects/target.maven-rewriteManifest/test.target
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="test">
+	<locations>
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" ignoreExistingMetadata="true" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-core</artifactId>
+					<version>4.1.0</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+			<instructions>
+				<![CDATA[
+					Bundle-Name:           Bundle derived from maven artifact ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
+					version:               ${version_cleanup;${mvnVersion}}
+					Bundle-SymbolicName:   org.mockito.mockito-core2
+					Bundle-Version:        ${version}
+					Import-Package:        *;resolution:=optional
+					Export-Package:        *;version="${version}";-noimport:=true
+					DynamicImport-Package: *
+				]]>
+			</instructions>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
@@ -186,4 +186,20 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
 	}
+
+	@Test
+	public void testMavenRewriteManifest() throws Exception {
+		Verifier verifier = getVerifier("target.maven-rewriteManifest", false, true);
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+	}
+
+	@Test
+	public void testMavenRewriteManifestNoInstruction() throws Exception {
+		Verifier verifier = getVerifier("target.maven-rewriteManifest-noInstruction", false, true);
+		assertThrows("Verification did not fail even if bnd instruction was missing.", VerificationException.class,
+				() -> verifier.executeGoal("verify"));
+		verifier.verifyTextInLog(
+				"Reason: The location must contain exactly one bnd instruction which must contain a symbolic name that differs from the original one.");
+	}
 }

--- a/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinition.java
+++ b/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinition.java
@@ -149,6 +149,8 @@ public interface TargetDefinition {
 
 		String getLabel();
 
+		boolean ignoreExistingMetadata();
+		
 		@Override
 		public default String getTypeDescription() {
 			return TYPE;

--- a/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinitionFile.java
+++ b/tycho-targetplatform/src/main/java/org/eclipse/tycho/targetplatform/TargetDefinitionFile.java
@@ -69,7 +69,7 @@ import aQute.bnd.osgi.resource.CapReqBuilder;
 
 public final class TargetDefinitionFile implements TargetDefinition {
 
-	public static final String ELEMENT_LOCATIONS = "locations";
+  public static final String ELEMENT_LOCATIONS = "locations";
 	private static final Map<URI, TargetDefinitionFile> FILE_CACHE = new ConcurrentHashMap<>();
 	// just for information purpose
 	private final String origin;
@@ -82,6 +82,7 @@ public final class TargetDefinitionFile implements TargetDefinition {
 	private final List<ImplicitDependency> implicitDependencies;
 	public static final String FILE_EXTENSION = ".target";
 	public static final String APPLICATION_TARGET = "application/target";
+	private static final String ATTRIBUTE_IGNORE_EXISTING_METADATA = "ignoreExistingMetadata";
 
 	private abstract static class AbstractPathLocation implements TargetDefinition.PathLocation {
 		private String path;
@@ -168,7 +169,7 @@ public final class TargetDefinitionFile implements TargetDefinition {
 			MissingManifestStrategy getMissingManifestStrategy, boolean includeSource,
 			Collection<BNDInstructions> getInstructions, DependencyDepth getIncludeDependencyDepth,
 			Collection<MavenArtifactRepositoryReference> getRepositoryReferences, Element getFeatureTemplate,
-			String label) implements TargetDefinition.MavenGAVLocation {
+			String label, boolean ignoreExistingMetadata) implements TargetDefinition.MavenGAVLocation {
 
 		MavenLocation {
 			getFeatureTemplate = getFeatureTemplate == null ? null : (Element) getFeatureTemplate.cloneNode(true);
@@ -543,7 +544,7 @@ public final class TargetDefinitionFile implements TargetDefinition {
 		return new MavenLocation(parseRoots(dom, globalExcludes), scopes, parseManifestStrategy(dom),
 				Boolean.parseBoolean(dom.getAttribute("includeSource")), parseInstructions(dom),
 				parseDependencyDepth(dom, scope), parseRepositoryReferences(dom), featureTemplate,
-				dom.getAttribute("label"));
+				dom.getAttribute("label"), Boolean.parseBoolean(dom.getAttribute(ATTRIBUTE_IGNORE_EXISTING_METADATA)));
 	}
 
 	private static IULocation parseIULocation(Element dom) {


### PR DESCRIPTION
The purpose of this change is to add the capability to override existing manifest files. Therefore a new attribute in the maven location was introduced. Added 2 integration tests to ensure that the functionality works as expected.

This RP is related to https://github.com/eclipse-m2e/m2e-core/pull/2115 