### PR TITLE
Update maven-resolver-util to 1.9.27

### DIFF
--- a/tycho-core/pom.xml
+++ b/tycho-core/pom.xml
@@ -180,7 +180,7 @@
 		<dependency>
 	      <groupId>org.apache.maven.resolver</groupId>
 	      <artifactId>maven-resolver-util</artifactId>
-	      <version>1.9.20</version>
+	      <version>1.9.27</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>


### PR DESCRIPTION
There is dependabot PR trying to go to 2.x
(https://github.com/eclipse-tycho/tycho/pull/5853 ) but we missed that there are still releases in 1.9 series with important work in them (https://github.com/apache/maven-resolver/releases )