### PR TITLE
Refactor o.e.t.versions.engine.Versions to o.e.t.helper.VersionTool

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/SourcesBundleDependencyMetadataGenerator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/SourcesBundleDependencyMetadataGenerator.java
@@ -31,9 +31,9 @@ import org.eclipse.tycho.BuildPropertiesParser;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.OptionalResolutionAction;
 import org.eclipse.tycho.TargetEnvironment;
-import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.core.publisher.TychoMavenPropertiesAdvice;
 import org.eclipse.tycho.core.shared.MavenContext;
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.p2.metadata.DependencyMetadataGenerator;
 import org.eclipse.tycho.p2.metadata.PublisherOptions;
 import org.eclipse.tycho.p2.publisher.AbstractMetadataGenerator;
@@ -63,7 +63,7 @@ public class SourcesBundleDependencyMetadataGenerator extends AbstractMetadataGe
         ArrayList<IPublisherAction> actions = new ArrayList<>();
 
         String id = artifact.getArtifactId();
-        String version = toCanonicalVersion(artifact.getVersion());
+        String version = VersionTool.toCanonicalVersion(artifact.getVersion());
         try {
             // generated source bundle is not available at this point in filesystem yet, need to create
             // in-memory BundleDescription instead
@@ -103,17 +103,6 @@ public class SourcesBundleDependencyMetadataGenerator extends AbstractMetadataGe
         }
 
         return advice;
-    }
-
-    private static String toCanonicalVersion(String version) {
-        if (version == null) {
-            return null;
-        }
-        if (version.endsWith(TychoConstants.SUFFIX_SNAPSHOT)) {
-            return version.substring(0, version.length() - TychoConstants.SUFFIX_SNAPSHOT.length())
-                    + TychoConstants.SUFFIX_QUALIFIER;
-        }
-        return version;
     }
 
     public long createId(String sourceBundleSymbolicName, String version) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverTest.java
@@ -174,6 +174,40 @@ public class P2ResolverTest extends P2ResolverTestBase {
     }
 
     @Test
