### PR TITLE
Add classpathDependencies option for target platform resolution

### DIFF
--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/DependencyResolutionConfiguration.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/DependencyResolutionConfiguration.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.tycho.ClasspathDependenciesAction;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.core.TargetPlatformConfiguration.LocalArtifactHandling;
 import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
@@ -27,6 +28,7 @@ public class DependencyResolutionConfiguration {
     }
 
     public OptionalResolutionAction optionalDependencies;
+    public ClasspathDependenciesAction classpathDependencies;
     public List<ExtraRequirementConfiguration> extraRequirements;
     public Properties profileProperties;
     @Parameter(property = DefaultTargetPlatformConfigurationReader.LOCAL_ARTIFACTS_PROPERTY, name = DefaultTargetPlatformConfigurationReader.LOCAL_ARTIFACTS)

--- a/tycho-api/src/main/java/org/eclipse/tycho/ClasspathDependenciesAction.java
+++ b/tycho-api/src/main/java/org/eclipse/tycho/ClasspathDependenciesAction.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho;
+
+/**
+ * Defines how extra classpath dependencies (from <code>jars.extra.classpath</code> in
+ * build.properties) are handled during target platform resolution.
+ */
+public enum ClasspathDependenciesAction {
+
+    /**
+     * Treat extra classpath dependencies as required.
+     */
+    REQUIRE,
+
+    /**
+     * Treat extra classpath dependencies as optional (included if available, not an error if
+     * missing).
+     */
+    OPTIONAL,
+
+    /**
+     * Ignore extra classpath dependencies during resolution.
+     */
+    IGNORE;
+}

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -66,6 +66,7 @@ import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.jdt.internal.compiler.util.CtSym;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.tycho.ArtifactKey;
+import org.eclipse.tycho.BuildFailureException;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.ClasspathEntry.AccessRule;
 import org.eclipse.tycho.DefaultArtifactKey;
