### PR TITLE
Restore default Maven arguments

### DIFF
--- a/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/pom.xml
+++ b/tycho-its/projects/tycho-surefire-plugin/junit4/tycho-osgibooter-cnfe-repro/pom.xml
@@ -7,7 +7,6 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>
-    <tycho-version>6.0.0-SNAPSHOT</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tycho.showEclipseLog>true</tycho.showEclipseLog>
   </properties>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit4Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit4Test.java
@@ -16,7 +16,6 @@ import static org.eclipse.tycho.test.util.SurefireUtil.testResultFile;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
@@ -82,8 +81,8 @@ public class JUnit4Test extends AbstractTychoIntegrationTest {
 		File fresh_repo = new File(verifier.getBasedir(), "fresh_local_repo");
 		fresh_repo = new File("/tmp/fresh_dir");
 		verifier.setLocalRepo(fresh_repo.toString());
-		verifier.setCliOptions(
-				List.of("-Dmy.custom.plugin.repo=" + global_repo.toURI().toString(), "--no-transfer-progress"));
+		verifier.addCliOption("-Dmy.custom.plugin.repo=" + global_repo.toURI().toString());
+		verifier.addCliOption("--no-transfer-progress");
 
 		verifier.executeGoal("integration-test");
 		verifier.verifyErrorFreeLog();


### PR DESCRIPTION
Default arguments were overridden with `Verifier.setCliOptions()`. Use `addCliOption()` instead.

Default arguments include `-Dtycho-version=...` which the test sample relies on. Default arguments are set in:

https://github.com/eclipse-tycho/tycho/blob/6d2eb27291b8b21e98b3869e6deae8c461d71c66/tycho-its/src/test/java/org/eclipse/tycho/test/AbstractTychoIntegrationTest.java#L165

See #5995 and #6018