### PR TITLE
Skip source bundles during classpath resolution

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/TychoProjectManager.java
@@ -65,6 +65,7 @@ import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.core.osgitools.OsgiManifestParserException;
 import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
+import org.eclipse.tycho.core.resolver.target.ArtifactTypeHelper;
 import org.eclipse.tycho.helper.PluginRealmHelper;
 import org.eclipse.tycho.model.project.EclipseProject;
 import org.eclipse.tycho.p2maven.tmp.BundlesAction;
@@ -297,7 +298,7 @@ public class TychoProjectManager {
         List<ArtifactDescriptor> dependencies = tychoProject
                 .getDependencyArtifacts(DefaultReactorProject.adapt(project)).getArtifacts();
         for (ArtifactDescriptor descriptor : dependencies) {
-            if (TychoConstants.CLASSIFIER_SOURCES.equals(descriptor.getClassifier())) {
+            if (ArtifactTypeHelper.isSourceBundle(descriptor)) {
                 continue;
             }
             File location = descriptor.fetchArtifact().get();

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
@@ -60,6 +60,7 @@ import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.core.osgitools.OsgiManifestParserException;
+import org.eclipse.tycho.core.resolver.target.ArtifactTypeHelper;
 import org.eclipse.tycho.targetplatform.TargetDefinition.MavenGAVLocation;
 
 public final class MavenDependencyInjector {
@@ -117,7 +118,7 @@ public final class MavenDependencyInjector {
         MavenDependencyInjector generator = new MavenDependencyInjector(project, bundleReader, descriptorMapping,
                 logger);
         for (ArtifactDescriptor artifact : dependencies.getArtifacts()) {
-            if (TychoConstants.CLASSIFIER_SOURCES.equals(artifact.getClassifier())) {
+            if (ArtifactTypeHelper.isSourceBundle(artifact)) {
                 //there is no need to struggle with source when we inject dependencies
                 continue;
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -74,6 +74,7 @@ import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.ee.ExecutionEnvironmentUtils;
 import org.eclipse.tycho.core.ee.StandardExecutionEnvironment;
 import org.eclipse.tycho.core.osgitools.DependencyComputer.DependencyEntry;
+import org.eclipse.tycho.core.resolver.target.ArtifactTypeHelper;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
@@ -364,8 +365,14 @@ public class EquinoxResolver implements DependenciesResolver {
         Map<File, ArtifactDescriptor> descriptors = new LinkedHashMap<>();
 
         List<ArtifactDescriptor> list = artifacts.getArtifacts(ArtifactType.TYPE_ECLIPSE_PLUGIN);
+        Set<String> requiredSourceBundleIds = ArtifactTypeHelper.collectRequiredSourceBundleIds(list);
 
         for (ArtifactDescriptor artifact : list) {
+            if (ArtifactTypeHelper.isSourceBundle(artifact)
+                    && !requiredSourceBundleIds.contains(artifact.getKey().getId())) {
+                // source bundles are not needed for OSGi resolution unless explicitly referenced
+                continue;
+            }
             File location = artifact.getLocation(true);
             OsgiManifest mf = loadManifest(location, artifact);
             descriptors.put(location, artifact);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -71,6 +72,7 @@ import org.eclipse.tycho.core.osgitools.project.EclipsePluginProject;
 import org.eclipse.tycho.core.osgitools.project.EclipsePluginProjectImpl;
 import org.eclipse.tycho.core.osgitools.targetplatform.DefaultDependencyArtifacts;
 import org.eclipse.tycho.core.resolver.P2ResolverFactory;
+import org.eclipse.tycho.core.resolver.target.ArtifactTypeHelper;
 import org.eclipse.tycho.model.classpath.JUnitBundle;
 import org.eclipse.tycho.model.classpath.JUnitClasspathContainerEntry;
 import org.eclipse.tycho.model.classpath.LibraryClasspathEntry;
@@ -159,7 +161,13 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
             classpath.add(new DefaultClasspathEntry(reactorProject, artifactKey,
                     List.of(new File(project.getBuild().getOutputDirectory())), null));
             List<ArtifactDescriptor> bundles = artifacts.getArtifacts(ArtifactType.TYPE_ECLIPSE_PLUGIN);
+            Set<String> requiredSourceBundleIds = ArtifactTypeHelper.collectRequiredSourceBundleIds(bundles);
             for (ArtifactDescriptor bundle : bundles) {
+                if (ArtifactTypeHelper.isSourceBundle(bundle)
+                        && !requiredSourceBundleIds.contains(bundle.getKey().getId())) {
+                    // source bundles are not needed for compilation unless explicitly referenced
+                    continue;
+                }
                 //TODO we might want to compute the access rules based on the manifest exported packages
                 Collection<AccessRule> rules = null;
                 classpath.add(new DefaultClasspathEntry(bundle.getMavenProject(), bundle.getKey(),

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/target/ArtifactTypeHelper.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/target/ArtifactTypeHelper.java
@@ -17,7 +17,10 @@ import static org.eclipse.tycho.ArtifactType.TYPE_ECLIPSE_FEATURE;
 import static org.eclipse.tycho.ArtifactType.TYPE_ECLIPSE_PLUGIN;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
+import org.eclipse.equinox.internal.p2.metadata.IRequiredCapability;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IProvidedCapability;
@@ -29,6 +32,7 @@ import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
+import org.eclipse.tycho.ArtifactDescriptor;
 import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.DefaultArtifactKey;
@@ -155,6 +159,46 @@ public class ArtifactTypeHelper {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns {@code true} if the given artifact descriptor represents a source bundle.
+     * <p>
+     * Source bundles are identified either by their classifier being
+     * {@link TychoConstants#CLASSIFIER_SOURCES}.
+     */
+    public static boolean isSourceBundle(ArtifactDescriptor artifact) {
+        if (artifact == null) {
+            return false;
+        }
+        return TychoConstants.CLASSIFIER_SOURCES.equals(artifact.getClassifier());
+    }
+
+    /**
+     * Scans the p2 IU requirements of all given artifacts and returns the set of bundle symbolic
+     * names that are explicitly required via {@code Require-Bundle} and whose name indicates a
+     * source bundle (i.e. the name ends with {@code .source}).
+     * <p>
+     * This information is used to avoid skipping source bundles that are genuinely needed for
+     * resolution (e.g. a bundle that explicitly declares
+     * {@code Require-Bundle: com.example.plugin.source}).
+     */
+    public static Set<String> collectRequiredSourceBundleIds(Collection<ArtifactDescriptor> artifacts) {
+        Set<String> result = new HashSet<>();
+        for (ArtifactDescriptor artifact : artifacts) {
+            for (IInstallableUnit iu : artifact.getInstallableUnits()) {
+                for (IRequirement req : iu.getRequirements()) {
+                    if (req instanceof IRequiredCapability cap
+                            && BundlesAction.CAPABILITY_NS_OSGI_BUNDLE.equals(cap.getNamespace())) {
+                        String name = cap.getName();
+                        if (name != null && name.endsWith(".source")) {
+                            result.add(name);
+                        }
+                    }
+                }
+            }
+        }
+        return result;
     }
 
     public static ArtifactKey toTychoArtifactKey(IInstallableUnit iu, IArtifactKey p2ArtifactKey) {


### PR DESCRIPTION
 Source bundles were unnecessarily downloaded
 during the validate-classpath phase and bnd classpath resolution.
 They are not needed for OSGi resolution or compilation.

 Added `ArtifactTypeHelper.isSourceBundle()` to detect source bundles
 by classifier and applied the filter in `EquinoxResolver.newState()` and
 `OsgiBundleProject.resolveClassPath()`. Adapting existing places to use
 this new helper as well.