### PR TITLE
Skip manifest update when version range is semantically unchanged

### DIFF
--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/DependencyChecker.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/DependencyChecker.java
@@ -27,6 +27,7 @@ import org.eclipse.tycho.artifacts.ArtifactVersion;
 import org.eclipse.tycho.core.MarkdownBuilder;
 import org.eclipse.tycho.model.manifest.MutableBundleManifest;
 import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
 
 /**
  * Base class for dependency checkers that validates version ranges for
@@ -263,5 +264,21 @@ public abstract class DependencyChecker {
 				results.add(suggestion);
 			}
 		}
+	}
+
+	/**
+	 * Checks whether two version range strings are semantically equivalent using
+	 * OSGi {@link VersionRange} comparison. For example {@code [3.5.0,4)} and
+	 * {@code [3.5.0,4.0.0)} are semantically equal.
+	 *
+	 * @param range1 the first version range string
+	 * @param range2 the second version range string
+	 * @return {@code true} if both ranges represent the same semantic range
+	 */
+	protected static boolean isSameVersionRange(String range1, String range2) {
+		if (range1 == null || range2 == null) {
+			return range1 == range2;
+		}
+		return VersionRange.valueOf(range1).equals(VersionRange.valueOf(range2));
 	}
 }

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/ImportPackageChecker.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/ImportPackageChecker.java
@@ -131,20 +131,24 @@ public class ImportPackageChecker extends DependencyChecker {
 			Version lowestVersion = lowestPackageVersion.getOrDefault(packageName, Version.emptyVersion);
 			Version stripped = stripQualifier(lowestVersion, packageName);
 			String current = importedPackagesVersion.get(packageName);
+			String newRange;
 			if (current == null) {
-				packageUpdates.put(packageName,
-						String.format("[%s,%d)", stripped, (stripped.getMajor() + 1)));
+				newRange = String.format("[%s,%d)", stripped, (stripped.getMajor() + 1));
 			} else {
 				VersionRange range = VersionRange.valueOf(current);
 				Version right = range.getRight();
 				if (right == null) {
-					packageUpdates.put(packageName,
-							String.format("[%s,%d)", stripped, (stripped.getMajor() + 1)));
+					newRange = String.format("[%s,%d)", stripped, (stripped.getMajor() + 1));
 				} else {
-					packageUpdates.put(packageName,
-							String.format("[%s,%s%c", stripped, right, range.getRightType()));
+					newRange = String.format("[%s,%s%c", stripped, right, range.getRightType());
 				}
 			}
+			if (!isSameVersionRange(current, newRange)) {
+				packageUpdates.put(packageName, newRange);
+			}
+		}
+		if (packageUpdates.isEmpty()) {
+			return false;
 		}
 		manifest.updateImportedPackageVersions(packageUpdates);
 		return true;

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/RequireBundleChecker.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/RequireBundleChecker.java
@@ -398,20 +398,24 @@ public class RequireBundleChecker extends DependencyChecker {
 			Version lowestVersion = lowestBundleVersion.getOrDefault(bundleName, Version.emptyVersion);
 			Version stripped = stripQualifier(lowestVersion, bundleName);
 			String current = requiredBundleVersions.get(bundleName);
+			String newRange;
 			if (current == null) {
-				bundleUpdates.put(bundleName,
-						String.format("[%s,%d)", stripped, (stripped.getMajor() + 1)));
+				newRange = String.format("[%s,%d)", stripped, (stripped.getMajor() + 1));
 			} else {
 				VersionRange range = VersionRange.valueOf(current);
 				Version right = range.getRight();
 				if (right == null) {
-					bundleUpdates.put(bundleName,
-							String.format("[%s,%d)", stripped, (stripped.getMajor() + 1)));
+					newRange = String.format("[%s,%d)", stripped, (stripped.getMajor() + 1));
 				} else {
-					bundleUpdates.put(bundleName,
-							String.format("[%s,%s%c", stripped, right, range.getRightType()));
+					newRange = String.format("[%s,%s%c", stripped, right, range.getRightType());
 				}
 			}
+			if (!isSameVersionRange(current, newRange)) {
+				bundleUpdates.put(bundleName, newRange);
+			}
+		}
+		if (bundleUpdates.isEmpty()) {
+			return false;
 		}
 		manifest.updateRequiredBundleVersions(bundleUpdates);
 		return true;

