### PR TITLE
materialize-products: deleteP2Cache on macOS Foo.app/Contents/Eclipse

### DIFF
--- a/tycho-its/projects/product.deleteP2Cache/pom.xml
+++ b/tycho-its/projects/product.deleteP2Cache/pom.xml
@@ -39,6 +39,11 @@
 							<ws>gtk</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>x86_64</arch>
+						</environment>
 					</environments>
 				</configuration>
 			</plugin>

--- a/tycho-its/projects/product.keepP2Cache/pom.xml
+++ b/tycho-its/projects/product.keepP2Cache/pom.xml
@@ -39,6 +39,11 @@
 							<ws>gtk</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>x86_64</arch>
+						</environment>
 					</environments>
 				</configuration>
 			</plugin>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/P2DirectorPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/P2DirectorPluginTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
@@ -104,19 +105,22 @@ public class P2DirectorPluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 
 		File basedir = new File(verifier.getBasedir());
-		Path productDir = basedir.toPath().resolve("target/products/test.product/linux/gtk/x86_64");
+		for (String productDirRelative : List.of("target/products/test.product/linux/gtk/x86_64",
+				"target/products/test.product/macosx/cocoa/x86_64/Eclipse.app/Contents/Eclipse")) {
+			Path productDir = basedir.toPath().resolve(productDirRelative);
 
-		// Verify product was created
-		assertTrue("Product directory should exist", Files.exists(productDir));
+			// Verify product was created
+			assertTrue("Product directory should exist: " + productDir, Files.exists(productDir));
 
-		// Verify p2 cache directory was deleted
-		Path cacheDir = productDir.resolve("p2/org.eclipse.equinox.p2.core/cache");
-		assertFalse("P2 cache directory should not exist when deleteP2Cache=true", Files.exists(cacheDir));
+			// Verify p2 cache directory was deleted
+			Path cacheDir = productDir.resolve("p2/org.eclipse.equinox.p2.core/cache");
+			assertFalse("P2 cache directory should not exist when deleteP2Cache=true", Files.exists(cacheDir));
 
-		// Verify that p2 directory itself still exists (just not the cache
-		// subdirectory)
-		Path p2Dir = productDir.resolve("p2");
-		assertTrue("P2 directory should still exist", Files.exists(p2Dir));
+			// Verify that p2 directory itself still exists (just not the cache
+			// subdirectory)
+			Path p2Dir = productDir.resolve("p2");
+			assertTrue("P2 directory should still exist: " + p2Dir, Files.exists(p2Dir));
+		}
 	}
 
 	@Test
@@ -126,14 +130,18 @@ public class P2DirectorPluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 
 		File basedir = new File(verifier.getBasedir());
-		Path productDir = basedir.toPath().resolve("target/products/test.product/linux/gtk/x86_64");
+		for (String productDirRelative : List.of("target/products/test.product/linux/gtk/x86_64",
+				"target/products/test.product/macosx/cocoa/x86_64/Eclipse.app/Contents/Eclipse")) {
+			Path productDir = basedir.toPath().resolve(productDirRelative);
 
-		// Verify product was created
-		assertTrue("Product directory should exist", Files.exists(productDir));
+			// Verify product was created
+			assertTrue("Product directory should exist: " + productDir, Files.exists(productDir));
 
-		// Verify p2 cache directory exists (default behavior - cache should be kept)
-		Path cacheDir = productDir.resolve("p2/org.eclipse.equinox.p2.core/cache");
-		assertTrue("P2 cache directory should exist by default (deleteP2Cache not set)", Files.exists(cacheDir));
+			// Verify p2 cache directory exists (default behavior - cache should be kept)
+			Path cacheDir = productDir.resolve("p2/org.eclipse.equinox.p2.core/cache");
+			assertTrue("P2 cache directory should exist by default (deleteP2Cache not set): " + cacheDir,
+					Files.exists(cacheDir));
+		}
 	}
 
 }

--- a/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/MaterializeProductsMojo.java
+++ b/tycho-p2-director-plugin/src/main/java/org/eclipse/tycho/plugins/p2/director/MaterializeProductsMojo.java
@@ -326,7 +326,7 @@ public final class MaterializeProductsMojo extends AbstractProductMojo {
         try {
             command.execute();
             if (deleteP2Cache) {
-                deleteP2CacheDirectory(destination);
+                deleteP2CacheDirectory(DirectorRuntime.getDestination(destination, env));
             }
         } catch (DirectorCommandException e) {
             IStatus status = StatusTool.findStatus(e);


### PR DESCRIPTION
`deleteP2Cache` was not considering the macOS-specific substructure `<productRoot>/Foo.app/Contents/Eclipse`.