### PR TITLE
Retry HTTP 502/503/504 errors in Java11HttpTransportFactory

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/HttpTransportFactory.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/HttpTransportFactory.java
@@ -18,6 +18,21 @@ public interface HttpTransportFactory {
 
 	static final long TIMEOUT_SECONDS = Long.getLong("tycho.http.transport.timeout", 30);
 
+	/**
+	 * Maximum number of retries for transient HTTP errors (502/503/504) before
+	 * failing. Configurable via system property {@code tycho.http.transport.retry.count}.
+	 */
+	static final int HTTP_RETRY_COUNT = Math.max(0,
+			Integer.getInteger("tycho.http.transport.retry.count", 3));
+
+	/**
+	 * Initial delay in seconds before the first retry on a transient HTTP error.
+	 * Subsequent retries multiply this by the attempt number (linear back-off).
+	 * Configurable via system property {@code tycho.http.transport.retry.initial-delay}.
+	 */
+	static final long HTTP_RETRY_INITIAL_DELAY_SECONDS = Math.max(0L,
+			Long.getLong("tycho.http.transport.retry.initial-delay", 5));
+
 	HttpTransport createTransport(URI uri);
 
 }

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/Java11HttpTransportFactory.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/Java11HttpTransportFactory.java
@@ -109,19 +109,41 @@ public class Java11HttpTransportFactory implements HttpTransportFactory, Initial
 		@Override
 		public <T> T get(ResponseConsumer<T> consumer) throws IOException {
 			try {
-				try {
-					return performGet(consumer, client);
-				} catch (IOException e) {
-					if (isGoaway(e)) {
-						logger.info("Received GOAWAY from server " + uri.getHost() + " will retry download of " + uri
-								+ " with Http/1...");
-						TimeUnit.SECONDS.sleep(1);
-						return performGet(consumer, clientHttp1);
+				IOException lastTransient = null;
+				for (int attempt = 0; attempt <= HTTP_RETRY_COUNT; attempt++) {
+					if (attempt > 0) {
+						long delay = HTTP_RETRY_INITIAL_DELAY_SECONDS * attempt;
+						logger.warn("Received transient HTTP error for " + uri + ", retrying (attempt " + attempt + "/"
+								+ HTTP_RETRY_COUNT + ") in " + delay + " seconds...");
+						TimeUnit.SECONDS.sleep(delay);
 					}
-					throw e;
+					try {
+						return performGetHandlingGoaway(consumer);
+					} catch (TransientHttpException e) {
+						if (attempt < HTTP_RETRY_COUNT) {
+							lastTransient = e;
+						} else {
+							throw e;
+						}
+					}
 				}
+				throw lastTransient;
 			} catch (InterruptedException e) {
 				throw new InterruptedIOException();
+			}
+		}
+
+		private <T> T performGetHandlingGoaway(ResponseConsumer<T> consumer) throws IOException, InterruptedException {
+			try {
+				return performGet(consumer, client);
+			} catch (IOException e) {
+				if (isGoaway(e)) {
+					logger.info("Received GOAWAY from server " + uri.getHost() + " will retry download of " + uri
+							+ " with Http/1...");
+					TimeUnit.SECONDS.sleep(1);
+					return performGet(consumer, clientHttp1);
+				}
+				throw e;
 			}
 		}
 
@@ -129,6 +151,15 @@ public class Java11HttpTransportFactory implements HttpTransportFactory, Initial
 				throws IOException, InterruptedException {
 			HttpRequest request = builder.GET().timeout(Duration.ofSeconds(TIMEOUT_SECONDS)).build();
 			HttpResponse<InputStream> response = httpClient.send(request, BodyHandlers.ofInputStream());
+			if (isRetryableStatus(response.statusCode())) {
+				// Drain and discard the error body before retrying, to avoid consumer
+				// side-effects (e.g. cache corruption) caused by processing the error response.
+				try (InputStream body = response.body()) {
+					body.transferTo(OutputStream.nullOutputStream());
+				} catch (IOException ignored) {
+				}
+				throw new TransientHttpException(response.statusCode(), response.uri());
+			}
 			try (ResponseImplementation<InputStream> implementation = new ResponseImplementation<>(response) {
 
 				@Override
@@ -170,19 +201,33 @@ public class Java11HttpTransportFactory implements HttpTransportFactory, Initial
 		@Override
 		public Response head() throws IOException {
 			try {
-				try {
-					return doHead(client);
-				} catch (IOException e) {
-					if (isGoaway(e)) {
-						logger.debug("Received GOAWAY from server " + uri.getHost()
-								+ " will retry with Http/1...");
-						TimeUnit.SECONDS.sleep(1);
-						return doHead(clientHttp1);
-					}
-					throw e;
+				Response response = doHeadHandlingGoaway();
+				for (int attempt = 1; attempt <= HTTP_RETRY_COUNT
+						&& isRetryableStatus(response.statusCode()); attempt++) {
+					response.close();
+					long delay = HTTP_RETRY_INITIAL_DELAY_SECONDS * attempt;
+					logger.warn("Received transient HTTP error for " + uri + ", retrying HEAD (attempt " + attempt + "/"
+							+ HTTP_RETRY_COUNT + ") in " + delay + " seconds...");
+					TimeUnit.SECONDS.sleep(delay);
+					response = doHeadHandlingGoaway();
 				}
+				return response;
 			} catch (InterruptedException e) {
 				throw new InterruptedIOException();
+			}
+		}
+
+		private Response doHeadHandlingGoaway() throws IOException, InterruptedException {
+			try {
+				return doHead(client);
+			} catch (IOException e) {
+				if (isGoaway(e)) {
+					logger.debug("Received GOAWAY from server " + uri.getHost()
+							+ " will retry with Http/1...");
+					TimeUnit.SECONDS.sleep(1);
+					return doHead(clientHttp1);
+				}
+				throw e;
 			}
 		}
 
@@ -281,6 +326,10 @@ public class Java11HttpTransportFactory implements HttpTransportFactory, Initial
 				.cookieHandler(cookieManager)
 				.proxy(proxySelector).build();
 
+	}
+
+	private static boolean isRetryableStatus(int statusCode) {
+		return statusCode == 502 || statusCode == 503 || statusCode == 504;
 	}
 
 	private static boolean isGoaway(Throwable e) {

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TransientHttpException.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/transport/TransientHttpException.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.transport;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Thrown when an HTTP request receives a transient server-side error response
+ * (e.g. 502, 503, 504) that may succeed on retry.
+ */
+class TransientHttpException extends IOException {
+
+    private final int statusCode;
+
+    TransientHttpException(int statusCode, URI uri) {
+        super("Server returned HTTP code: " + statusCode + " for URL " + uri);
+        this.statusCode = statusCode;
+    }
+
+    int getStatusCode() {
+        return statusCode;
+    }
+
+}

--- a/src/site/markdown/SystemProperties.md
+++ b/src/site/markdown/SystemProperties.md
@@ -70,3 +70,5 @@ tycho.p2.transport.bundlepools.shared | true/false | true | query shared bundle 
 tycho.p2.transport.bundlepools.workspace | true/false | true | query Workspace bundle pools for artifacts before downloading them from remote servers
 tycho.p2.transport.mavenmirror.enabled | true/false | true | if enough metadata is supplied in the P2 data, use global configured maven repositories as a possible mirror for P2 artifacts
 tycho.p2.transport.mavenmirror.priority | number | 500 | priority used for maven as a P2 mirror
+tycho.http.transport.retry.count | number | 3 | Maximum number of retries when a transient HTTP server error (502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout) is received; set to 0 to disable retries
+tycho.http.transport.retry.initial-delay | number | 5 | Initial delay in seconds before the first retry on a transient HTTP error; each subsequent retry multiplies this value by the attempt number (linear back-off)


### PR DESCRIPTION
 Transient gateway errors (502 Bad Gateway, 503 Service Unavailable,
 504 Gateway Timeout) can temporarily interrupt artifact downloads and
 fail the entire build. This change adds automatic retries with linear
 back-off (default: 3 retries, 5 s initial delay).

 The retry is detected before the consumer is invoked in performGet()
 to prevent SharedHttpCacheStorage side-effects (header caching, cached
 file deletion) from corrupting state on a failed attempt.

 Both GET and HEAD paths are covered. Retry counts and initial delay
 are configurable via system properties:
```
   -Dtycho.http.transport.retry.count=<n>
   -Dtycho.http.transport.retry.initial-delay=<seconds>
```