### PR TITLE
Support fragment host bundles in dependency check

### DIFF
--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/DependencyChecker.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/DependencyChecker.java
@@ -144,6 +144,36 @@ public abstract class DependencyChecker {
 			String dependencyName, String packageNameFilter, Version version,
 			Map<MethodSignature, Collection<String>> references, ArtifactVersion v, IInstallableUnit unit,
 			String versionStr, org.eclipse.equinox.p2.metadata.Version matchedVersion, String dependencyType) {
+		return checkMethodsInCollections(collections, methods, dependencyName, packageNameFilter, version, references,
+				v, unit, versionStr, matchedVersion, dependencyType, Map.of());
+	}
+
+	/**
+	 * Checks if methods are present in any of the given collections and reports
+	 * problems for missing ones. This supports checking against a main bundle's
+	 * classes combined with re-exported bundle classes, with optional provenance
+	 * information for re-exported packages.
+	 *
+	 * @param collections         the class collections to check (main + re-exported)
+	 * @param methods             the methods to find
+	 * @param dependencyName      the name of the dependency
+	 * @param packageNameFilter   optional filter to restrict provided method list
+	 * @param version             the version being checked
+	 * @param references          the references to the methods
+	 * @param v                   the artifact version
+	 * @param unit                the installable unit
+	 * @param versionStr          the version string from the manifest
+	 * @param matchedVersion      the matched version
+	 * @param dependencyType      the type of dependency (e.g., "Require-Bundle")
+	 * @param reexportProvenance  map from package name to provenance description
+	 *                            (e.g., "re-exported from `org.eclipse.swt [3.133.0,4.0.0)`")
+	 * @return true if all methods were found
+	 */
+	protected boolean checkMethodsInCollections(List<ClassCollection> collections, Set<MethodSignature> methods,
+			String dependencyName, String packageNameFilter, Version version,
+			Map<MethodSignature, Collection<String>> references, ArtifactVersion v, IInstallableUnit unit,
+			String versionStr, org.eclipse.equinox.p2.metadata.Version matchedVersion, String dependencyType,
+			Map<String, String> reexportProvenance) {
 		boolean ok = true;
 		Set<MethodSignature> set = new HashSet<>();
 		for (ClassCollection cc : collections) {
@@ -170,14 +200,16 @@ public abstract class DependencyChecker {
 						}
 					}
 				}
