### PR TITLE
Add ability to define a "top level" category when mirroring repos using tycho-p2-extras-plugin

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorOptions.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2/tools/mirroring/facade/MirrorOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 SAP SE and others.
+ * Copyright (c) 2011, 2026 SAP SE and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ public class MirrorOptions {
     private boolean latestVersionOnly = false;
     private Map<String, String> filter = new HashMap<>();
     private boolean ignoreErrors = false;
+    private String categoryName = null;
 
     /**
      * Creates mirror options with default values.
@@ -128,5 +129,13 @@ public class MirrorOptions {
 
     public boolean isIgnoreErrors() {
         return this.ignoreErrors;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public String getCategoryName() {
+        return this.categoryName;
     }
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 SAP SE and others.
+ * Copyright (c) 2010, 2026 SAP SE and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -106,6 +106,9 @@ public class MirrorApplicationServiceImpl implements MirrorApplicationService {
         final TychoMirrorApplication mirrorApp = createMirrorApplication(sources, destination, agent, logger);
         mirrorApp.setSlicingOptions(createSlicingOptions(mirrorOptions));
         mirrorApp.setIgnoreErrors(mirrorOptions.isIgnoreErrors());
+        if (mirrorOptions.getCategoryName() != null && !mirrorOptions.getCategoryName().isBlank()) {
+            mirrorApp.setCategoryName(mirrorOptions.getCategoryName());
+        }
         try {
             // we want to see mirror progress as this is a possibly long-running operation
             mirrorApp.setVerbose(true);

--- a/tycho-core/src/main/java/org/eclipse/tycho/p2tools/TychoMirrorApplication.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2tools/TychoMirrorApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 SAP SE and others.
+ * Copyright (c) 2010, 2026 SAP SE and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,11 +19,13 @@ import static java.util.stream.Collectors.mapping;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -41,9 +43,13 @@ import org.eclipse.equinox.p2.internal.repository.tools.SlicingOptions;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IRequirement;
+import org.eclipse.equinox.p2.metadata.MetadataFactory;
+import org.eclipse.equinox.p2.metadata.MetadataFactory.InstallableUnitDescription;
 import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.equinox.p2.metadata.expression.IMatchExpression;
 import org.eclipse.equinox.p2.query.CollectionResult;
+import org.eclipse.equinox.p2.query.IQueryResult;
 import org.eclipse.equinox.p2.query.IQueryable;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.IRepository;
@@ -73,6 +79,7 @@ public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfrom
     private boolean filterProvided;
     private boolean addOnlyProvidingRepoReferences;
     private TargetPlatform targetPlatform;
+    private String categoryName;
     private Logger logger;
 
     public TychoMirrorApplication(IProvisioningAgent agent, DestinationRepositoryDescriptor destination,
@@ -269,6 +276,10 @@ public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfrom
                 logger.info("Adding references to the following repositories:");
                 references.stream().map(r -> r.getLocation()).distinct().forEach(loc -> logger.info("  " + loc));
             }
+            if (categoryName != null && !categoryName.isBlank()) {
+                logger.info("Injecting parent category \"" + categoryName + "\" into destination repository");
+                injectParentCategory(categoryName, repository, logger);
+            }
         }
         super.finalizeRepositories();
     }
@@ -405,6 +416,34 @@ public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfrom
         return Stream.empty();
     }
 
+    private static void injectParentCategory(String categoryName, IMetadataRepository destRepo, Logger logger) {
+        IQueryResult<IInstallableUnit> categories = destRepo.query(QueryUtil.createIUCategoryQuery(), null);
+        List<IRequirement> requirements = new ArrayList<>();
+        for (IInstallableUnit iu : categories) {
+            VersionRange exactRange = new VersionRange(iu.getVersion(), true, iu.getVersion(), true);
+            requirements.add(MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, iu.getId(),
+                    exactRange, null, false, false));
+            logger.info("  Wrapping category: \"" + iu.getProperty(IInstallableUnit.PROP_NAME) + "\" (" + iu.getId()
+                    + ")");
+        }
+        if (requirements.isEmpty()) {
+            logger.info("No category IUs found to wrap; uparentcategory not created");
+            return;
+        }
+
+        InstallableUnitDescription desc = new InstallableUnitDescription();
+        String id = "tycho.mirroring.category." + categoryName.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9._-]", ".");
+        desc.setId(id);
+        desc.setVersion(Version.createOSGi(1, 0, 0));
+        desc.setProperty(QueryUtil.PROP_TYPE_CATEGORY, Boolean.TRUE.toString());
+        desc.setProperty(IInstallableUnit.PROP_NAME, categoryName);
+        desc.setRequirements(requirements.toArray(IRequirement[]::new));
+        desc.setSingleton(true);
+
+        destRepo.addInstallableUnits(List.of(MetadataFactory.createInstallableUnit(desc)));
+        logger.info("Parent category \"" + categoryName + "\" injected with id '" + id + "'");
+    }
+
     public void setIncludeSources(boolean includeAllSource, TargetPlatform targetPlatform) {
         this.includeAllSource = includeAllSource;
         this.targetPlatform = targetPlatform;
@@ -424,6 +463,10 @@ public class TychoMirrorApplication extends org.eclipse.tycho.p2tools.copiedfrom
 
     public void setAddOnlyProvidingRepoReferences(boolean addOnlyProvidingRepoReferences) {
         this.addOnlyProvidingRepoReferences = addOnlyProvidingRepoReferences;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorStandaloneParentCategoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorStandaloneParentCategoryTest.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Contributors to the Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2tools;
+
+import static org.eclipse.tycho.p2tools.MirrorApplicationServiceTest.sourceRepos;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
+import org.eclipse.tycho.BuildDirectory;
+import org.eclipse.tycho.BuildOutputDirectory;
+import org.eclipse.tycho.p2.tools.DestinationRepositoryDescriptor;
+import org.eclipse.tycho.p2.tools.mirroring.facade.MirrorOptions;
+import org.eclipse.tycho.test.util.LogVerifier;
+import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class MirrorStandaloneParentCategoryTest extends TychoPlexusTestCase {
+
+    private static final String DEFAULT_NAME = "dummy";
+    private static final String PARENT_CATEGORY_NAME = "Parent Category";
+    private static final String PARENT_CATEGORY_ID = "tycho.mirroring.category.parent.category";
+
+    private DestinationRepositoryDescriptor destinationRepo;
+    private MirrorApplicationServiceImpl subject;
+
+    @Rule
+    public final TemporaryFolder tempFolder = new TemporaryFolder();
+    @Rule
+    public final LogVerifier logVerifier = new LogVerifier();
+
+    private BuildDirectory targetFolder;
+
+    @Before
+    public void initTestContext() throws Exception {
+        IProvisioningAgent agent = lookup(IProvisioningAgent.class);
+        agent.getService(IArtifactRepositoryManager.class);
+        destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest"), DEFAULT_NAME);
+        subject = new MirrorApplicationServiceImpl();
+        subject.setAgent(agent);
+        subject.setLogger(logVerifier.getLogger());
+        targetFolder = new BuildOutputDirectory(tempFolder.getRoot());
+    }
+
+    @Test
+    public void testParentCategoryIsInjected() throws Exception {
+        MirrorOptions options = new MirrorOptions();
+        options.setCategoryName(PARENT_CATEGORY_NAME);
+
+        subject.mirrorStandalone(sourceRepos("withcategories"), destinationRepo, Collections.emptyList(), options,
+                targetFolder);
+
+        IInstallableUnit parent = findParentUnit();
+        assertNotNull("Parent category IU was not injected into the destination repository", parent);
+        assertEquals(PARENT_CATEGORY_ID, parent.getId());
+        assertEquals(PARENT_CATEGORY_NAME, parent.getProperty(IInstallableUnit.PROP_NAME));
+        assertEquals(Boolean.TRUE.toString(), parent.getProperty(QueryUtil.PROP_TYPE_CATEGORY));
+    }
+
+    @Test
+    public void testParentWrapsAllSourceCategories() throws Exception {
+        MirrorOptions options = new MirrorOptions();
+        options.setCategoryName(PARENT_CATEGORY_NAME);
+
+        subject.mirrorStandalone(sourceRepos("withcategories"), destinationRepo, Collections.emptyList(), options,
+                targetFolder);
+
+        IInstallableUnit parent = findParentUnit();
+        assertNotNull(parent);
+
+        Set<String> requiredIds = parent.getRequirements().stream()
+                .map(r -> r.getMatches().getParameters()[0].toString()).collect(Collectors.toSet());
+
+        assertTrue("Parent should require test.category.alpha",
+                requiredIds.contains("org.eclipse.example.category.alpha"));
+        assertTrue("Parent should require test.category.beta",
+                requiredIds.contains("org.eclipse.example.category.beta"));
+        assertEquals("Parent should require exactly the two source categories", 2, requiredIds.size());
+    }
+
+    @Test
+    public void testNoCategoryNameProducesNoParentUnit() throws Exception {
+        subject.mirrorStandalone(sourceRepos("withcategories"), destinationRepo, Collections.emptyList(),
+                new MirrorOptions(), targetFolder);
+
+        IInstallableUnit parent = findParentUnit();
+        assertTrue("No parent IU should be present when categoryName is not set", parent == null);
+    }
+
+    @Test
+    public void testParentNotDuplicatedOnAppend() throws Exception {
+        MirrorOptions options = new MirrorOptions();
+        options.setCategoryName(PARENT_CATEGORY_NAME);
+
+        // Mirror twice to the same destination (append=true is the default)
+        subject.mirrorStandalone(sourceRepos("withcategories"), destinationRepo, Collections.emptyList(), options,
+                targetFolder);
+        subject.mirrorStandalone(sourceRepos("withcategories"), destinationRepo, Collections.emptyList(), options,
+                targetFolder);
+
+        IQueryResult<IInstallableUnit> result = openDestinationRepo().query(QueryUtil.createIUQuery(PARENT_CATEGORY_ID),
+                null);
+        long count = StreamSupport.stream(result.spliterator(), false).count();
+        assertEquals("Parent category IU must appear exactly once after two mirror runs", 1, count);
+    }
+
+    // --- helpers ---
+
+    private IInstallableUnit findParentUnit() throws Exception {
+        IQueryResult<IInstallableUnit> result = openDestinationRepo().query(QueryUtil.createIUQuery(PARENT_CATEGORY_ID),
+                null);
+        return result.isEmpty() ? null : result.iterator().next();
+    }
+
+    private IMetadataRepository openDestinationRepo() throws Exception {
+        IProvisioningAgent agent = lookup(IProvisioningAgent.class);
+        IMetadataRepositoryManager mgr = agent.getService(IMetadataRepositoryManager.class);
+        return mgr.loadRepository(destinationRepo.getLocation().toURI(), null);
+    }
+
+}

--- a/tycho-core/src/test/resources/repositories/withcategories/artifacts.xml
+++ b/tycho-core/src/test/resources/repositories/withcategories/artifacts.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?artifactRepository version='1.1.0'?>
+<repository name='withcategories'
+	type='org.eclipse.equinox.p2.artifact.repository.simpleRepository'
+	version='1'>
+	<properties size='2'>
+		<property name='p2.timestamp' value='1308584189023' />
+		<property name='p2.compressed' value='false' />
+	</properties>
+	<mappings size='3'>
+		<rule filter='(&amp; (classifier=osgi.bundle))'
+			output='${repoUrl}/plugins/${id}_${version}.jar' />
+		<rule filter='(&amp; (classifier=binary))'
+			output='${repoUrl}/binary/${id}_${version}' />
+		<rule filter='(&amp; (classifier=org.eclipse.update.feature))'
+			output='${repoUrl}/features/${id}_${version}.jar' />
+	</mappings>
+	<artifacts size='0'>
+	</artifacts>
+</repository>

--- a/tycho-core/src/test/resources/repositories/withcategories/content.xml
+++ b/tycho-core/src/test/resources/repositories/withcategories/content.xml
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?metadataRepository version='1.1.0'?>
+<repository name='withcategories'
+	type='org.eclipse.equinox.internal.p2.metadata.repository.LocalMetadataRepository'
+	version='1'>
+	<properties size='2'>
+		<property name='p2.timestamp' value='1308584189029' />
+		<property name='p2.compressed' value='false' />
+	</properties>
+	<units size='3'>
+		<unit id='org.eclipse.core.runtime' version='3.4.0.v20080512'>
+			<update id='org.eclipse.core.runtime'
+				range='[0.0.0,3.4.0.v20080512)' severity='0' />
+			<properties size='2'>
+				<property name='org.eclipse.equinox.p2.name'
+					value='Core Runtime' />
+				<property name='org.eclipse.equinox.p2.provider'
+					value='Eclipse.org' />
+			</properties>
+			<provides size='2'>
+				<provided namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.core.runtime' version='3.4.0.v20080512' />
+				<provided namespace='osgi.bundle'
+					name='org.eclipse.core.runtime' version='3.4.0.v20080512' />
+			</provides>
+			<touchpoint id='org.eclipse.equinox.p2.none'
+				version='1.0.0' />
+		</unit>
+		<unit id='org.eclipse.example.category.alpha'
+			version='1.0.0.20240101'>
+			<properties size='2'>
+				<property name='org.eclipse.equinox.p2.name'
+					value='Alpha Tools' />
+				<property name='org.eclipse.equinox.p2.type.category'
+					value='true' />
+			</properties>
+			<provides size='1'>
+				<provided namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.example.category.alpha' version='1.0.0.20240101' />
+			</provides>
+			<requires size='1'>
+				<required namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.core.runtime'
+					range='[3.4.0.v20080512,3.4.0.v20080512]' />
+			</requires>
+		</unit>
+		<unit id='org.eclipse.example.category.beta'
+			version='1.0.0.20240101'>
+			<properties size='2'>
+				<property name='org.eclipse.equinox.p2.name'
+					value='Beta Tools' />
+				<property name='org.eclipse.equinox.p2.type.category'
+					value='true' />
+			</properties>
+			<provides size='1'>
+				<provided namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.example.category.beta' version='1.0.0.20240101' />
+			</provides>
+			<requires size='1'>
+				<required namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.core.runtime'
+					range='[3.4.0.v20080512,3.4.0.v20080512]' />
+			</requires>
+		</unit>
+	</units>
+</repository>

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 SAP AG and others.
+ * Copyright (c) 2011, 2026 SAP AG and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -217,6 +217,28 @@ public class MirrorMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean ignoreErrors;
 
+    /**
+     * <p>
+     * The name of a synthetic top-level category that will be injected into the destination
+     * repository after mirroring. All category IUs from the mirrored source repositories will
+     * appear as children of this parent entry in Eclipse's "Install New Software" dialog,
+     * rather than each appearing as a separate top-level entry.
+     * </p>
+     * <p>
+     * For example, setting <code>categoryName</code> to <code>Parent Category</code> when mirroring
+     * EGit and TM4E will produce a single "Parent Category" entry that expands to reveal each
+     * tool's own categories, instead of showing them as individual top-level entries.
+     * </p>
+     * <p>
+     * When omitted, the behaviour is unchanged: source categories appear as individual top-level
+     * entries in the destination repository.
+     * </p>
+     *
+     * @since 5.0.3
+     */
+    @Parameter
+    private String categoryName;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         RepositoryReferences sourceDescriptor = null;
@@ -266,6 +288,7 @@ public class MirrorMojo extends AbstractMojo {
         options.setLatestVersionOnly(latestVersionOnly);
         options.getFilter().putAll(filter);
         options.setIgnoreErrors(ignoreErrors);
+        options.setCategoryName(categoryName);
         return options;
     }
 

--- a/tycho-its/projects/p2Repository.mirror.category/pom.xml
+++ b/tycho-its/projects/p2Repository.mirror.category/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>tycho-its-project.p2Repository.mirror</groupId>
+  <artifactId>prm.category</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <tycho-version>6.0.0-SNAPSHOT</tycho-version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho.extras</groupId>
+        <artifactId>tycho-p2-extras-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <executions>
+          <execution>
+            <id>mirror-with-parent-category</id>
+            <phase>package</phase>
+            <goals>
+              <goal>mirror</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <source>
+            <repository>
+              <id>withcategories</id>
+              <layout>p2</layout>
+              <url>${source-url}</url>
+            </repository>
+          </source>
+          <destination>${project.build.directory}/repository</destination>
+          <categoryName>Parent Category</categoryName>
+          <mirrorMetadataOnly>true</mirrorMetadataOnly>
+          <compress>false</compress>
+          <xzCompress>false</xzCompress>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tycho-its/projects/p2Repository.mirror.category/source-repo/artifacts.xml
+++ b/tycho-its/projects/p2Repository.mirror.category/source-repo/artifacts.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?artifactRepository version='1.1.0'?>
+<repository name='withcategories'
+	type='org.eclipse.equinox.p2.artifact.repository.simpleRepository'
+	version='1'>
+	<properties size='2'>
+		<property name='p2.timestamp' value='1308584189023' />
+		<property name='p2.compressed' value='false' />
+	</properties>
+	<mappings size='3'>
+		<rule filter='(&amp; (classifier=osgi.bundle))'
+			output='${repoUrl}/plugins/${id}_${version}.jar' />
+		<rule filter='(&amp; (classifier=binary))'
+			output='${repoUrl}/binary/${id}_${version}' />
+		<rule filter='(&amp; (classifier=org.eclipse.update.feature))'
+			output='${repoUrl}/features/${id}_${version}.jar' />
+	</mappings>
+	<artifacts size='0'>
+	</artifacts>
+</repository>

--- a/tycho-its/projects/p2Repository.mirror.category/source-repo/content.xml
+++ b/tycho-its/projects/p2Repository.mirror.category/source-repo/content.xml
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?metadataRepository version='1.1.0'?>
+<repository name='withcategories'
+	type='org.eclipse.equinox.internal.p2.metadata.repository.LocalMetadataRepository'
+	version='1'>
+	<properties size='2'>
+		<property name='p2.timestamp' value='1308584189029' />
+		<property name='p2.compressed' value='false' />
+	</properties>
+	<units size='3'>
+		<unit id='org.eclipse.core.runtime' version='3.4.0.v20080512'>
+			<update id='org.eclipse.core.runtime'
+				range='[0.0.0,3.4.0.v20080512)' severity='0' />
+			<properties size='2'>
+				<property name='org.eclipse.equinox.p2.name'
+					value='Core Runtime' />
+				<property name='org.eclipse.equinox.p2.provider'
+					value='Eclipse.org' />
+			</properties>
+			<provides size='2'>
+				<provided namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.core.runtime' version='3.4.0.v20080512' />
+				<provided namespace='osgi.bundle'
+					name='org.eclipse.core.runtime' version='3.4.0.v20080512' />
+			</provides>
+			<touchpoint id='org.eclipse.equinox.p2.none'
+				version='1.0.0' />
+		</unit>
+		<unit id='org.eclipse.example.category.alpha'
+			version='1.0.0.20240101'>
+			<properties size='2'>
+				<property name='org.eclipse.equinox.p2.name'
+					value='Alpha Tools' />
+				<property name='org.eclipse.equinox.p2.type.category'
+					value='true' />
+			</properties>
+			<provides size='1'>
+				<provided namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.example.category.alpha' version='1.0.0.20240101' />
+			</provides>
+			<requires size='1'>
+				<required namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.core.runtime'
+					range='[3.4.0.v20080512,3.4.0.v20080512]' />
+			</requires>
+		</unit>
+		<unit id='org.eclipse.example.category.beta'
+			version='1.0.0.20240101'>
+			<properties size='2'>
+				<property name='org.eclipse.equinox.p2.name'
+					value='Beta Tools' />
+				<property name='org.eclipse.equinox.p2.type.category'
+					value='true' />
+			</properties>
+			<provides size='1'>
+				<provided namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.example.category.beta' version='1.0.0.20240101' />
+			</provides>
+			<requires size='1'>
+				<required namespace='org.eclipse.equinox.p2.iu'
+					name='org.eclipse.core.runtime'
+					range='[3.4.0.v20080512,3.4.0.v20080512]' />
+			</requires>
+		</unit>
+	</units>
+</repository>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorCategoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorCategoryTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Contributors to the Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.p2Repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Verifies that the {@code mirror} goal of the tycho-p2-extras-plugin injects a
+ * parent category that wraps all categories of the mirrored source repository
+ * when {@code categoryName} is configured.
+ */
+public class P2RepositoryMirrorCategoryTest extends AbstractTychoIntegrationTest {
+
+	private static final String PARENT_CATEGORY_ID = "tycho.mirroring.category.parent.category";
+
+	@Test
+	public void testParentCategoryInjected() throws Exception {
+		Verifier verifier = getVerifier("p2Repository.mirror.category", false);
+
+		// Point the configured source repository at the bundled fixture
+		File sourceRepo = new File(verifier.getBasedir(), "source-repo");
+		verifier.addCliOption("-Dsource-url=" + sourceRepo.toURI());
+
+		verifier.executeGoals(List.of("verify"));
+		verifier.verifyErrorFreeLog();
+		verifier.verifyTextInLog("Injecting parent category \"Parent Category\"");
+
+		Document content = P2RepositoryMirrorTest
+				.parseDocument(new File(verifier.getBasedir(), "target/repository/content.xml"));
+		XPath xpath = XPathFactory.newInstance().newXPath();
+
+		String parentExpr = "repository/units/unit[@id='" + PARENT_CATEGORY_ID + "']";
+		Node parent = (Node) xpath.evaluate(parentExpr, content, XPathConstants.NODE);
+		assertNotNull("Parent category IU was not injected into the mirrored repository", parent);
+
+		assertEquals("Parent IU must be marked as a category", "true", xpath.evaluate(
+				parentExpr + "/properties/property[@name='org.eclipse.equinox.p2.type.category']/@value", content));
+
+		NodeList requiredNames = (NodeList) xpath.evaluate(parentExpr + "/requires/required/@name", content,
+				XPathConstants.NODESET);
+		Set<String> requiredIds = new HashSet<>();
+		for (int i = 0; i < requiredNames.getLength(); i++) {
+			requiredIds.add(requiredNames.item(i).getNodeValue());
+		}
+
+		assertTrue("Parent should wrap category alpha", requiredIds.contains("org.eclipse.example.category.alpha"));
+		assertTrue("Parent should wrap category beta", requiredIds.contains("org.eclipse.example.category.beta"));
+		assertEquals("Parent should wrap exactly the two source categories", 2, requiredIds.size());
+	}
+}


### PR DESCRIPTION
PR to address - https://github.com/eclipse-tycho/tycho/issues/4517

When mirroring multiple p2 repositories into a single destination using the mirror goal, each source repository's category IUs appear as separate top-level entries in Eclipse's "Install New Software" dialog. This change adds a new optional <categoryName> parameter that injects a synthetic root category IU into the destination repository, causing all mirrored source categories to appear as children of a single named entry instead.