@@ -426,8 +427,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
                     this.currentSourceRoots = new ArrayList<String>();
                     for (SourcepathEntry entry : sourcepath) {
                         File sourcesRoot = entry.getSourcesRoot();
-                        File releaseSourceRoot = new File(sourcesRoot.getParentFile(),
-                                sourcesRoot.getName() + release);
+                        File releaseSourceRoot = new File(sourcesRoot.getParentFile(), sourcesRoot.getName() + release);
                         if (releaseSourceRoot.isDirectory()) {
                             this.currentSourceRoots.add(releaseSourceRoot.getAbsolutePath().toString());
                         }
@@ -902,11 +902,15 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo impl
     public List<ClasspathEntry> getClasspath() throws MojoExecutionException {
         List<ClasspathEntry> classpath;
         String dependencyScope = getDependencyScope();
-        if (Artifact.SCOPE_TEST.equals(dependencyScope)) {
-            classpath = new ArrayList<>(getBundleProject().getTestClasspath(DefaultReactorProject.adapt(project)));
-        } else {
-            ReactorProject reactorProject = DefaultReactorProject.adapt(project);
-            classpath = new ArrayList<>(getBundleProject().getClasspath(reactorProject));
+        try {
+            if (Artifact.SCOPE_TEST.equals(dependencyScope)) {
+                classpath = new ArrayList<>(getBundleProject().getTestClasspath(DefaultReactorProject.adapt(project)));
+            } else {
+                ReactorProject reactorProject = DefaultReactorProject.adapt(project);
+                classpath = new ArrayList<>(getBundleProject().getClasspath(reactorProject));
+            }
+        } catch (BuildFailureException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
         }
         if (extraClasspathElements != null) {
             try {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TargetPlatformConfiguration.java
@@ -36,6 +36,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.ClasspathDependenciesAction;
 import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.TargetEnvironment;
@@ -122,6 +123,8 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
     private List<TargetPlatformFilter> filters;
 
     private OptionalResolutionAction optionalAction = OptionalResolutionAction.REQUIRE;
+
+    private ClasspathDependenciesAction classpathDependenciesAction = ClasspathDependenciesAction.REQUIRE;
 
     private final List<ArtifactKey> extraRequirements = new ArrayList<>();
     private final Set<String> exclusions = new HashSet<>();
@@ -298,6 +301,14 @@ public class TargetPlatformConfiguration implements DependencyResolverConfigurat
 
     public void setOptionalResolutionAction(OptionalResolutionAction optionalAction) {
         this.optionalAction = optionalAction;
+    }
+
+    public ClasspathDependenciesAction getClasspathDependenciesAction() {
+        return classpathDependenciesAction;
+    }
+
+    public void setClasspathDependenciesAction(ClasspathDependenciesAction classpathDependenciesAction) {
+        this.classpathDependenciesAction = classpathDependenciesAction;
     }
 
     /**

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -43,7 +43,9 @@ import org.eclipse.equinox.p2.metadata.IRequirement;
 import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.BuildFailureException;
 import org.eclipse.tycho.BuildPropertiesParser;
+import org.eclipse.tycho.ClasspathDependenciesAction;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.ClasspathEntry.AccessRule;
 import org.eclipse.tycho.DefaultArtifactKey;
@@ -366,6 +368,9 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
 
     private void addExtraClasspathEntries(List<ClasspathEntry> classpath, ReactorProject project,
             DependencyArtifacts artifacts) {
+        TargetPlatformConfiguration tpConfig = projectManager
+                .getTargetPlatformConfiguration(project.adapt(MavenProject.class));
+        ClasspathDependenciesAction classpathAction = tpConfig.getClasspathDependenciesAction();
         EclipsePluginProject pdeProject = getEclipsePluginProject(project);
         Collection<BuildOutputJar> outputJars = pdeProject.getOutputJarMap().values();
         for (BuildOutputJar buildOutputJar : outputJars) {
@@ -388,7 +393,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
                     if (matchingBundle != null) {
                         classpath.add(addBundleToClasspath(matchingBundle, path));
                     } else {
-                        logger.warn("Missing extra classpath entry " + entry.trim());
+                        handleMissingExtraClasspathEntry(entry.trim(), classpathAction);
                     }
                 } else {
                     entry = entry.trim();
@@ -398,7 +403,7 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
                         ArtifactKey projectKey = getArtifactKey(project);
                         classpath.add(new DefaultClasspathEntry(project, projectKey, locations, null));
                     } else {
-                        logger.warn("Missing extra classpath entry " + entry);
+                        handleMissingExtraClasspathEntry(entry, classpathAction);
                     }
                 }
             }
@@ -426,6 +431,19 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
                             Collections.singletonList(location), null));
                 }
             }
+        }
+    }
+
+    private void handleMissingExtraClasspathEntry(String entry, ClasspathDependenciesAction action) {
+        switch (action) {
+        case IGNORE:
+            break;
+        case OPTIONAL:
+            logger.warn("Missing extra classpath entry " + entry);
+            break;
+        case REQUIRE:
+            throw new BuildFailureException("Missing extra classpath entry " + entry
+                    + ". Configure <classpathDependencies> in target-platform-configuration to 'optional' or 'ignore' if this is expected.");
         }
     }
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/AdditionalBundleRequirementsInstallableUnitProvider.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/AdditionalBundleRequirementsInstallableUnitProvider.java
@@ -34,8 +34,10 @@ import org.eclipse.equinox.p2.metadata.MetadataFactory;
 import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.tycho.BuildProperties;
 import org.eclipse.tycho.BuildPropertiesParser;
+import org.eclipse.tycho.ClasspathDependenciesAction;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.p2maven.tmp.BundlesAction;
@@ -80,10 +82,18 @@ public class AdditionalBundleRequirementsInstallableUnitProvider implements Inst
             //"classic" pde project with build properties
             ReactorProject reactorProject = DefaultReactorProject.adapt(project);
             BuildProperties buildProperties = buildPropertiesParser.parse(reactorProject);
-            Stream<IRequirement> extraClassPath = buildProperties.getJarsExtraClasspath().stream()
-                    .map(TychoConstants.PLATFORM_URL_PATTERN::matcher).filter(Matcher::matches)
-                    .map(m -> MetadataFactory.createRequirement(BundlesAction.CAPABILITY_NS_OSGI_BUNDLE, m.group(2),
-                            VersionRange.emptyRange, null, true, false));
+            TargetPlatformConfiguration tpConfig = projectManager.getTargetPlatformConfiguration(project);
+            ClasspathDependenciesAction classpathAction = tpConfig.getClasspathDependenciesAction();
+            Stream<IRequirement> extraClassPath;
+            if (classpathAction == ClasspathDependenciesAction.IGNORE) {
+                extraClassPath = Stream.empty();
+            } else {
+                boolean optional = classpathAction == ClasspathDependenciesAction.OPTIONAL;
+                extraClassPath = buildProperties.getJarsExtraClasspath().stream()
+                        .map(TychoConstants.PLATFORM_URL_PATTERN::matcher).filter(Matcher::matches)
+                        .map(m -> MetadataFactory.createRequirement(BundlesAction.CAPABILITY_NS_OSGI_BUNDLE,
+                                m.group(2), VersionRange.emptyRange, null, optional, false));
+            }
             Stream<IRequirement> additionalBundles = buildProperties.getAdditionalBundles().stream()
                     .map(bundleName -> MetadataFactory.createRequirement(BundlesAction.CAPABILITY_NS_OSGI_BUNDLE,
                             bundleName, VersionRange.emptyRange, null, true, false));

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -36,6 +36,7 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.tycho.BuildFailureException;
+import org.eclipse.tycho.ClasspathDependenciesAction;
 import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.TargetEnvironment;
@@ -65,6 +66,7 @@ public class DefaultTargetPlatformConfigurationReader {
     public static final String REFERENCED_REPOSITORY_MODE = "referencedRepositoryMode";
     public static final String DEPENDENCY_RESOLUTION = "dependency-resolution";
     public static final String OPTIONAL_DEPENDENCIES = "optionalDependencies";
+    public static final String CLASSPATH_DEPENDENCIES = "classpathDependencies";
     public static final String LOCAL_ARTIFACTS = "localArtifacts";
     public static final String LOCAL_ARTIFACTS_PROPERTY = "tycho.localArtifacts";
 
@@ -217,6 +219,7 @@ public class DefaultTargetPlatformConfigurationReader {
         }
 
         setOptionalDependencies(result, resolverDom);
+        setClasspathDependencies(result, resolverDom);
         setLocalArtifacts(result, resolverDom, mavenSession);
         readExtraRequirements(result, resolverDom);
         readProfileProperties(result, resolverDom);
@@ -260,6 +263,21 @@ public class DefaultTargetPlatformConfigurationReader {
         } else {
             throw new BuildFailureException(
                     "Illegal value of <optionalDependencies> dependency resolution parameter: " + value);
+        }
+    }
+
+    private void setClasspathDependencies(TargetPlatformConfiguration result, Xpp3Dom resolverDom) {
+        String value = getStringValue(resolverDom.getChild(CLASSPATH_DEPENDENCIES));
+
+        if (value == null) {
+            return;
+        }
+        try {
+            result.setClasspathDependenciesAction(ClasspathDependenciesAction.valueOf(value.toUpperCase()));
+        } catch (IllegalArgumentException e) {
+            throw new BuildFailureException("Illegal value of <" + CLASSPATH_DEPENDENCIES
+                    + "> dependency resolution parameter: " + value + ", allowed values are: "
+                    + Arrays.toString(ClasspathDependenciesAction.values()));
         }
     }
 

--- a/tycho-its/projects/api-tools/embedded-jars/org.eclipse.pde.build/build.properties
+++ b/tycho-its/projects/api-tools/embedded-jars/org.eclipse.pde.build/build.properties
@@ -11,7 +11,6 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-extra.lib/pdebuild-ant.jar = ../org.apache.ant/ant.jar
 bin.includes = plugin.xml,\
                plugin.properties,\
                *.jar,\
@@ -25,5 +24,3 @@ src.includes = about.html,\
                schema/
 source.lib/pdebuild-ant.jar = src_ant/
 output.lib/pdebuild-ant.jar = bin_ant/
-jars.extra.classpath = platform:/plugin/org.apache.ant/lib/ant.jar,\
-                       platform:/plugin/org.eclipse.equinox.p2.repository.tools/lib/repository-tools-ant.jar


### PR DESCRIPTION
   Adds a new `<classpathDependencies>` configuration option under
   `<dependency-resolution>` in target-platform-configuration with values
   `require` (default), `optional`, and `ignore`. This controls how
   `jars.extra.classpath` entries from `build.properties` are handled during
   resolution, fixing issues where platform-specific extra classpath
   entries cause resolution failures (e.g. SWT SVG fragment).

As a continuation of 
- https://github.com/eclipse-tycho/tycho/pull/5883
- https://github.com/eclipse-tycho/tycho/pull/4771