--- a/tycho-its/projects/baselinePlugin/check-dependencies/pom.xml
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/pom.xml
@@ -22,6 +22,7 @@
 		<module>require-bundle-no-upper-bound</module>
 		<module>require-bundle-split-package</module>
 		<module>require-bundle-reexport</module>
+		<module>require-bundle-correct-range</module>
 	</modules>
 	<build>
 		<plugins>

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-correct-range/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-correct-range/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Require Bundle Correct Range Test
+Bundle-SymbolicName: tycho.its.test.require.bundle.correct.range
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.20.0,4)"

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-correct-range/build.properties
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-correct-range/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-correct-range/pom.xml
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-correct-range/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>tycho-its-project.check-dependencies</groupId>
+		<artifactId>check-dependencies-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>tycho.its.test.require.bundle.correct.range</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-correct-range/src/tycho/its/test/UsesURIUtilCorrectRange.java
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-correct-range/src/tycho/its/test/UsesURIUtilCorrectRange.java
@@ -1,0 +1,16 @@
+package tycho.its.test;
+
+import java.net.URI;
+import org.eclipse.core.runtime.URIUtil;
+
+/**
+ * Uses URIUtil.append(URI, String) from org.eclipse.equinox.common.
+ * The MANIFEST declares Require-Bundle with range [3.5.0,4) which already
+ * has the correct lower bound. The checker should detect this is semantically
+ * equal to [3.5.0,4.0.0) and leave the manifest untouched.
+ */
+public class UsesURIUtilCorrectRange {
+	public URI test() throws Exception {
+		return URIUtil.append(new URI("http://example.com"), "path");
+	}
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/BaselinePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/BaselinePluginTest.java
@@ -216,6 +216,13 @@ public class BaselinePluginTest extends AbstractTychoIntegrationTest {
 						"Lower bound must stay unchanged because CoreException is from re-exported org.eclipse.equinox.common")
 				.assertBundleUpperBound("org.eclipse.core.runtime", "4.0.0",
 						"Upper bound should be preserved from original range");
+
+		// Require-Bundle with range [3.20.0,4) where the lower bound is already
+		// correct. The suggested range [3.20.0,4.0.0) is semantically equivalent,
+		// so the manifest must remain untouched (no cosmetic reformatting).
+		ManifestAssertions.of(manifestOf(checkDepsDir, "require-bundle-correct-range"))
+				.assertBundleRawVersion("org.eclipse.equinox.common", "[3.20.0,4)",
+						"Version range must stay as [3.20.0,4) and not be reformatted to [3.20.0,4.0.0)");
 	}
 
 	private static File manifestOf(File projectDir, String module) {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/ManifestAssertions.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/ManifestAssertions.java
@@ -39,12 +39,17 @@ public class ManifestAssertions {
 
 	private final Map<String, VersionRange> importPackageRanges;
 	private final Map<String, VersionRange> requireBundleRanges;
+	private final Map<String, String> requireBundleRawVersions;
+	private final Map<String, String> importPackageRawVersions;
 	private final String bundleName;
 
 	private ManifestAssertions(Map<String, VersionRange> importPackageRanges,
-			Map<String, VersionRange> requireBundleRanges, String bundleName) {
+			Map<String, VersionRange> requireBundleRanges, Map<String, String> importPackageRawVersions,
+			Map<String, String> requireBundleRawVersions, String bundleName) {
 		this.importPackageRanges = importPackageRanges;
 		this.requireBundleRanges = requireBundleRanges;
+		this.importPackageRawVersions = importPackageRawVersions;
+		this.requireBundleRawVersions = requireBundleRawVersions;
 		this.bundleName = bundleName;
 	}
 
@@ -70,10 +75,16 @@ public class ManifestAssertions {
 		Map<String, VersionRange> importRanges = parseRanges(
 				attrs.getValue(Constants.IMPORT_PACKAGE), Constants.IMPORT_PACKAGE,
 				Constants.VERSION_ATTRIBUTE);
+		Map<String, String> importRaw = parseRawVersions(
+				attrs.getValue(Constants.IMPORT_PACKAGE), Constants.IMPORT_PACKAGE,
+				Constants.VERSION_ATTRIBUTE);
 		Map<String, VersionRange> requireRanges = parseRanges(
 				attrs.getValue(Constants.REQUIRE_BUNDLE), Constants.REQUIRE_BUNDLE,
 				Constants.BUNDLE_VERSION_ATTRIBUTE);
-		return new ManifestAssertions(importRanges, requireRanges, symbolicName);
+		Map<String, String> requireRaw = parseRawVersions(
+				attrs.getValue(Constants.REQUIRE_BUNDLE), Constants.REQUIRE_BUNDLE,
+				Constants.BUNDLE_VERSION_ATTRIBUTE);
+		return new ManifestAssertions(importRanges, requireRanges, importRaw, requireRaw, symbolicName);
 	}
 
 	/**
@@ -100,6 +111,33 @@ public class ManifestAssertions {
 				String versionStr = element.getAttribute(versionAttr);
 				if (versionStr != null) {
 					result.put(element.getValue(), new VersionRange(versionStr));
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Parses a manifest header into a map from entry name to raw version string.
+	 *
+	 * @param headerValue the raw header value (may be {@code null})
+	 * @param headerName  the header name for {@link ManifestElement#parseHeader}
+	 * @param versionAttr the attribute name holding the version
+	 * @return a map of entry names to their raw version strings
+	 * @throws BundleException if parsing fails
+	 */
+	private static Map<String, String> parseRawVersions(String headerValue, String headerName,
+			String versionAttr) throws BundleException {
+		Map<String, String> result = new HashMap<>();
+		if (headerValue == null || headerValue.isBlank()) {
+			return result;
+		}
+		ManifestElement[] elements = ManifestElement.parseHeader(headerName, headerValue);
+		if (elements != null) {
+			for (ManifestElement element : elements) {
+				String versionStr = element.getAttribute(versionAttr);
+				if (versionStr != null) {
+					result.put(element.getValue(), versionStr);
 				}
 			}
 		}
@@ -189,6 +227,26 @@ public class ManifestAssertions {
 		assertNotNull(message + " [Require-Bundle " + bundleId + "] - upper bound should exist: " + range, right);
 		assertTrue(message + " [Require-Bundle " + bundleId + "] - expected upper bound " + expected
 				+ " but was " + right, right.compareTo(expected) == 0);
+		return this;
+	}
+
+	/**
+	 * Asserts that the raw version string for a {@code Require-Bundle} entry
+	 * exactly matches the expected string. This verifies that the manifest was
+	 * not modified when the existing range is already semantically correct.
+	 *
+	 * @param bundleId        the required bundle symbolic name
+	 * @param expectedRawVersion the expected raw version string (e.g.
+	 *                        {@code "[3.5.0,4)"})
+	 * @param message         assertion context message
+	 * @return this instance for chaining
+	 */
+	public ManifestAssertions assertBundleRawVersion(String bundleId, String expectedRawVersion, String message) {
+		String rawVersion = requireBundleRawVersions.get(bundleId);
+		assertNotNull(message + " - Require-Bundle '" + bundleId + "' should have a version in " + bundleName,
+				rawVersion);
+		assertTrue(message + " [Require-Bundle " + bundleId + "] - expected raw version '" + expectedRawVersion
+				+ "' but was '" + rawVersion + "'", expectedRawVersion.equals(rawVersion));
 		return this;
 	}
 }

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/.settings/org.eclipse.jdt.core.prefs
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21


### PR DESCRIPTION
   Compare old and new version ranges using OSGi VersionRange.equals()
   before applying suggestions. This prevents cosmetic reformatting like
   [3.5.0,4) to [3.5.0,4.0.0) which are semantically equivalent.
   Added integration test with require-bundle-correct-range module.