### PR TITLE
Fix ClassNotFoundException in osgibooter

### DIFF
--- a/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: com.example.test
+Bundle-Version: 1.0.0.qualifier
+Require-Bundle: org.junit
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/build.properties
+++ b/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/pom.xml
+++ b/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>com.example.test</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-test-plugin</packaging>
+
+  <properties>
+    <tycho-version>6.0.0-SNAPSHOT</tycho-version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <tycho.showEclipseLog>true</tycho.showEclipseLog>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>osgi_without_bundle_to_file_adapter_do_not_update_me</id>
+      <layout>p2</layout>
+      <!-- The OsgiSurefireBooter classpath bug is only reproducible on 2021-12 or older before Bundle.adapt(File.class) was implemented.
+           Do not update the URL here to avoid false negatives.
+           See:
+           - https://github.com/eclipse-tycho/tycho/pull/5995
+           - https://github.com/eclipse-equinox/equinox/commit/3889f7ce2d2906ca7d46f341de95ebe865212808
+      -->
+      
+      <url>https://download.eclipse.org/releases/2021-12</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+        <id>dynamic-repo</id>
+        <url>${my.custom.plugin.repo}</url>
+        <snapshots><enabled>true</enabled></snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/src/com/example/test/SimpleTest.java
+++ b/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/src/com/example/test/SimpleTest.java
@@ -1,0 +1,9 @@
+package com.example.test;
+
+import org.junit.Test;
+
+public class SimpleTest {
+	@Test
+	public void testTrivial() {
+	}
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit4Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit4Test.java
@@ -16,6 +16,7 @@ import static org.eclipse.tycho.test.util.SurefireUtil.testResultFile;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
@@ -36,6 +37,56 @@ public class JUnit4Test extends AbstractTychoIntegrationTest {
 
 		// ensure that JUnit 3 style tests also work -> related to bug 388909
 		assertTrue(testResultFile(verifier.getBasedir(), "bundle.test", "JUnit3Test").exists());
+
+	}
+
+	/**
+	 * On old Equinox, bundles paths are not easily available, requiring heavy
+	 * classpath computation logic in
+	 * org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.
+	 * 
+	 */
+	@Test
+	public void osgibooter_on_old_equinox() throws Exception {
+		Verifier verifier = getVerifier("tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro");
+		File global_repo = new File(verifier.getLocalRepository());
+		// Depending on locations of:
+		// - local repository
+		// - surefire installation
+		// buggy Tycho surefire may produce accidentally valid result, resulting in
+		// false negative for this test.
+		// For example, if
+		// - this test project is in /Users/user/git/tycho/tycho-its
+		// - local repository is in `/tmp/fresh_dir`
+		// The test will pass, as
+		// `/Users/user/git/tycho/tycho-its/target/projects/JUnit4Test/osgibooter_on_old_equinox/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/target/work/configuration/config.ini`
+		// would have install area
+		// `/Users/user/git/tycho/tycho-its/target/projects/JUnit4Test/osgibooter_on_old_equinox/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/target/work`
+		// and refer to
+		// `/tmp/fresh_dir/org/eclipse/tycho/org.eclipse.tycho.surefire.osgibooter/6.0.0-SNAPSHOT/org.eclipse.tycho.surefire.osgibooter-6.0.0-SNAPSHOT.jar`
+		// relative path to osbibooter from install area:
+		// ../../../../../../../../../../../../../../tmp/fresh_dir/org/eclipse/tycho/org.eclipse.tycho.surefire.osgibooter/6.0.0-SNAPSHOT/org.eclipse.tycho.surefire.osgibooter-6.0.0-SNAPSHOT.jar
+		// if resolved against surefire project location
+		// /Users/user/git/tycho/tycho-its/target/projects/JUnit4Test/osgibooter_on_old_equinox/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro
+		// rejecting extra "../" becomes
+		// /tmp/fresh_dir/org/eclipse/tycho/org.eclipse.tycho.surefire.osgibooter/6.0.0-SNAPSHOT/org.eclipse.tycho.surefire.osgibooter-6.0.0-SNAPSHOT.jar
+		// matching the correct location by accident.
+		// Such accidental match would result in a false-negative of this test.
+		// The probability of false negative grows as local repository path length
+		// shrinks.
+		// To reduce the probability and force the test to fail, we use longer
+		// repository path here.
+
+		// Disturb location of repository in relation to Surefire installation location
+		// to avoid accidental incorrect relative path matching in OsgiSurefireBooter.
+		File fresh_repo = new File(verifier.getBasedir(), "fresh_local_repo");
+		fresh_repo = new File("/tmp/fresh_dir");
+		verifier.setLocalRepo(fresh_repo.toString());
+		verifier.setCliOptions(
+				List.of("-Dmy.custom.plugin.repo=" + global_repo.toURI().toString(), "--no-transfer-progress"));
+
+		verifier.executeGoal("integration-test");
+		verifier.verifyErrorFreeLog();
 	}
 
 	@Test

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -69,7 +70,9 @@ import org.apache.maven.surefire.booter.ProviderFactory;
 import org.apache.maven.surefire.booter.StartupConfiguration;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.service.resolver.ResolverError;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
@@ -121,10 +124,15 @@ public class OsgiSurefireBooter {
         File adapt = bundle.adapt(File.class);
         if (adapt == null) {
             String location = bundle.getLocation();
+            // Example: initial@reference:file:../../fresh_local_repo/org/eclipse/tycho/org.eclipse.tycho.surefire.osgibooter/6.0.0-SNAPSHOT/org.eclipse.tycho.surefire.osgibooter-6.0.0-SNAPSHOT.jar
             String prefix = "initial@reference:file:";
             if (location.startsWith(prefix)) {
                 File file = new File(location.substring(prefix.length()));
                 try {
+                    if (!file.isAbsolute()) {
+                        // Relative paths in Equinox bundle locations are relative to the install area
+                        file = new File(getInstallLocation(), file.getPath());
+                    }
                     URL url = file.getCanonicalFile().toURI().toURL();
                     return url;
                 } catch (IOException e) {
@@ -134,6 +142,27 @@ public class OsgiSurefireBooter {
             throw new IllegalStateException("Can't adapt bundle to file: " + bundle);
         }
         return adapt.toURI().toURL();
+    }
+
+    private static File getInstallLocation() {
+        Location installLocation = Platform.getInstallLocation();
+        if (installLocation == null) {
+            throw new IllegalStateException("Cannot resolve relative bundle path: install location is not set");
+        }
+        URL installUrl = installLocation.getURL();
+        if (installUrl == null) {
+            throw new IllegalStateException(
+                    "Cannot resolve relative bundle path: install location URL is not available");
+        }
+        try {
+            File installDir = new File(installUrl.toURI());
+            if (!installDir.isDirectory()) {
+                throw new IllegalStateException("Configuration area does not exist: " + installUrl);
+            }
+            return installDir;
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Configuration area is malformed: " + installUrl);
+        }
     }
 
     public static int invokeSureFire(String[] args, Properties testProps) throws Exception {


### PR DESCRIPTION
JUnit4 test worked fine in Tycho 4.0.13 and can't start since Tycho 5.0.0.

The bug reveals itself for a combination of a fresh local repository, old target platform, and "normal" filesystem.

For example:
- on MacOS, if local repository is stored in `/tmp`, the bug is not reproduced, but if local repository is stored in home directory, the bug is reproducible.
- on Linux, the bug stops being reproducible if local repository is prepopulated

Causes https://github.com/eclipse-rcptt/org.eclipse.rcptt/issues/321
[AI fix](https://github.com/basilevs/tycho/pull/1#event-25406166800)

```
[INFO] --- tycho-surefire:6.0.0-SNAPSHOT:test (default-test) @ com.example.test ---
[INFO] Selected test framework junit (4.0.0) with provider junit4 [4.0.0,5.0.0)
[INFO] Executing test runtime with timeout (seconds): 0, logs, if any, will be placed at: /Users/vasiligulevich/git/tycho-osgibooter-cnfe-repro/target/work/data/.metadata/.log
[INFO] Command line: /Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java -Dosgi.noShutdown=false -Dosgi.os=macosx -Dosgi.ws=cocoa -Dosgi.arch=aarch64 -Dosgi.clean=true -jar /Users/vasiligulevich/m2tmp/p2/osgi/bundle/org.eclipse.equinox.launcher/1.6.400.v20210924-0641/org.eclipse.equinox.launcher-1.6.400.v20210924-0641.jar -consolelog -data /Users/vasiligulevich/git/tycho-osgibooter-cnfe-repro/target/work/data -install /Users/vasiligulevich/git/tycho-osgibooter-cnfe-repro/target/work -configuration /Users/vasiligulevich/git/tycho-osgibooter-cnfe-repro/target/work/configuration -application org.eclipse.tycho.surefire.osgibooter.headlesstest -testproperties /Users/vasiligulevich/git/tycho-osgibooter-cnfe-repro/target/surefire.properties
!SESSION 2026-05-11 22:32:48.088 -----------------------------------------------
eclipse.buildId=unknown
java.version=21.0.10
java.vendor=Eclipse Adoptium
BootLoader constants: OS=macosx, ARCH=aarch64, WS=cocoa, NL=en_GE
Framework arguments:  -application org.eclipse.tycho.surefire.osgibooter.headlesstest -testproperties /Users/vasiligulevich/git/tycho-osgibooter-cnfe-repro/target/surefire.properties
Command-line arguments:  -consolelog -data /Users/vasiligulevich/git/tycho-osgibooter-cnfe-repro/target/work/data -application org.eclipse.tycho.surefire.osgibooter.headlesstest -testproperties /Users/vasiligulevich/git/tycho-osgibooter-cnfe-repro/target/surefire.properties

!ENTRY org.eclipse.osgi 4 0 2026-05-11 22:32:48.444
!MESSAGE Application error
!STACK 1
java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:116)
	at org.eclipse.tycho.surefire.osgibooter.HeadlessTestApplication.start(HeadlessTestApplication.java:29)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1440)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.maven.surefire.api.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:137)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:148)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:88)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.invokeSureFire(OsgiSurefireBooter.java:195)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	... 14 more
Caused by: java.lang.RuntimeException: Unable to create test class 'com.example.test.SimpleTest'
	at org.apache.maven.surefire.api.util.DefaultScanResult.loadClass(DefaultScanResult.java:117)
	at org.apache.maven.surefire.api.util.DefaultScanResult.applyFilter(DefaultScanResult.java:85)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.scanClassPath(JUnitCoreProvider.java:254)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.setTestsToRun(JUnitCoreProvider.java:180)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:124)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	... 20 more
Caused by: java.lang.ClassNotFoundException: com.example.test.SimpleTest cannot be found by org.eclipse.tycho.surefire.osgibooter_6.0.0
	at org.eclipse.osgi.internal.loader.BundleLoader.generateException(BundleLoader.java:516)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass0(BundleLoader.java:511)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:403)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:168)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at org.apache.maven.surefire.api.util.DefaultScanResult.loadClass(DefaultScanResult.java:115)
	... 25 more
Root exception:
java.lang.RuntimeException: Unable to create test class 'com.example.test.SimpleTest'
	at org.apache.maven.surefire.api.util.DefaultScanResult.loadClass(DefaultScanResult.java:117)
	at org.apache.maven.surefire.api.util.DefaultScanResult.applyFilter(DefaultScanResult.java:85)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.scanClassPath(JUnitCoreProvider.java:254)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.setTestsToRun(JUnitCoreProvider.java:180)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:124)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.maven.surefire.api.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:137)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:148)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:88)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.invokeSureFire(OsgiSurefireBooter.java:195)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:116)
	at org.eclipse.tycho.surefire.osgibooter.HeadlessTestApplication.start(HeadlessTestApplication.java:29)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1440)
Caused by: java.lang.ClassNotFoundException: com.example.test.SimpleTest cannot be found by org.eclipse.tycho.surefire.osgibooter_6.0.0
	at org.eclipse.osgi.internal.loader.BundleLoader.generateException(BundleLoader.java:516)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass0(BundleLoader.java:511)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:403)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:168)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at org.apache.maven.surefire.api.util.DefaultScanResult.loadClass(DefaultScanResult.java:115)
```

On old Eclipse Platforms (2021-12 and older), `Bundle.adapt(File.class)` [returns `null`](https://github.com/eclipse-equinox/equinox/commit/3889f7ce2d2906ca7d46f341de95ebe865212808) and `OsgiSurefireBooter.getURL()` falls back to parsing the bundle location string. Equinox stores these as relative paths (e.g. `initial@reference:file:../../repo/bundle.jar`) to be resolved against `osgi.install.area`, but the old code resolved against CWD instead, resulting in non-existent URLs and effectively empty class path.

# Changes
- Resolve relative bundle paths against the install area using `Platform.getInstallLocation()`. Null install location is treated as a fatal error (IllegalStateException) since fallback to working directory resolution would be silently incorrect.
- Enhance `ClassNotFoundException` message with the full classpath for easier debugging
- Add integration test (JUnit4Test#osgibooter) that reproduces the issue using a fresh local Maven repository, forcing Equinox to use relative bundle paths

The (intended) commit message:

> Fix ClassNotFoundException in osgibooter when bundle locations use
> relative paths
> 
> On old Eclipse Platforms (2021-12 and older), Bundle.adapt(File.class)
> returns null and OsgiSurefireBooter.getURL() falls back to parsing the
> bundle location string. Equinox stores these as relative paths (e.g.
> initial@reference:file:../../repo/bundle.jar) to be resolved against
> osgi.install.area, but the old code resolved against CWD instead,
> resulting in non-existent URLs and effectively empty class path.
> Changes:
> - Resolve relative bundle paths against the install area using
> Platform.getInstallLocation(). Null install location is treated as a
> fatal error (IllegalStateException) since fallback to working directory
> resolution would be silently incorrect.
> - Enhance ClassNotFoundException message with the full classpath for
> easier debugging
> - Add integration test (JUnit4Test#osgibooter) that reproduces the issue
> using an alternative Maven repository to prevent accidental resolution
> of erroneous relative paths to correct paths
> 