+    public void testSourceBundleShortVersion() throws Exception {
+        tpConfig.addP2Repository(resourceFile("repositories/jre").toURI());
+        String featureId = "org.eclipse.tycho.p2.impl.resolver.test.feature01";
+        projectToResolve = createReactorProject(resourceFile("sourcebundles/feature01"), TYPE_ECLIPSE_FEATURE,
+                featureId);
+
+        File bundle = resourceFile("sourcebundles/bundle01");
+        String bundleId = "org.eclipse.tycho.p2.impl.resolver.test.bundle01";
+        String bundleVersion = "1-SNAPSHOT";
+        reactorProjects.add(createReactorProject(bundle, TYPE_ECLIPSE_PLUGIN, bundleId));
+
+        ReactorProjectStub sb = new ReactorProjectStub(bundle, bundleId, bundleId, bundleVersion, TYPE_ECLIPSE_PLUGIN);
+        SourcesBundleDependencyMetadataGenerator metadata = new SourcesBundleDependencyMetadataGenerator();
+        metadata.setMavenContext(new MockMavenContext(null, logVerifier.getLogger()));
+        DependencyMetadata generateMetadata = metadata.generateMetadata(new ArtifactMock(sb, "source"),
+                getEnvironments(), null, new PublisherOptions());
+        sb.setDependencyMetadata(generateMetadata);
+        reactorProjects.add(sb);
+
+        result = singleEnv(impl.resolveTargetDependencies(getTargetPlatform(false), projectToResolve));
+
+        assertEquals(3, result.getArtifacts().size());
+        List<P2ResolutionResult.Entry> entries = new ArrayList<>(result.getArtifacts());
+        Collections.sort(entries, (entry1, entry2) -> entry1.getId().compareTo(entry2.getId()));
+        assertEquals("org.eclipse.tycho.p2.impl.resolver.test.bundle01", entries.get(0).getId());
+        assertEquals("org.eclipse.tycho.p2.impl.resolver.test.bundle01.source", entries.get(1).getId());
+        assertEquals("1.0.0.qualifier", entries.get(1).getVersion());
+        assertEquals("org.eclipse.tycho.p2.impl.resolver.test.feature01", entries.get(2).getId());
+        assertEquals(bundle, entries.get(0).getLocation(true));
+        assertEquals(bundle, entries.get(1).getLocation(true));
+        assertEquals("sources", entries.get(1).getClassifier());
+    }
+
+    @Test
     public void testEclipseRepository() throws Exception {
         tpConfig.addP2Repository(resourceFile("repositories/e342_2").toURI());
         tpConfig.addP2Repository(resourceFile("repositories/launchers").toURI());

--- a/tycho-spi/src/main/java/org/eclipse/tycho/helper/VersionTool.java
+++ b/tycho-spi/src/main/java/org/eclipse/tycho/helper/VersionTool.java
@@ -11,24 +11,27 @@
  *    Sonatype Inc. - initial API and implementation
  *    Marco Lehmann-Mörz - issue #2877 - tycho-versions-plugin:bump-versions does not honor SNAPSHOT suffix
  *******************************************************************************/
-package org.eclipse.tycho.versions.engine;
+package org.eclipse.tycho.helper;
 
 import java.io.File;
 
 import org.eclipse.tycho.TychoConstants;
 import org.osgi.framework.Version;
 
-public class Versions {
+public class VersionTool {
+
     public static String toCanonicalVersion(String version) {
         if (version == null) {
             return null;
         }
-
         if (version.endsWith(TychoConstants.SUFFIX_SNAPSHOT)) {
-            return version.substring(0, version.length() - TychoConstants.SUFFIX_SNAPSHOT.length())
-                    + TychoConstants.SUFFIX_QUALIFIER;
+            String unqualifiedVersion = version.substring(0,
+                    version.length() - TychoConstants.SUFFIX_SNAPSHOT.length());
+            // Ensure that valid Maven versions such as 1-SNAPSHOT, 1.0-SNAPSHOT, and 1.0.0-SNAPSHOT all produce a valid OSGi version
+            // by padding missing minor and micro segments with 0.
+            // For all 3 cases it returns 1.0.0.qualifier.
+            return Version.valueOf(unqualifiedVersion) + TychoConstants.SUFFIX_QUALIFIER;
         }
-
         return version;
     }
 
@@ -87,7 +90,7 @@ public class Versions {
 
     public static String validateOsgiVersion(String version, File location) {
         try {
-            Versions.assertIsOsgiVersion(Versions.toCanonicalVersion(version));
+            assertIsOsgiVersion(toCanonicalVersion(version));
         } catch (RuntimeException e) {
             return String.format("Version %s is not valid for %s", version, location);
         }

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/VersionBumpBuildListener.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/VersionBumpBuildListener.java
@@ -26,8 +26,8 @@ import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.build.BuildListener;
 import org.eclipse.tycho.core.exceptions.VersionBumpRequiredException;
 import org.eclipse.tycho.helper.ProjectHelper;
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.versions.engine.ProjectMetadataReader;
-import org.eclipse.tycho.versions.engine.Versions;
 import org.eclipse.tycho.versions.engine.VersionsEngine;
 import org.eclipse.tycho.versions.pom.PomFile;
 import org.osgi.framework.Version;
@@ -77,7 +77,7 @@ public class VersionBumpBuildListener implements BuildListener {
                             String currentVersion = pomFile.getVersion();
                             Optional<Version> suggestedVersion = vbe.getSuggestedVersion();
                             String newVersion = suggestedVersion.map(String::valueOf)
-                                    .orElseGet(() -> Versions.incrementVersion(currentVersion,
+                                    .orElseGet(() -> VersionTool.incrementVersion(currentVersion,
                                             VersionBumpMojo.getIncrement(session, project, projectHelper)));
                             boolean isSnapshot = currentVersion.endsWith(TychoConstants.SUFFIX_SNAPSHOT);
                             if (isSnapshot && !newVersion.endsWith(TychoConstants.SUFFIX_SNAPSHOT)) {

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/DefaultVersionRangeUpdateStrategy.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/DefaultVersionRangeUpdateStrategy.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.versions.engine;
 
+import org.eclipse.tycho.helper.VersionTool;
 import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
 
@@ -41,7 +42,7 @@ public class DefaultVersionRangeUpdateStrategy implements VersionRangeUpdateStra
     }
 
     private Version parseBaseVersion(String version) {
-        String baseVersion = Versions.toBaseVersion(version);
+        String baseVersion = VersionTool.toBaseVersion(version);
         return Version.valueOf(baseVersion);
     }
 
@@ -172,8 +173,8 @@ public class DefaultVersionRangeUpdateStrategy implements VersionRangeUpdateStra
 
         ImportRefVersionConstraint versionConstraintUsingBaseVersion = toBaseVersionConstraint(
                 originalVersionConstraint);
-        String referencedBaseVersion = Versions.toBaseVersion(originalReferencedVersion);
-        String newReferencedBaseVersion = Versions.toBaseVersion(newReferencedVersion);
+        String referencedBaseVersion = VersionTool.toBaseVersion(originalReferencedVersion);
+        String newReferencedBaseVersion = VersionTool.toBaseVersion(newReferencedVersion);
 
         if ((updateMatchingBounds && versionConstraintUsingBaseVersion.getVersion().equals(referencedBaseVersion))
                 || versionConstraintUsingBaseVersion.matches(referencedBaseVersion)
@@ -186,7 +187,7 @@ public class DefaultVersionRangeUpdateStrategy implements VersionRangeUpdateStra
 
     private ImportRefVersionConstraint toBaseVersionConstraint(ImportRefVersionConstraint originalVersionConstraint) {
         if (originalVersionConstraint.getVersion() != null) {
-            return new ImportRefVersionConstraint(Versions.toBaseVersion(originalVersionConstraint.getVersion()),
+            return new ImportRefVersionConstraint(VersionTool.toBaseVersion(originalVersionConstraint.getVersion()),
                     originalVersionConstraint.getMatch());
         } else {
             return originalVersionConstraint;

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/VersionChange.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/VersionChange.java
@@ -15,14 +15,16 @@ package org.eclipse.tycho.versions.engine;
 
 import java.util.Objects;
 
+import org.eclipse.tycho.helper.VersionTool;
+
 public class VersionChange {
 
     private final String version;
     private final String newVersion;
 
     public VersionChange(String version, String newVersion) {
-        this.version = Versions.toCanonicalVersion(version);
-        this.newVersion = Versions.toCanonicalVersion(newVersion);
+        this.version = VersionTool.toCanonicalVersion(version);
+        this.newVersion = VersionTool.toCanonicalVersion(newVersion);
     }
 
     public String getVersion() {

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/VersionUpdater.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/engine/VersionUpdater.java
@@ -27,6 +27,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.model.IU;
 import org.eclipse.tycho.model.ProductConfiguration;
@@ -108,14 +109,14 @@ public abstract class VersionUpdater {
                 continue;
             }
 
-            String pomVersion = Versions.toCanonicalVersion(pom.getVersion());
+            String pomVersion = VersionTool.toCanonicalVersion(pom.getVersion());
 
             VersionAdaptor adaptor = updaters.get(pom.getPackaging());
 
             if (adaptor != null) {
-                String osgiVersion = Versions.toCanonicalVersion(adaptor.getVersion(project, logger));
+                String osgiVersion = VersionTool.toCanonicalVersion(adaptor.getVersion(project, logger));
 
-                if (osgiVersion != null && !Versions.isVersionEquals(pomVersion, osgiVersion)) {
+                if (osgiVersion != null && !VersionTool.isVersionEquals(pomVersion, osgiVersion)) {
                     addVersionChange(engine, pom, osgiVersion);
                 }
             }

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/BundleManifestManipulator.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/BundleManifestManipulator.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.TychoConstants;
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.model.manifest.MutableBundleManifest;
 import org.eclipse.tycho.versions.bundle.MutableBndFile;
 import org.eclipse.tycho.versions.engine.MetadataManipulator;
@@ -34,7 +35,6 @@ import org.eclipse.tycho.versions.engine.PomVersionChange;
 import org.eclipse.tycho.versions.engine.ProjectMetadata;
 import org.eclipse.tycho.versions.engine.VersionChange;
 import org.eclipse.tycho.versions.engine.VersionChangesDescriptor;
-import org.eclipse.tycho.versions.engine.Versions;
 import org.osgi.framework.Constants;
 
 @Component(role = MetadataManipulator.class, hint = "bundle-manifest")
@@ -54,7 +54,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         if (isBundle(project)) {
             VersionChange versionChangeForProject = findVersionChangeForProject(project, versionChangeContext);
             if (versionChangeForProject != null) {
-                String error = Versions.validateOsgiVersion(versionChangeForProject.getNewVersion(),
+                String error = VersionTool.validateOsgiVersion(versionChangeForProject.getNewVersion(),
                         getManifestFile(project));
                 return error != null ? Collections.singleton(error) : null;
             }
@@ -100,8 +100,8 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         }
         MutableBundleManifest mf = bundleManifest.get();
         // ignore ".qualifier" literals in package versions
-        String versionToReplace = Versions.toBaseVersion(versionChangeForProject.getVersion());
-        String newVersion = Versions.toBaseVersion(versionChangeForProject.getNewVersion());
+        String versionToReplace = VersionTool.toBaseVersion(versionChangeForProject.getVersion());
+        String newVersion = VersionTool.toBaseVersion(versionChangeForProject.getNewVersion());
 
         Set<PackageVersionChange> packageVersionChanges = new HashSet<>();
         for (Entry<String, String> exportedPackageVersion : mf.getExportedPackagesVersion().entrySet()) {
@@ -194,7 +194,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
                 logger.info("  META-INF/MANIFEST.MF//Fragment-Host//" + mf.getFragmentHostSymbolicName()
                         + ";bundle-version: " + newVersionRange + " => " + newVersionRange);
 
-                mf.setFragmentHostVersion(Versions.toBaseVersion(newVersionRange));
+                mf.setFragmentHostVersion(VersionTool.toBaseVersion(newVersionRange));
             }
         }
     }

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/EclipseRepositoryProductFileManipulator.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/EclipseRepositoryProductFileManipulator.java
@@ -23,13 +23,13 @@ import java.util.Map;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.model.ProductConfiguration;
 import org.eclipse.tycho.versions.engine.MetadataManipulator;
 import org.eclipse.tycho.versions.engine.PomVersionChange;
 import org.eclipse.tycho.versions.engine.ProductConfigurations;
 import org.eclipse.tycho.versions.engine.ProjectMetadata;
 import org.eclipse.tycho.versions.engine.VersionChangesDescriptor;
-import org.eclipse.tycho.versions.engine.Versions;
 import org.eclipse.tycho.versions.pom.PomFile;
 import org.eclipse.tycho.versions.utils.ProductFileFilter;
 
@@ -56,7 +56,7 @@ public class EclipseRepositoryProductFileManipulator extends ProductFileManipula
                 for (Map.Entry<File, ProductConfiguration> entry : getProductConfigurations(project).entrySet()) {
                     if (isSameProject(project, change.getProject())
                             && change.getVersion().equals(entry.getValue().getVersion())) {
-                        String error = Versions.validateOsgiVersion(change.getNewVersion(), entry.getKey());
+                        String error = VersionTool.validateOsgiVersion(change.getNewVersion(), entry.getKey());
                         if (error != null) {
                             errors.add(error);
                         }

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/EclipseTargetFileManipulator.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/EclipseTargetFileManipulator.java
@@ -24,13 +24,13 @@ import java.util.stream.Stream.Builder;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
 import org.eclipse.tycho.versions.engine.MetadataManipulator;
 import org.eclipse.tycho.versions.engine.PomVersionChange;
 import org.eclipse.tycho.versions.engine.ProjectMetadata;
 import org.eclipse.tycho.versions.engine.TargetFiles;
 import org.eclipse.tycho.versions.engine.VersionChangesDescriptor;
-import org.eclipse.tycho.versions.engine.Versions;
 import org.eclipse.tycho.versions.pom.PomFile;
 
 import de.pdark.decentxml.Document;
@@ -76,12 +76,12 @@ public class EclipseTargetFileManipulator extends AbstractMetadataManipulator {
                         String artifactId = coordinates[1];
                         String version = coordinates[2];
                         if (groupId.equals(change.getGroupId()) && artifactId.equals(change.getArtifactId())
-                                && Versions.isVersionEquals(version, change.getVersion())) {
+                                && VersionTool.isVersionEquals(version, change.getVersion())) {
                             Builder<String> builder = Stream.builder();
                             builder.add(MVN_URL);
                             builder.add(groupId);
                             builder.add(artifactId);
-                            builder.add(Versions.toMavenVersion(change.getNewVersion()));
+                            builder.add(VersionTool.toMavenVersion(change.getNewVersion()));
                             for (int i = 3; i < coordinates.length; i++) {
                                 builder.add(coordinates[i]);
                             }

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/FeatureXmlManipulator.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/FeatureXmlManipulator.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.model.Feature.ImportRef;
 import org.eclipse.tycho.model.Feature.RequiresRef;
@@ -30,7 +31,6 @@ import org.eclipse.tycho.versions.engine.PomVersionChange;
 import org.eclipse.tycho.versions.engine.ProjectMetadata;
 import org.eclipse.tycho.versions.engine.VersionChangesDescriptor;
 import org.eclipse.tycho.versions.engine.VersionRangeUpdateStrategy;
-import org.eclipse.tycho.versions.engine.Versions;
 
 @Component(role = MetadataManipulator.class, hint = "eclipse-feature")
 public class FeatureXmlManipulator extends AbstractMetadataManipulator {
@@ -66,7 +66,7 @@ public class FeatureXmlManipulator extends AbstractMetadataManipulator {
             for (PomVersionChange change : versionChangeContext.getVersionChanges()) {
                 if (change.getArtifactId().equals(feature.getId())
                         && change.getVersion().equals(feature.getVersion())) {
-                    String error = Versions.validateOsgiVersion(change.getNewVersion(), getFeatureFile(project));
+                    String error = VersionTool.validateOsgiVersion(change.getNewVersion(), getFeatureFile(project));
                     return error != null ? Collections.singleton(error) : null;
                 }
             }

--- a/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/PomManipulator.java
+++ b/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/PomManipulator.java
@@ -16,8 +16,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.versions.manipulation;
 
-import static org.eclipse.tycho.versions.engine.Versions.eq;
-import static org.eclipse.tycho.versions.engine.Versions.isVersionEquals;
+import static org.eclipse.tycho.helper.VersionTool.eq;
+import static org.eclipse.tycho.helper.VersionTool.isVersionEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,11 +27,11 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.versions.engine.MetadataManipulator;
 import org.eclipse.tycho.versions.engine.PomVersionChange;
 import org.eclipse.tycho.versions.engine.ProjectMetadata;
 import org.eclipse.tycho.versions.engine.VersionChangesDescriptor;
-import org.eclipse.tycho.versions.engine.Versions;
 import org.eclipse.tycho.versions.pom.Build;
 import org.eclipse.tycho.versions.pom.DependencyManagement;
 import org.eclipse.tycho.versions.pom.GAV;
@@ -82,8 +82,7 @@ public class PomManipulator extends AbstractMetadataManipulator {
                     versionChangeContext.findMetadataByBasedir(new File(project.getBasedir(), module))
                             .ifPresent(moduleMeta -> {
                                 PomFile modulePom = moduleMeta.getMetadata(PomFile.class);
-                                if (modulePom != null && modulePom.isMutable()
-                                        && POM.equals(modulePom.getPackaging())
+                                if (modulePom != null && modulePom.isMutable() && POM.equals(modulePom.getPackaging())
                                         && isVersionEquals(modulePom.getVersion(), change.getVersion())) {
                                     if (versionChangeContext.addVersionChange(
                                             new PomVersionChange(modulePom, change.getNewVersion()))) {
@@ -110,8 +109,8 @@ public class PomManipulator extends AbstractMetadataManipulator {
         // TODO visitor pattern is a better way to implement this
 
         for (PomVersionChange change : versionChangeContext.getVersionChanges()) {
-            String version = Versions.toMavenVersion(change.getVersion());
-            String newVersion = Versions.toMavenVersion(change.getNewVersion());
+            String version = VersionTool.toMavenVersion(change.getVersion());
+            String newVersion = VersionTool.toMavenVersion(change.getNewVersion());
             if (isGavEquals(pom, change)) {
                 List<String> ciFriendlyProperties = PomUtil.getContainedPropertyNames(pom.getRawVersion());
                 if (!ciFriendlyProperties.isEmpty()) {
@@ -139,8 +138,7 @@ public class PomManipulator extends AbstractMetadataManipulator {
                 }
             } else {
                 GAV parent = pom.getParent();
-                if (parent != null && isGavEquals(parent, change)
-                        && !PomUtil.containsProperties(parent.getVersion())) {
+                if (parent != null && isGavEquals(parent, change) && !PomUtil.containsProperties(parent.getVersion())) {
                     logger.info("  %s//project/parent/version: %s => %s".formatted(pomName, version, newVersion));
                     parent.setVersion(newVersion);
                 }

--- a/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/VersionsEngineTest.java
+++ b/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/engine/tests/VersionsEngineTest.java
@@ -17,10 +17,10 @@ import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 
+import org.eclipse.tycho.helper.VersionTool;
 import org.eclipse.tycho.testing.TestUtil;
 import org.eclipse.tycho.versions.engine.IllegalVersionChangeException;
 import org.eclipse.tycho.versions.engine.ProjectMetadataReader;
-import org.eclipse.tycho.versions.engine.Versions;
 import org.eclipse.tycho.versions.engine.VersionsEngine;
 
 public class VersionsEngineTest extends AbstractVersionChangeTest {
@@ -280,7 +280,7 @@ public class VersionsEngineTest extends AbstractVersionChangeTest {
 
     public void testWrongSnapshotVersion() throws Exception {
         try {
-            Versions.assertIsOsgiVersion("1.2.3_SNAPSHOT");
+            VersionTool.assertIsOsgiVersion("1.2.3_SNAPSHOT");
             fail("invalid version accepted");
         } catch (NumberFormatException e) {
             // thrown by equinox <3.8M5
@@ -290,7 +290,7 @@ public class VersionsEngineTest extends AbstractVersionChangeTest {
     }
 
     public void testAssertOsgiVersion() {
-        Versions.assertIsOsgiVersion("1.2.3.qualifier");
+        VersionTool.assertIsOsgiVersion("1.2.3.qualifier");
     }
 
     public void testBuildPluginManagement() throws Exception {


### PR DESCRIPTION
- Replace SourcesBundleDependencyMetadataGenerator.toCanonicalVersion with VersionTool.toCanonicalVersion and fix it to ensure that valid Maven versions such as 1-SNAPSHOT and 1.0-SNAPSHOT are handled just like 1.0.0-SNAPSHOT to produce 1.0.0.qualifier, i.e., ensure that it returns a valid OSGi version.