### PR TITLE
Add support for split-packages in RequireBundleChecker

### DIFF
--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/DependencyCheckMojo.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/DependencyCheckMojo.java
@@ -168,6 +168,7 @@ public class DependencyCheckMojo extends AbstractMojo {
 				requireBundleChecker.check(bundleName, bundleVersionStr);
 			}
 		}
+		requireBundleChecker.complete();
 		List<DependencyVersionProblem> dependencyProblems = context.getProblems();
 		if (dependencyProblems.isEmpty()) {
 			return;

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/RequireBundleChecker.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/RequireBundleChecker.java
@@ -13,6 +13,7 @@
 package org.eclipse.tycho.baseline.analyze;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,12 +40,24 @@ import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
 
 /**
- * Checker for Require-Bundle dependencies.
+ * Checker for Require-Bundle dependencies. Works in two phases:
+ * <ol>
+ * <li>{@link #check(String, String)} collects all versions and required data
+ * for each required bundle.</li>
+ * <li>{@link #complete()} performs the actual version checking, handling
+ * split-package situations where multiple bundles export the same package.</li>
+ * </ol>
  */
 public class RequireBundleChecker extends DependencyChecker {
 
 	private final Collection<IInstallableUnit> units;
 	private final List<ClassUsage> usages;
+	private final List<BundleCheckData> pendingChecks = new ArrayList<>();
+
+	private record BundleCheckData(String bundleName, String bundleVersionStr, IInstallableUnit unit,
+			Version compiledAgainstVersion, org.eclipse.equinox.p2.metadata.Version matchedBundleVersion,
+			List<ArtifactVersion> versions, Path compiledAgainstArtifact) {
+	}
 
 	/**
 	 * Creates a new Require-Bundle checker.
@@ -60,34 +73,99 @@ public class RequireBundleChecker extends DependencyChecker {
 	}
 
 	/**
-	 * Checks a Require-Bundle dependency.
+	 * Collects version data for a Require-Bundle dependency. The actual version
+	 * checking is deferred to {@link #complete()} to allow split-package detection
+	 * across all required bundles.
 	 * 
 	 * @param bundleName       the symbolic name of the required bundle
 	 * @param bundleVersionStr the version range string
-	 * @throws MojoFailureException if checks failed
+	 * @throws MojoFailureException if data collection fails
 	 */
 	public void check(String bundleName, String bundleVersionStr) throws MojoFailureException {
-		Log log = context.getLog();
 		Optional<IInstallableUnit> bundleProvidingUnit = ArtifactMatcher.findBundle(bundleName, units);
 		if (bundleProvidingUnit.isEmpty()) {
 			return;
 		}
 		IInstallableUnit unit = bundleProvidingUnit.get();
 		org.eclipse.equinox.p2.metadata.Version matchedBundleVersion = unit.getVersion();
+		Version current = null;
 		if (matchedBundleVersion.isOSGiCompatible()) {
-			Version current = new Version(matchedBundleVersion.toString());
+			current = new Version(matchedBundleVersion.toString());
 			allVersions.computeIfAbsent(bundleName, nil -> new TreeSet<>()).add(current);
 			lowestVersion.put(bundleName, current);
 		}
 		VersionRange versionRange = VersionRange.valueOf(bundleVersionStr);
 		List<ArtifactVersion> list = context.getVersionProviders().stream()
 				.flatMap(avp -> avp.getBundleVersions(unit, bundleName, versionRange, context.getProject())).toList();
+		// Find the compiled-against version's artifact
+		Path compiledAgainstArtifact = null;
+		for (ArtifactVersion v : list) {
+			Version version = v.getVersion();
+			if (version != null && current != null && version.equals(current) && v.getArtifact() != null) {
+				compiledAgainstArtifact = v.getArtifact();
+				break;
+			}
+		}
+		pendingChecks.add(new BundleCheckData(bundleName, bundleVersionStr, unit, current, matchedBundleVersion, list,
+				compiledAgainstArtifact));
+	}
+
+	/**
+	 * Performs the actual version checking for all collected bundles. Detects
+	 * split-package situations where the same package is exported by multiple
+	 * required bundles and filters method checks to only include classes that
+	 * actually belong to the respective bundle.
+	 * 
+	 * @throws MojoFailureException if the check encounters fatal problems
+	 */
+	public void complete() throws MojoFailureException {
+		Log log = context.getLog();
+		// Phase 1: Determine exported packages and class names per bundle from
+		// compiled-against versions
+		Map<String, Set<String>> bundleExportedPackages = new HashMap<>();
+		Map<String, Set<String>> bundleClassNames = new HashMap<>();
+		for (BundleCheckData data : pendingChecks) {
+			if (data.compiledAgainstArtifact() != null) {
+				Set<String> exportedPkgs = getExportedPackagesFromJar(data.compiledAgainstArtifact());
+				bundleExportedPackages.put(data.bundleName(), exportedPkgs);
+				ClassCollection cc = context.getClassCollection(data.compiledAgainstArtifact());
+				Set<String> classNames = cc.provides().map(MethodSignature::className).collect(Collectors.toSet());
+				bundleClassNames.put(data.bundleName(), classNames);
+			}
+		}
+		// Phase 2: Identify split packages (exported by multiple required bundles)
+		Map<String, Set<String>> packageToBundles = new HashMap<>();
+		for (var entry : bundleExportedPackages.entrySet()) {
+			for (String pkg : entry.getValue()) {
+				packageToBundles.computeIfAbsent(pkg, k -> new HashSet<>()).add(entry.getKey());
+			}
+		}
+		Set<String> splitPackages = packageToBundles.entrySet().stream().filter(e -> e.getValue().size() > 1)
+				.map(Map.Entry::getKey).collect(Collectors.toSet());
+		if (!splitPackages.isEmpty()) {
+			log.debug("Detected split packages: " + splitPackages);
+		}
+		// Phase 3: Check each bundle's versions with split-package awareness
+		for (BundleCheckData data : pendingChecks) {
+			Set<String> myClassNames = bundleClassNames.getOrDefault(data.bundleName(), Set.of());
+			checkBundle(data, splitPackages, myClassNames);
+		}
+	}
+
+	private void checkBundle(BundleCheckData data, Set<String> splitPackages, Set<String> myClassNames)
+			throws MojoFailureException {
+		Log log = context.getLog();
+		String bundleName = data.bundleName();
+		String bundleVersionStr = data.bundleVersionStr();
+		IInstallableUnit unit = data.unit();
+		org.eclipse.equinox.p2.metadata.Version matchedBundleVersion = data.matchedBundleVersion();
 		if (log.isDebugEnabled()) {
 			log.debug("== Bundle " + bundleName + " " + bundleVersionStr + " is provided by " + unit
-					+ " with version range " + versionRange + ", matching versions: "
-					+ list.stream().map(av -> av.getVersion()).map(String::valueOf).collect(Collectors.joining(", ")));
+					+ " with version range " + VersionRange.valueOf(bundleVersionStr) + ", matching versions: "
+					+ data.versions().stream().map(av -> av.getVersion()).map(String::valueOf)
+							.collect(Collectors.joining(", ")));
 		}
-		for (ArtifactVersion v : list) {
+		for (ArtifactVersion v : data.versions()) {
 			Version version = v.getVersion();
 			if (version == null) {
 				continue;
@@ -100,17 +178,23 @@ public class RequireBundleChecker extends DependencyChecker {
 			if (artifact == null) {
 				continue;
 			}
-			// Determine exported packages for THIS specific version from the JAR manifest
 			Set<String> exportedPackages = getExportedPackagesFromJar(artifact);
 			if (exportedPackages.isEmpty()) {
 				continue;
 			}
-			// Collect methods our code uses from these exported packages
 			Set<MethodSignature> bundleMethods = new TreeSet<>();
 			Map<MethodSignature, Collection<String>> references = new HashMap<>();
 			for (String packageName : exportedPackages) {
-				bundleMethods.addAll(collectMethodsForPackage(usages, packageName));
-				references.putAll(collectReferencesForPackage(usages, packageName));
+				Set<MethodSignature> packageMethods = collectMethodsForPackage(usages, packageName);
+				Map<MethodSignature, Collection<String>> packageRefs = collectReferencesForPackage(usages, packageName);
+				if (splitPackages.contains(packageName)) {
+					// Filter to only methods whose class is in this bundle
+					packageMethods = packageMethods.stream().filter(m -> myClassNames.contains(m.className()))
+							.collect(Collectors.toCollection(TreeSet::new));
+					packageRefs.entrySet().removeIf(e -> !myClassNames.contains(e.getKey().className()));
+				}
+				bundleMethods.addAll(packageMethods);
+				references.putAll(packageRefs);
 			}
 			if (bundleMethods.isEmpty()) {
 				continue;
@@ -121,8 +205,6 @@ public class RequireBundleChecker extends DependencyChecker {
 				}
 			}
 			ClassCollection collection = context.getClassCollection(artifact);
-			// For Require-Bundle, pass null as packageNameFilter since methods can come
-			// from different packages
 			boolean ok = checkMethodsInCollection(collection, bundleMethods, bundleName, null, version, references, v,
 					unit, bundleVersionStr, matchedBundleVersion, "Require-Bundle");
 			if (ok) {

--- a/tycho-its/projects/baselinePlugin/check-dependencies/pom.xml
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/pom.xml
@@ -20,6 +20,7 @@
 		<module>import-package-unversioned</module>
 		<module>require-bundle-with-range</module>
 		<module>require-bundle-no-upper-bound</module>
+		<module>require-bundle-split-package</module>
 	</modules>
 	<build>
 		<plugins>

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-split-package/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-split-package/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Require Bundle Split Package Test
+Bundle-SymbolicName: tycho.its.test.require.bundle.split.package
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.3.0,4.0.0)",
+ org.eclipse.equinox.registry;bundle-version="[3.3.0,4.0.0)"

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-split-package/build.properties
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-split-package/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-split-package/pom.xml
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-split-package/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>tycho-its-project.check-dependencies</groupId>
+		<artifactId>check-dependencies-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>tycho.its.test.require.bundle.split.package</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-split-package/src/tycho/its/test/UsesSplitPackage.java
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-split-package/src/tycho/its/test/UsesSplitPackage.java
@@ -1,0 +1,25 @@
+package tycho.its.test;
+
+import java.net.URI;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.URIUtil;
+
+/**
+ * Uses types from the split package org.eclipse.core.runtime contributed by
+ * two different bundles:
+ * <ul>
+ * <li>URIUtil.append(URI, String) from org.eclipse.equinox.common</li>
+ * <li>IConfigurationElement.createExecutableExtension(String) from
+ * org.eclipse.equinox.registry</li>
+ * </ul>
+ * The checker must not attribute registry types to common or vice versa.
+ */
+public class UsesSplitPackage {
+	public URI appendUri() throws Exception {
+		return URIUtil.append(new URI("http://example.com"), "path");
+	}
+
+	public Object createExtension(IConfigurationElement element) throws Exception {
+		return element.createExecutableExtension("class");
+	}
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/BaselinePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/BaselinePluginTest.java
@@ -196,6 +196,15 @@ public class BaselinePluginTest extends AbstractTychoIntegrationTest {
 						"Lower bound must be 3.5.0 because URIUtil.append was added in 3.5.0")
 				.assertBundleUpperBound("org.eclipse.equinox.common", "4.0.0",
 						"Upper bound should be next major version, not 'null'");
+
+		// Require-Bundle with split package: org.eclipse.equinox.common and
+		// org.eclipse.equinox.registry both export org.eclipse.core.runtime.
+		// The checker must not blame common for types from registry.
+		ManifestAssertions.of(manifestOf(checkDepsDir, "require-bundle-split-package"))
+				.assertBundleLowerBound("org.eclipse.equinox.common", "3.5.0",
+						"Lower bound for common must reflect URIUtil.append, not registry types like IConfigurationElement")
+				.assertBundleUpperBound("org.eclipse.equinox.common", "4.0.0",
+						"Upper bound for common should be preserved from original range");
 	}
 
 	private static File manifestOf(File projectDir, String module) {


### PR DESCRIPTION
Currently a split-package is not handled properly by RequireBundleChecker: As the class is not contained in one of the bundles it is claimed that this is missing until it bubbles up to the compiled-against version as it is assumed to be there (what is not the case). Then the same also happens for the other bundle as there is another version missing.

This now adds a two-phase approach where we detect split packages and only check types that are part of our split.