+				String provenance = reexportProvenance.getOrDefault(mthd.packageName(), "");
+				String provenanceSuffix = provenance.isEmpty() ? "" : " (package `" + mthd.packageName() + "` " + provenance + ")";
 				context.addProblem(new DependencyVersionProblem(dependencyName + "_" + version,
 						String.format(
-								"%s `%s %s` (compiled against `%s` provided by `%s %s`) includes `%s` (provided by `%s`) but this version is missing the method `%s#%s`",
+								"%s `%s %s` (compiled against `%s` provided by `%s %s`) includes `%s` (provided by `%s`) but this version is missing the method `%s#%s`%s",
 								dependencyType, dependencyName, versionStr,
 								matchedVersion != null ? matchedVersion.toString()
 										: org.eclipse.equinox.p2.metadata.Version.emptyVersion.toString(),
 								unit.getId(), unit.getVersion(), version, v.getProvider(), mthd.className(),
-								getMethodRef(mthd)),
+								getMethodRef(mthd), provenanceSuffix),
 						references.get(mthd), provided));
 				ok = false;
 				withError.add(dependencyName);

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/RequireBundleChecker.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/analyze/RequireBundleChecker.java
@@ -57,7 +57,7 @@ public class RequireBundleChecker extends DependencyChecker {
 	private final List<BundleCheckData> pendingChecks = new ArrayList<>();
 	private final Map<Path, Set<String>> exportedPackagesCache = new HashMap<>();
 	private final Map<Path, Map<String, String>> reexportCache = new HashMap<>();
-	private final Map<String, Path> lowestArtifactCache = new HashMap<>();
+	private final Map<String, ArtifactVersion> lowestArtifactCache = new HashMap<>();
 
 	private record BundleCheckData(String bundleName, String bundleVersionStr, IInstallableUnit unit,
 			Version compiledAgainstVersion, org.eclipse.equinox.p2.metadata.Version matchedBundleVersion,
@@ -138,11 +138,16 @@ public class RequireBundleChecker extends DependencyChecker {
 				// (compiled-against) version for accurate split-package detection
 				Set<String> visited = new HashSet<>();
 				visited.add(data.bundleName());
-				List<Path> reexportArtifacts = resolveReexportChain(data.compiledAgainstArtifact(), visited,
-						this::findCurrentBundleArtifact);
-				for (Path reexportArtifact : reexportArtifacts) {
-					exportedPkgs.addAll(getExportedPackagesFromJar(reexportArtifact));
-					ClassCollection reCC = context.getClassCollection(reexportArtifact);
+				List<ArtifactVersion> reexportArtifacts = resolveReexportChain(data.compiledAgainstArtifact(), visited,
+						this::findCurrentBundleArtifactVersion);
+				for (ArtifactVersion reexportAV : reexportArtifacts) {
+					Path reexportPath = reexportAV.getArtifact();
+					ClassCollection reCC = getClassCollectionWithFragments(reexportAV);
+					if (reCC.provides().findAny().isEmpty()) {
+						log.warn("Skip re-exported "+reexportPath+" because it seem not contain any classes");
+						continue;
+					}
+					exportedPkgs.addAll(getExportedPackagesFromJar(reexportPath));
 					reCC.provides().map(MethodSignature::className).forEach(classNames::add);
 				}
 				bundleExportedPackages.put(data.bundleName(), exportedPkgs);
@@ -201,10 +206,26 @@ public class RequireBundleChecker extends DependencyChecker {
 			// Resolve re-exported bundles for this version and include their packages
 			Set<String> visited = new HashSet<>();
 			visited.add(bundleName);
-			List<Path> reexportArtifacts = resolveReexportChain(artifact, visited,
-					this::findLowestMatchingBundleArtifact);
-			for (Path reexportArtifact : reexportArtifacts) {
-				exportedPackages.addAll(getExportedPackagesFromJar(reexportArtifact));
+			Map<String, String> reexportProvenance = new HashMap<>();
+			List<ArtifactVersion> reexportArtifacts = resolveReexportChain(artifact, visited,
+					this::findLowestMatchingBundleArtifactVersion);
+			List<ArtifactVersion> nonEmptyReexports = new ArrayList<>();
+			for (ArtifactVersion reexportAV : reexportArtifacts) {
+				Path reexportPath = reexportAV.getArtifact();
+				ClassCollection reCC = getClassCollectionWithFragments(reexportAV);
+				if (reCC.provides().findAny().isEmpty()) {
+					continue;
+				}
+				nonEmptyReexports.add(reexportAV);
+				String reexportBundleName = findBundleNameFromJar(reexportPath);
+				for (String pkg : getExportedPackagesFromJar(reexportPath)) {
+					exportedPackages.add(pkg);
+					if (!reexportBundleName.isEmpty()) {
+						reexportProvenance.put(pkg,
+								String.format("re-exported by `%s` from require-bundle `%s`",
+										reexportBundleName, bundleName));
+					}
+				}
 			}
 			Set<MethodSignature> bundleMethods = new TreeSet<>();
 			Map<MethodSignature, Collection<String>> references = new HashMap<>();
@@ -230,12 +251,12 @@ public class RequireBundleChecker extends DependencyChecker {
 			}
 			// Check against combined collection: main bundle + re-exported bundles
 			List<ClassCollection> collections = new ArrayList<>();
-			collections.add(context.getClassCollection(artifact));
-			for (Path reexportArtifact : reexportArtifacts) {
-				collections.add(context.getClassCollection(reexportArtifact));
+			collections.add(getClassCollectionWithFragments(v));
+			for (ArtifactVersion reexportAV : nonEmptyReexports) {
+				collections.add(getClassCollectionWithFragments(reexportAV));
 			}
 			boolean ok = checkMethodsInCollections(collections, bundleMethods, bundleName, null, version, references,
-					v, unit, bundleVersionStr, matchedBundleVersion, "Require-Bundle");
+					v, unit, bundleVersionStr, matchedBundleVersion, "Require-Bundle", reexportProvenance);
 			if (ok) {
 				lowestVersion.merge(bundleName, version, (v1, v2) -> v1.compareTo(v2) > 0 ? v2 : v1);
 			}
@@ -251,12 +272,13 @@ public class RequireBundleChecker extends DependencyChecker {
 	 * @param bundleJarPath  the JAR to read re-exports from
 	 * @param visited        set of already-visited bundle names (for cycle
 	 *                       prevention)
-	 * @param artifactFinder strategy to find a bundle artifact given name and range
-	 * @return list of artifact paths for all transitively re-exported bundles
+	 * @param artifactFinder strategy to find a bundle artifact version given name
+	 *                       and range
+	 * @return list of artifact versions for all transitively re-exported bundles
 	 */
-	private List<Path> resolveReexportChain(Path bundleJarPath, Set<String> visited,
-			BiFunction<String, VersionRange, Path> artifactFinder) {
-		List<Path> result = new ArrayList<>();
+	private List<ArtifactVersion> resolveReexportChain(Path bundleJarPath, Set<String> visited,
+			BiFunction<String, VersionRange, ArtifactVersion> artifactFinder) {
+		List<ArtifactVersion> result = new ArrayList<>();
 		Map<String, String> reexports = getReexportedBundlesFromJar(bundleJarPath);
 		for (Map.Entry<String, String> entry : reexports.entrySet()) {
 			String reexportName = entry.getKey();
@@ -264,10 +286,10 @@ public class RequireBundleChecker extends DependencyChecker {
 				continue;
 			}
 			VersionRange range = VersionRange.valueOf(entry.getValue());
-			Path reexportArtifact = artifactFinder.apply(reexportName, range);
-			if (reexportArtifact != null) {
-				result.add(reexportArtifact);
-				result.addAll(resolveReexportChain(reexportArtifact, visited, artifactFinder));
+			ArtifactVersion reexportAV = artifactFinder.apply(reexportName, range);
+			if (reexportAV != null && reexportAV.getArtifact() != null) {
+				result.add(reexportAV);
+				result.addAll(resolveReexportChain(reexportAV.getArtifact(), visited, artifactFinder));
 			}
 		}
 		return result;
@@ -280,9 +302,9 @@ public class RequireBundleChecker extends DependencyChecker {
 	 *
 	 * @param bundleName the symbolic name of the bundle
 	 * @param range      the version range to match
-	 * @return the path to the lowest matching artifact, or {@code null}
+	 * @return the lowest matching artifact version, or {@code null}
 	 */
-	private Path findLowestMatchingBundleArtifact(String bundleName, VersionRange range) {
+	private ArtifactVersion findLowestMatchingBundleArtifactVersion(String bundleName, VersionRange range) {
 		String cacheKey = bundleName + ":" + range;
 		return lowestArtifactCache.computeIfAbsent(cacheKey, k -> {
 			Optional<IInstallableUnit> bundleUnit = ArtifactMatcher.findBundle(bundleName, units);
@@ -293,21 +315,21 @@ public class RequireBundleChecker extends DependencyChecker {
 			return context.getVersionProviders().stream()
 					.flatMap(avp -> avp.getBundleVersions(iu, bundleName, range, context.getProject()))
 					.filter(av -> av.getVersion() != null && av.getArtifact() != null)
-					.min(Comparator.comparing(ArtifactVersion::getVersion)).map(ArtifactVersion::getArtifact)
+					.min(Comparator.comparing(ArtifactVersion::getVersion))
 					.orElse(null);
 		});
 	}
 
 	/**
-	 * Finds the current (compiled-against / target platform) artifact for a bundle.
-	 * Used during Phase 1 to determine class names for accurate split-package
-	 * detection with re-exported bundles.
+	 * Finds the current (compiled-against / target platform) artifact version for a
+	 * bundle. Used during Phase 1 to determine class names for accurate
+	 * split-package detection with re-exported bundles.
 	 *
 	 * @param bundleName the symbolic name of the bundle
 	 * @param range      the version range (used to filter available versions)
-	 * @return the path to the current version's artifact, or {@code null}
+	 * @return the current version's artifact version, or {@code null}
 	 */
-	private Path findCurrentBundleArtifact(String bundleName, VersionRange range) {
+	private ArtifactVersion findCurrentBundleArtifactVersion(String bundleName, VersionRange range) {
 		Optional<IInstallableUnit> bundleUnit = ArtifactMatcher.findBundle(bundleName, units);
 		if (bundleUnit.isEmpty()) {
 			return null;
@@ -320,11 +342,35 @@ public class RequireBundleChecker extends DependencyChecker {
 		return context.getVersionProviders().stream()
 				.flatMap(avp -> avp.getBundleVersions(iu, bundleName, range, context.getProject()))
 				.filter(av -> av.getVersion() != null && av.getVersion().equals(current) && av.getArtifact() != null)
-				.findFirst().map(ArtifactVersion::getArtifact).orElse(null);
+				.findFirst().orElse(null);
 	}
 
 	private Set<String> getExportedPackagesFromJar(Path jarPath) {
 		return exportedPackagesCache.computeIfAbsent(jarPath, this::readExportedPackagesFromJar);
+	}
+
+	/**
+	 * Reads the {@code Bundle-SymbolicName} from a JAR's manifest.
+	 *
+	 * @param jarPath the JAR file to read
+	 * @return the symbolic name, or an empty string if unavailable
+	 */
+	private String findBundleNameFromJar(Path jarPath) {
+		try (JarFile jar = new JarFile(jarPath.toFile())) {
+			Manifest manifest = jar.getManifest();
+			if (manifest != null) {
+				String bsn = manifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME);
+				if (bsn != null) {
+					ManifestElement[] elements = ManifestElement.parseHeader(Constants.BUNDLE_SYMBOLICNAME, bsn);
+					if (elements != null && elements.length > 0) {
+						return elements[0].getValue();
+					}
+				}
+			}
+		} catch (BundleException | java.io.IOException e) {
+			context.getLog().debug("Could not read bundle name from " + jarPath + ": " + e);
+		}
+		return "";
 	}
 
 	private Set<String> readExportedPackagesFromJar(Path jarPath) {
@@ -346,6 +392,60 @@ public class RequireBundleChecker extends DependencyChecker {
 			context.getLog().debug("Could not read exported packages from " + jarPath + ": " + e);
 		}
 		return packages;
+	}
+
+	/**
+	 * Checks whether a JAR's manifest declares {@code Eclipse-ExtensibleAPI: true},
+	 * indicating it is a host bundle that expects fragments to provide classes.
+	 *
+	 * @param jarPath the JAR file to check
+	 * @return {@code true} if the bundle has extensible API
+	 */
+	private boolean isExtensibleAPI(Path jarPath) {
+		try (JarFile jar = new JarFile(jarPath.toFile())) {
+			Manifest manifest = jar.getManifest();
+			if (manifest != null) {
+				return "true".equalsIgnoreCase(manifest.getMainAttributes().getValue("Eclipse-ExtensibleAPI"));
+			}
+		} catch (java.io.IOException e) {
+			context.getLog().debug("Could not read manifest from " + jarPath + ": " + e);
+		}
+		return false;
+	}
+
+	/**
+	 * Gets a {@link ClassCollection} for a bundle artifact version, resolving
+	 * fragment classes when the JAR is an empty host bundle with
+	 * {@code Eclipse-ExtensibleAPI: true}. Uses
+	 * {@link ArtifactVersion#fragments()} to find fragments in the same
+	 * repository where the host was found.
+	 *
+	 * @param av the artifact version to analyze
+	 * @return the class collection (potentially augmented with fragment classes)
+	 */
+	private ClassCollection getClassCollectionWithFragments(ArtifactVersion av) {
+		Path jarPath = av.getArtifact();
+		if (jarPath == null) {
+			return new ClassCollection();
+		}
+		ClassCollection hostCC = context.getClassCollection(jarPath);
+		if (hostCC.provides().findAny().isPresent()) {
+			return hostCC;
+		}
+		// Empty JAR — check if it's an extensible API host
+		if (!isExtensibleAPI(jarPath)) {
+			return hostCC;
+		}
+		// Ask the artifact version for fragments from the same repository
+		ArtifactVersion fragment = av.fragments()
+				.filter(f -> f.getArtifact() != null)
+				.findFirst().orElse(null);
+		if (fragment == null) {
+			context.getLog().debug("No fragment found for extensible API host " + av);
+			return hostCC;
+		}
+		context.getLog().debug("Resolved fragment for " + av + ": " + fragment);
+		return context.getClassCollection(fragment.getArtifact());
 	}
 
 	/**

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/provider/EclipseIndexBundleArtifactVersion.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/provider/EclipseIndexBundleArtifactVersion.java
@@ -12,19 +12,27 @@
  *******************************************************************************/
 package org.eclipse.tycho.baseline.provider;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.equinox.internal.p2.metadata.IRequiredCapability;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+import org.eclipse.tycho.artifacts.ArtifactVersion;
 import org.eclipse.tycho.copyfrom.oomph.P2Index.Repository;
+import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 
 class EclipseIndexBundleArtifactVersion extends AbstractEclipseArtifactVersion {
 
 	private final String bundleName;
+	private List<ArtifactVersion> cachedFragments;
 
 	public EclipseIndexBundleArtifactVersion(EclipseIndexArtifactVersionProvider provider,
 			List<Repository> repositories, String bundleName, Version version, Logger logger) {
@@ -54,5 +62,62 @@ class EclipseIndexBundleArtifactVersion extends AbstractEclipseArtifactVersion {
 			}
 		}
 		return Optional.empty();
+	}
+
+	@Override
+	public Stream<ArtifactVersion> fragments() {
+		if (cachedFragments != null) {
+			return cachedFragments.stream();
+		}
+		// Ensure the unit is resolved so we know which repo it came from
+		Optional<IInstallableUnit> hostUnit = unit;
+		if (hostUnit == null) {
+			hostUnit = findUnit();
+		}
+		if (hostUnit == null || hostUnit.isEmpty() || unitRepo == null) {
+			cachedFragments = List.of();
+			return cachedFragments.stream();
+		}
+		Version hostVersion = hostUnit.get().getVersion();
+		try {
+			org.apache.maven.model.Repository r = new org.apache.maven.model.Repository();
+			r.setUrl(unitRepo.getLocation().toString());
+			IMetadataRepository metadataRepository = getVersionProvider().repositoryManager
+					.getMetadataRepository(r);
+			Collection<IInstallableUnit> candidates = metadataRepository
+					.query(QueryUtil.createMatchQuery(
+							"providedCapabilities.exists(x | x.namespace == $0 && x.name == $1)",
+							BundlesAction.CAPABILITY_NS_OSGI_FRAGMENT, bundleName),
+							null)
+					.toUnmodifiableSet();
+			cachedFragments = candidates.stream()
+					.filter(candidate -> fragmentMatchesHostVersion(candidate, bundleName, hostVersion))
+					.map(fragmentIU -> (ArtifactVersion) new EclipseIndexFragmentArtifactVersion(
+							getVersionProvider(), unitRepo, fragmentIU))
+					.toList();
+			return cachedFragments.stream();
+		} catch (Exception e) {
+			getVersionProvider().logger.error(
+					"Failed to query fragments for " + bundleName + " from " + unitRepo.getLocation() + ": " + e);
+			cachedFragments = List.of();
+			return cachedFragments.stream();
+		}
+	}
+
+	/**
+	 * Checks whether a fragment IU's {@code Fragment-Host} requirement includes the
+	 * given host version.
+	 */
+	private static boolean fragmentMatchesHostVersion(IInstallableUnit fragmentIU, String hostBundleName,
+			Version hostVersion) {
+		for (IRequirement req : fragmentIU.getRequirements()) {
+			if (req instanceof IRequiredCapability rc
+					&& BundlesAction.CAPABILITY_NS_OSGI_BUNDLE.equals(rc.getNamespace())
+					&& hostBundleName.equals(rc.getName())) {
+				VersionRange range = rc.getRange();
+				return range.isIncluded(hostVersion);
+			}
+		}
+		return false;
 	}
 }

--- a/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/provider/EclipseIndexFragmentArtifactVersion.java
+++ b/tycho-baseline-plugin/src/main/java/org/eclipse/tycho/baseline/provider/EclipseIndexFragmentArtifactVersion.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.baseline.provider;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.tycho.copyfrom.oomph.P2Index.Repository;
+
+/**
+ * Wraps a pre-resolved fragment {@link IInstallableUnit} found in the same
+ * repository as its host bundle. Used by
+ * {@link EclipseIndexBundleArtifactVersion#fragments()} to provide fragment
+ * artifacts without additional repository lookups.
+ */
+class EclipseIndexFragmentArtifactVersion extends AbstractEclipseArtifactVersion {
+
+	EclipseIndexFragmentArtifactVersion(EclipseIndexArtifactVersionProvider provider, Repository repository,
+			IInstallableUnit fragmentIU) {
+		super(provider, List.of(repository), fragmentIU.getVersion());
+		this.unitRepo = repository;
+		this.unit = Optional.of(fragmentIU);
+	}
+
+	@Override
+	protected Optional<IInstallableUnit> findUnit() {
+		return unit;
+	}
+}

--- a/tycho-its/projects/baselinePlugin/check-dependencies/pom.xml
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/pom.xml
@@ -23,6 +23,9 @@
 		<module>require-bundle-split-package</module>
 		<module>require-bundle-reexport</module>
 		<module>require-bundle-correct-range</module>
+		<module>require-bundle-swt-direct</module>
+		<module>require-bundle-swt-reexport</module>
+		<module>require-bundle-swt-bump</module>
 	</modules>
 	<build>
 		<plugins>

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-bump/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-bump/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Require Bundle SWT Bump Test
+Bundle-SymbolicName: tycho.its.test.require.bundle.swt.bump
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.swt;bundle-version="[3.131.0,4.0.0)"

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-bump/build.properties
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-bump/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-bump/pom.xml
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-bump/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>tycho-its-project.check-dependencies</groupId>
+		<artifactId>check-dependencies-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>tycho.its.test.require.bundle.swt.bump</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-bump/src/tycho/its/test/UsesSwtBump.java
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-bump/src/tycho/its/test/UsesSwtBump.java
@@ -1,0 +1,16 @@
+package tycho.its.test;
+
+import org.eclipse.swt.graphics.Point;
+
+/**
+ * Uses Point.clone() which was added as a public method in SWT 3.132 (covariant
+ * return type override of Object.clone()). With a lower bound of 3.131.0, the
+ * checker must detect that SWT 3.131.0 is missing this method and bump the
+ * lower bound to 3.132.0, proving that fragment class discovery works for
+ * detecting actual API changes.
+ */
+public class UsesSwtBump {
+	public Point clonePoint(Point p) {
+		return p.clone();
+	}
+}

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-direct/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-direct/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Require Bundle SWT Direct Test
+Bundle-SymbolicName: tycho.its.test.require.bundle.swt.direct
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.swt;bundle-version="[3.132.0,4.0.0)"

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-direct/build.properties
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-direct/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-direct/pom.xml
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-direct/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>tycho-its-project.check-dependencies</groupId>
+		<artifactId>check-dependencies-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>tycho.its.test.require.bundle.swt.direct</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-direct/src/tycho/its/test/UsesSwtDirectly.java
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-direct/src/tycho/its/test/UsesSwtDirectly.java
@@ -1,0 +1,18 @@
+package tycho.its.test;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Uses SWT Display and Shell from the org.eclipse.swt bundle. The host bundle
+ * org.eclipse.swt has Eclipse-ExtensibleAPI: true and its JAR is empty — real
+ * classes live in platform-specific fragments (e.g.,
+ * org.eclipse.swt.gtk.linux.x86_64). The checker must resolve the fragment to
+ * find the actual classes and not report false positives.
+ */
+public class UsesSwtDirectly {
+	public Shell createShell() {
+		Display display = Display.getDefault();
+		return new Shell(display);
+	}
+}

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-reexport/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-reexport/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Require Bundle SWT Reexport Test
+Bundle-SymbolicName: tycho.its.test.require.bundle.swt.reexport
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.jface;bundle-version="[3.38.0,4.0.0)"

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-reexport/build.properties
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-reexport/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-reexport/pom.xml
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-reexport/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>tycho-its-project.check-dependencies</groupId>
+		<artifactId>check-dependencies-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>tycho.its.test.require.bundle.swt.reexport</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-reexport/src/tycho/its/test/UsesSwtViaReexport.java
+++ b/tycho-its/projects/baselinePlugin/check-dependencies/require-bundle-swt-reexport/src/tycho/its/test/UsesSwtViaReexport.java
@@ -1,0 +1,17 @@
+package tycho.its.test;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Uses SWT Display and Shell through org.eclipse.jface which re-exports
+ * org.eclipse.swt via visibility:=reexport. The checker must resolve the SWT
+ * fragment (since org.eclipse.swt is an empty host bundle) through the
+ * re-export chain and not report false positives about missing SWT methods.
+ */
+public class UsesSwtViaReexport {
+	public Shell createShell() {
+		Display display = Display.getDefault();
+		return new Shell(display);
+	}
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/BaselinePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/BaselinePluginTest.java
@@ -223,6 +223,36 @@ public class BaselinePluginTest extends AbstractTychoIntegrationTest {
 		ManifestAssertions.of(manifestOf(checkDepsDir, "require-bundle-correct-range"))
 				.assertBundleRawVersion("org.eclipse.equinox.common", "[3.20.0,4)",
 						"Version range must stay as [3.20.0,4) and not be reformatted to [3.20.0,4.0.0)");
+
+		// Require-Bundle directly requiring org.eclipse.swt (an empty host bundle
+		// with Eclipse-ExtensibleAPI: true where real classes live in platform
+		// fragments). The checker must resolve a fragment to find SWT classes
+		// and not report false positives about missing Display/Shell methods.
+		ManifestAssertions.of(manifestOf(checkDepsDir, "require-bundle-swt-direct"))
+				.assertBundleLowerBound("org.eclipse.swt", "3.132.0",
+						"Lower bound must stay at 3.132.0 because Display.getDefault and Shell exist in all recent SWT versions")
+				.assertBundleUpperBound("org.eclipse.swt", "4.0.0",
+						"Upper bound should be preserved from original range");
+
+		// Require-Bundle requiring org.eclipse.jface which re-exports org.eclipse.swt.
+		// SWT classes are available through the re-export chain but the SWT host JAR
+		// is empty. The checker must resolve the fragment through the reexport and
+		// not report false positives about missing SWT methods.
+		ManifestAssertions.of(manifestOf(checkDepsDir, "require-bundle-swt-reexport"))
+				.assertBundleLowerBound("org.eclipse.jface", "3.38.0",
+						"Lower bound must stay because SWT methods used (Display/Shell) exist in all SWT versions included by this range")
+				.assertBundleUpperBound("org.eclipse.jface", "4.0.0",
+						"Upper bound should be preserved from original range");
+
+		// Require-Bundle directly requiring org.eclipse.swt with lower bound 3.131.0,
+		// but using Point.clone() which was added in SWT 3.132. The checker must
+		// resolve the SWT fragment, detect that Point.clone() is missing in SWT 3.131,
+		// and bump the lower bound to 3.132.0.
+		ManifestAssertions.of(manifestOf(checkDepsDir, "require-bundle-swt-bump"))
+				.assertBundleLowerBound("org.eclipse.swt", "3.132.0",
+						"Lower bound must be bumped to 3.132.0 because Point.clone() was added in SWT 3.132")
+				.assertBundleUpperBound("org.eclipse.swt", "4.0.0",
+						"Upper bound should be preserved from original range");
 	}
 
 	private static File manifestOf(File projectDir, String module) {

--- a/tycho-spi/src/main/java/org/eclipse/tycho/artifacts/ArtifactVersion.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/artifacts/ArtifactVersion.java
@@ -13,6 +13,7 @@
 package org.eclipse.tycho.artifacts;
 
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import org.osgi.framework.Version;
 
@@ -23,4 +24,14 @@ public interface ArtifactVersion {
     Version getVersion();
 
     String getProvider();
+
+    /**
+     * Returns fragment artifacts compatible with this bundle version
+     *
+     * @return a stream of artifact versions for compatible fragments, empty if
+     *         this is not a host bundle or no fragments are found
+     */
+    default Stream<ArtifactVersion> fragments() {
+        return Stream.empty();
+    }
 }


### PR DESCRIPTION
Add SWT fragment resolution tests for dependency checker

Add three integration test bundles for SWT host/fragment handling:
 - require-bundle-swt-direct: direct SWT dependency (no bump)
 - require-bundle-swt-reexport: SWT through JFace re-export chain (no bump)
 - require-bundle-swt-bump: Point.clone() detection proves fragment discovery