### PR TITLE
[bp] Add tycho-p2-extras:p2-manager mojo for managing P2 update sites

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,40 @@ If you are reading this in the browser, then you can quickly jump to specific ve
 
 ## 5.0.2
 
+### new `tycho-p2-extras:p2-manager` mojo for managing P2 update sites
+
+The new `tycho-p2-extras:p2-manager` goal provides a convenient way to maintain, update, and manage the integrity of public update sites.
+This mojo wraps the [P2 Manager application from JustJ Tools](https://eclipse.dev/justj/?page=tools) and makes it much easier to use compared to the previous approach using the eclipse-run goal.
+
+The P2 Manager helps with:
+- Promoting builds to update sites (nightly, milestone, or release)
+- Generating composite repositories
+- Managing repository history and retention policies
+- Creating browsable HTML pages for your update sites
+- Maintaining repository integrity
+
+```xml
+<plugin>
+    <groupId>org.eclipse.tycho.extras</groupId>
+    <artifactId>tycho-p2-extras-plugin</artifactId>
+    <version>${tycho-version}</version>
+    <executions>
+        <execution>
+            <id>promote-build</id>
+            <goals>
+                <goal>p2-manager</goal>
+            </goals>
+            <configuration>
+                <root>${project.build.directory}/updatesite</root>
+                <promote>file:${project.build.directory}/repository</promote>
+                <timestamp>${maven.build.timestamp}</timestamp>
+                <type>nightly</type>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
 ### Features
 
 - Add JUnit 6 provider support

--- a/src/site/markdown/BuildingSites.md
+++ b/src/site/markdown/BuildingSites.md
@@ -190,9 +190,18 @@ When adding references automatically, you can filter which ones are included:
 | `createArtifactRepository` | `true` | Create artifact files; set to `false` for a metadata-only repository |
 | `generateOSGiRepository` | `false` | Generate an OSGi Repository alongside the p2 repository |
 
+## Managing Update Sites with the P2 Manager
+
+Once a repository is built it needs to be published and maintained on a public update site.
+The `tycho-p2-extras:p2-manager` goal automates this, including nightly/milestone/release promotion, composite repository generation, and browsable HTML index pages.
+
+See [Managing P2 Update Sites](ManagingP2Sites.html) for full documentation.
+
 ## Further Reading
 
 - [Advanced Category Definitions](CategoryDefinitions.html) — Dynamic categories, p2 query expressions, and IU filtering
 - [Controlling Repository Content](RepositoryContent.html) — Detailed comparison of all inclusion and exclusion options
+- [Managing P2 Update Sites](ManagingP2Sites.html) — Publishing and maintaining public update sites with the P2 Manager
 - [Tycho P2 Repository Plugin Reference](tycho-p2-repository-plugin/plugin-info.html) — Complete reference for all configuration options
+- [P2 Manager Mojo Reference](tycho-extras/tycho-p2-extras-plugin/p2-manager-mojo.html) — Complete reference for all P2 Manager parameters
 - [Packaging Types](PackagingTypes.html) — Information about the `eclipse-repository` packaging type

--- a/src/site/markdown/ManagingP2Sites.md
+++ b/src/site/markdown/ManagingP2Sites.md
@@ -1,0 +1,208 @@
+# Managing P2 Update Sites
+
+Once a p2 repository has been built with Tycho, it typically needs to be published and maintained on a public update site.
+The `tycho-p2-extras:p2-manager` goal wraps the [P2 Manager application from JustJ Tools](https://eclipse.dev/justj/?page=tools) to automate this lifecycle.
+Compared to invoking the application manually via `eclipse-run`, the mojo provides typed, validated configuration parameters and integrates naturally into the Maven build.
+
+## Update Site Anatomy
+
+The P2 Manager organises a managed update site into a well-defined folder hierarchy based on build type.
+Given a `root` of `/var/www/updates/myproject` and a `relative` of `updates`, the resulting structure looks like this:
+
+```
+updates/
+  nightly/
+    latest/          ← composite, always points to the newest nightly
+    N202405261200/   ← individual nightly (name = N + timestamp)
+    N202405251100/
+    ...              ← older nightlies pruned automatically by -retain
+  milestone/
+    latest/          ← composite, always points to the newest milestone
+    S202406010000/   ← individual milestone (name = S + timestamp)
+  release/
+    latest/          ← composite, always points to the newest release
+    1.2.0/           ← release folder named after the logical version
+```
+
+Composite repositories are generated automatically at every level, so users can point their Eclipse installation at `updates/nightly/latest` to always track the tip, or at `updates/release/latest` for the latest stable release.
+
+## Build Type Promotion Workflow
+
+The three build types form a deliberate promotion chain:
+
+| Type        | What is promoted                               | Prerequisite                  |
+|-------------|------------------------------------------------|-------------------------------|
+| `nightly`   | The built repository as a new nightly snapshot | None                          |
+| `milestone` | The built repository as a new milestone        | At least one nightly present  |
+| `release`   | The **latest milestone** (not the build output)| At least one milestone present|
+
+Note that for a `release` build the `promote` parameter is ignored — the P2 Manager mirrors the latest milestone content byte-for-byte as the release.
+This ensures releases are always identical to a validated milestone.
+
+## Basic Usage
+
+Add the mojo to any Maven project (it does not require an `eclipse-repository` packaging type and can run standalone with `requiresProject = false`):
+
+```xml
+<plugin>
+    <groupId>org.eclipse.tycho.extras</groupId>
+    <artifactId>tycho-p2-extras-plugin</artifactId>
+    <version>${tycho-version}</version>
+    <executions>
+        <execution>
+            <id>promote-build</id>
+            <goals>
+                <goal>p2-manager</goal>
+            </goals>
+            <configuration>
+                <root>${project.build.directory}/updatesite</root>
+                <promote>file:${project.build.directory}/repository</promote>
+                <timestamp>${maven.build.timestamp}</timestamp>
+                <type>nightly</type>
+                <label>My Project</label>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+Add the timestamp format to your POM properties so the value is in the expected `yyyyMMddHHmm` format:
+
+```xml
+<properties>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+</properties>
+```
+
+## Remote Publishing
+
+For publishing to a remote server the P2 Manager uses `rsync`.
+Set `remote` to an rsync-compatible destination and `targetUrl` to the public HTTP(S) URL of the `root` once it has been transferred:
+
+```xml
+<configuration>
+    <root>${project.build.directory}/updatesite</root>
+    <relative>myproject/updates</relative>
+    <remote>deploy-user@downloads.example.org:/var/www/downloads</remote>
+    <targetUrl>https://downloads.example.org</targetUrl>
+    <promote>file:${project.build.directory}/repository</promote>
+    <timestamp>${maven.build.timestamp}</timestamp>
+    <type>${build.type}</type>
+    <label>My Project</label>
+    <buildUrl>${env.BUILD_URL}</buildUrl>
+    <commit>https://github.com/myorg/myproject/commit/${git.commit}</commit>
+    <breadcrumbs>
+        <breadcrumb>My Project https://example.org/myproject</breadcrumb>
+    </breadcrumbs>
+</configuration>
+```
+
+When `remote` is not set the P2 Manager only populates `root` locally, which is useful for testing the generated site structure without an actual server.
+
+## Version Determination
+
+The P2 Manager derives the logical version of a repository (used for release folder names and milestone lifecycle management) by inspecting the versions of installable units inside the promoted repository.
+Use `versionIU` (prefix match) or `versionIUPattern` (regular expression) to select the relevant IU, typically the project's SDK feature:
+
+```xml
+<configuration>
+    <versionIU>com.example.sdk</versionIU>
+    <!-- or: -->
+    <versionIUPattern>com\.example\..*\.sdk</versionIUPattern>
+</configuration>
+```
+
+Without either setting all IUs are considered, which is usually not what you want.
+
+## Generated HTML Pages
+
+The P2 Manager generates browsable HTML index pages for the update site.
+Several parameters control branding:
+
+```xml
+<configuration>
+    <label>My Project</label>
+    <favicon>https://example.org/favicon.ico</favicon>
+    <titleImage>https://example.org/logo.png</titleImage>
+    <bodyImage>https://example.org/banner.svg</bodyImage>
+    <breadcrumbs>
+        <breadcrumb>My Project https://example.org</breadcrumb>
+        <breadcrumb>Downloads https://example.org/downloads</breadcrumb>
+    </breadcrumbs>
+    <archives>
+        <archive>0.x Archive https://example.org/old-downloads</archive>
+    </archives>
+</configuration>
+```
+
+To show a summary table of installable unit versions across all sites, set `summary` to the number of update site columns to include:
+
+```xml
+<configuration>
+    <summary>5</summary>
+    <!-- optional: restrict which IUs appear in the table -->
+    <summaryIUPattern>com\.example\..*(?&lt;!\.source)</summaryIUPattern>
+</configuration>
+```
+
+## Promoting Products
+
+To promote Tycho-built product archives alongside the p2 repository, set `promoteProducts` to the folder containing the product zip files:
+
+```xml
+<configuration>
+    <root>${project.build.directory}/updatesite</root>
+    <promote>file:${project.build.directory}/repository</promote>
+    <promoteProducts>${project.build.directory}/products</promoteProducts>
+    <type>${build.type}</type>
+</configuration>
+```
+
+Download links for each product archive will appear on the generated HTML index page.
+
+## Complete Parameter Reference
+
+| Parameter                  | Default                           | Description                                                              |
+|----------------------------|-----------------------------------|--------------------------------------------------------------------------|
+| `root`                     | *(required)*                      | Local root folder of the managed update site                             |
+| `type`                     | `nightly`                         | Build type: `nightly`, `milestone`, or `release`                         |
+| `timestamp`                | current time                      | Build timestamp (`yyyyMMddHHmm`)                                         |
+| `promote`                  |                                   | Repository URI or path to promote                                        |
+| `relative`                 |                                   | Relative path below `root` for this project's repositories               |
+| `remote`                   |                                   | rsync destination for remote publishing                                  |
+| `targetUrl`                |                                   | Public base URL of the root once published                               |
+| `retain`                   | `7`                               | Number of nightly builds to keep                                         |
+| `label`                    | `Project`                         | Project name used in generated HTML pages                                |
+| `buildUrl`                 |                                   | CI build URL linked from generated pages                                 |
+| `commit`                   |                                   | Git commit URL stored as a repository property                           |
+| `versionIU`                |                                   | IU ID prefix for logical version determination                           |
+| `versionIUPattern`         |                                   | IU ID regex for logical version determination                            |
+| `iuFilterPattern`          |                                   | Regex to restrict which IUs appear in generated index details            |
+| `primaryIUFilterPattern`   | `.*\.sdk(…)\.feature\.group`      | Regex selecting primary (SDK) features highlighted on index pages        |
+| `excludedCategoriesPattern`|                                   | Regex to remove category IUs from the promoted repository                |
+| `baselineUrl`              |                                   | URL to check for baseline artifact replacements                          |
+| `promoteProducts`          |                                   | Folder of Tycho product archives to promote alongside the repository     |
+| `downloads`                |                                   | Additional file paths to publish as downloads                            |
+| `favicon`                  | Eclipse favicon                   | Favicon URL for generated HTML pages                                     |
+| `titleImage`               | Eclipse logo                      | Title image URL for generated HTML pages                                 |
+| `bodyImage`                |                                   | Body image URL for generated HTML pages                                  |
+| `breadcrumbs`              |                                   | Navigation breadcrumbs (`label URL` pairs)                               |
+| `archives`                 |                                   | Archive navigation links (`label URL` pairs)                             |
+| `mappings`                 |                                   | Name mappings (`raw->Display` pairs) for navigation labels               |
+| `commitMappings`           |                                   | Regex mappings to rewrite commit URLs                                    |
+| `mavenWrappedMappings`     |                                   | Mappings to rewrite or remove `maven-wrapped-` IU properties             |
+| `excludes`                 |                                   | File names passed as `--exclude` to rsync                                |
+| `summary`                  | `0` (disabled)                    | Number of update site columns in the IU summary table                    |
+| `summaryIUPattern`         | excludes sources and features     | Regex selecting IUs shown in the summary table                           |
+| `simrelAlias`              | `false`                           | Create a SimRel-named alias (e.g. `2024-06`) for the current version     |
+| `bree`                     | `false`                           | Generate minimum execution environment details per bundle                |
+| `verbose`                  | `true`                            | Print detailed progress (set to `false` for quiet output)                |
+| `managerRepository`        | JustJ tools update site           | Maven repository from which the P2 Manager application is resolved       |
+
+For the full Mojo reference, see the [P2 Manager Mojo Reference](tycho-extras/tycho-p2-extras-plugin/p2-manager-mojo.html).
+
+## Further Reading
+
+- [Building P2 Update Sites](BuildingSites.html) — How to build a p2 repository with Tycho
+- [JustJ P2 Manager documentation](https://eclipse.dev/justj/?page=tools) — Upstream documentation for the wrapped application
+- [P2 Manager Mojo Reference](tycho-extras/tycho-p2-extras-plugin/p2-manager-mojo.html) — Auto-generated parameter reference

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -29,7 +29,9 @@
 			<item name="Building P2 Update Sites" href="BuildingSites.html">
 				<item name="Advanced Category Definitions" href="CategoryDefinitions.html" />
 				<item name="Controlling Repository Content" href="RepositoryContent.html" />
+				<item name="Managing P2 Update Sites" href="ManagingP2Sites.html" />
 				<item name="Tycho P2 Repository Plugin" href="tycho-p2-repository-plugin/plugin-info.html" />
+				<item name="P2 Manager Mojo" href="tycho-extras/tycho-p2-extras-plugin/p2-manager-mojo.html" />
 			</item>
 			<item name="Properties">
 				<item name="Build Properties" href="BuildProperties.html" />

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/P2ManagerMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/P2ManagerMojo.java
@@ -1,0 +1,398 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.tycho.plugins.p2.extras;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.model.Repository;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.tycho.MavenRepositoryLocation;
+import org.eclipse.tycho.osgi.framework.Bundles;
+import org.eclipse.tycho.osgi.framework.EclipseApplication;
+import org.eclipse.tycho.osgi.framework.EclipseApplicationManager;
+import org.eclipse.tycho.osgi.framework.EclipseFramework;
+import org.eclipse.tycho.osgi.framework.EclipseWorkspace;
+import org.eclipse.tycho.osgi.framework.EclipseWorkspaceManager;
+import org.eclipse.tycho.osgi.framework.Features;
+import org.osgi.framework.BundleException;
+
+/**
+ * This goal wraps the P2 Manager application from JustJ Tools to maintain,
+ * update, and manage the integrity of a public update site.
+ * 
+ * @see <a href="https://eclipse.dev/justj/?page=tools">JustJ P2 Manager</a>
+ */
+@Mojo(name = "p2-manager", threadSafe = true, requiresProject = false)
+public class P2ManagerMojo extends AbstractMojo {
+
+	@Component
+	private EclipseWorkspaceManager workspaceManager;
+
+	@Component
+	private EclipseApplicationManager applicationManager;
+
+	/**
+	 * The repository where the P2 Manager application should be sourced from
+	 */
+	@Parameter
+	private Repository managerRepository;
+
+	/**
+	 * Whether to print progress during the activities (opposite of -quiet flag)
+	 */
+	@Parameter(property = "p2manager.verbose", defaultValue = "true")
+	private boolean verbose;
+
+	/**
+	 * The root folder of the project's update site
+	 */
+	@Parameter(property = "p2manager.root", required = true)
+	private File root;
+
+	/**
+	 * Whether to show only the latest version of each installable unit
+	 */
+	@Parameter(property = "p2manager.latestVersionOnly")
+	private boolean latestVersionOnly;
+
+	/**
+	 * Number of nightly builds to retain
+	 */
+	@Parameter(property = "p2manager.retain", defaultValue = "7")
+	private int retain;
+
+	/**
+	 * The project label to use in generated pages
+	 */
+	@Parameter(property = "p2manager.label", defaultValue = "Project")
+	private String label;
+
+	/**
+	 * Build URL for reference in generated pages
+	 */
+	@Parameter(property = "p2manager.buildUrl")
+	private String buildUrl;
+
+	/**
+	 * Relative target folder within the root
+	 */
+	@Parameter(property = "p2manager.relative")
+	private String relative;
+
+	/**
+	 * Remote location for repository operations
+	 */
+	@Parameter(property = "p2manager.remote")
+	private String remote;
+
+	/**
+	 * Source repository URI to promote
+	 */
+	@Parameter(property = "p2manager.promote")
+	private String promote;
+
+	/**
+	 * Folder containing products to promote
+	 */
+	@Parameter(property = "p2manager.promoteProducts")
+	private File promoteProducts;
+
+	/**
+	 * List of download links to include in generated pages
+	 */
+	@Parameter(property = "p2manager.downloads")
+	private List<String> downloads;
+
+	/**
+	 * Build timestamp in format yyyyMMddHHmm
+	 */
+	@Parameter(property = "p2manager.timestamp")
+	private String timestamp;
+
+	/**
+	 * Build type (nightly, milestone, or release)
+	 */
+	@Parameter(property = "p2manager.type", defaultValue = "nightly")
+	private String type;
+
+	/**
+	 * Favicon URL for generated pages
+	 */
+	@Parameter(property = "p2manager.favicon", defaultValue = "https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/favicon.ico")
+	private String favicon;
+
+	/**
+	 * Title image URL for generated pages
+	 */
+	@Parameter(property = "p2manager.titleImage", defaultValue = "https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-426x100.png")
+	private String titleImage;
+
+	/**
+	 * Body image URL for generated pages
+	 */
+	@Parameter(property = "p2manager.bodyImage")
+	private String bodyImage;
+
+	/**
+	 * Target URL for generated pages
+	 */
+	@Parameter(property = "p2manager.targetUrl")
+	private String targetUrl;
+
+	/**
+	 * Baseline URL for comparison
+	 */
+	@Parameter(property = "p2manager.baselineUrl")
+	private String baselineUrl;
+
+	/**
+	 * Installable unit to use for version determination
+	 */
+	@Parameter(property = "p2manager.versionIU")
+	private String versionIU;
+
+	/**
+	 * Pattern to match IU for version determination
+	 */
+	@Parameter(property = "p2manager.versionIUPattern")
+	private String versionIUPattern;
+
+	/**
+	 * Pattern to filter installable units
+	 */
+	@Parameter(property = "p2manager.iuFilterPattern")
+	private String iuFilterPattern;
+
+	/**
+	 * Pattern to filter primary installable units
+	 */
+	@Parameter(property = "p2manager.primaryIUFilterPattern", defaultValue = ".*\\.sdk([_.-]feature)?\\.feature\\.group")
+	private String primaryIUFilterPattern;
+
+	/**
+	 * Pattern to exclude categories
+	 */
+	@Parameter(property = "p2manager.excludedCategoriesPattern")
+	private String excludedCategoriesPattern;
+
+	/**
+	 * Git commit identifier
+	 */
+	@Parameter(property = "p2manager.commit")
+	private String commit;
+
+	/**
+	 * Super target folder
+	 */
+	@Parameter(property = "p2manager.super")
+	private File superTargetFolder;
+
+	/**
+	 * Whether to use SimRel alias
+	 */
+	@Parameter(property = "p2manager.simrelAlias")
+	private boolean simrelAlias;
+
+	/**
+	 * Whether to generate BREE information
+	 */
+	@Parameter(property = "p2manager.bree")
+	private boolean bree;
+
+	/**
+	 * Summary level (0 = none)
+	 */
+	@Parameter(property = "p2manager.summary", defaultValue = "0")
+	private int summary;
+
+	/**
+	 * Pattern for summary IU filtering
+	 */
+	@Parameter(property = "p2manager.summaryIUPattern", defaultValue = ".*(?<!\\.source|\\.feature\\.group|\\.feature\\.jar)")
+	private String summaryIUPattern;
+
+	/**
+	 * Maven wrapped mappings (pattern->replacement)
+	 */
+	@Parameter(property = "p2manager.mavenWrappedMappings")
+	private List<String> mavenWrappedMappings;
+
+	/**
+	 * Name mappings (key->value)
+	 */
+	@Parameter(property = "p2manager.mappings")
+	private List<String> mappings;
+
+	/**
+	 * Commit mappings (pattern->url)
+	 */
+	@Parameter(property = "p2manager.commitMappings")
+	private List<String> commitMappings;
+
+	/**
+	 * Breadcrumbs for navigation
+	 */
+	@Parameter(property = "p2manager.breadcrumbs")
+	private List<String> breadcrumbs;
+
+	/**
+	 * Archives to include
+	 */
+	@Parameter(property = "p2manager.archives")
+	private List<String> archives;
+
+	/**
+	 * Paths to exclude
+	 */
+	@Parameter(property = "p2manager.excludes")
+	private List<String> excludes;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (root == null) {
+			throw new MojoFailureException("The 'root' parameter must be specified");
+		}
+
+		MavenRepositoryLocation repository = EclipseApplicationManager.getRepository(managerRepository,
+				URI.create("https://download.eclipse.org/justj/tools/updates/"));
+		EclipseApplication application = applicationManager.getApplication(repository, Bundles.of(), Features.of(),
+				"P2 Manager");
+		application.addFeature("org.eclipse.justj.p2.feature.group");
+		EclipseWorkspace<?> workspace = workspaceManager.getWorkspace(repository.getURL(), this);
+
+		List<String> arguments = new ArrayList<>();
+		arguments.add(EclipseApplication.ARG_APPLICATION);
+		arguments.add("org.eclipse.justj.p2.manager");
+		arguments.add("-consoleLog");
+
+		// Add flags
+		if (!verbose) {
+			arguments.add("-quiet");
+		}
+		if (latestVersionOnly) {
+			arguments.add("-latestVersionOnly");
+		}
+		if (simrelAlias) {
+			arguments.add("-simrel-alias");
+		}
+		if (bree) {
+			arguments.add("-bree");
+		}
+
+		// Add parameters with values
+		arguments.add("-root");
+		arguments.add(root.getAbsolutePath());
+
+		arguments.add("-retain");
+		arguments.add(String.valueOf(retain));
+
+		arguments.add("-label");
+		arguments.add(label);
+
+		arguments.add("-type");
+		arguments.add(type);
+
+		arguments.add("-favicon");
+		arguments.add(favicon);
+
+		arguments.add("-title-image");
+		arguments.add(titleImage);
+
+		arguments.add("-primary-iu-filter-pattern");
+		arguments.add(primaryIUFilterPattern);
+
+		arguments.add("-summary");
+		arguments.add(String.valueOf(summary));
+
+		arguments.add("-summary-iu-pattern");
+		arguments.add(summaryIUPattern);
+
+		// Add optional parameters
+		addOptionalParameter(arguments, "-build-url", buildUrl);
+		addOptionalParameter(arguments, "-relative", relative);
+		addOptionalParameter(arguments, "-remote", remote);
+		addOptionalParameter(arguments, "-promote", promote);
+		addOptionalFile(arguments, "-promote-products", promoteProducts);
+		addOptionalParameter(arguments, "-timestamp", timestamp);
+		addOptionalParameter(arguments, "-body-image", bodyImage);
+		addOptionalParameter(arguments, "-target-url", targetUrl);
+		addOptionalParameter(arguments, "-baseline-url", baselineUrl);
+		addOptionalParameter(arguments, "-version-iu", versionIU);
+		addOptionalParameter(arguments, "-version-iu-pattern", versionIUPattern);
+		addOptionalParameter(arguments, "-iu-filter-pattern", iuFilterPattern);
+		addOptionalParameter(arguments, "-excluded-categories-pattern", excludedCategoriesPattern);
+		addOptionalParameter(arguments, "-commit", commit);
+		addOptionalFile(arguments, "-super", superTargetFolder);
+
+		// Add list parameters
+		addListParameter(arguments, "-downloads", downloads);
+		addListParameter(arguments, "-maven-wrapped-mapping", mavenWrappedMappings);
+		addListParameter(arguments, "-mapping", mappings);
+		addListParameter(arguments, "-commit-mapping", commitMappings);
+		addListParameter(arguments, "-breadcrumb", breadcrumbs);
+		addListParameter(arguments, "-archive", archives);
+		addListParameter(arguments, "--exclude", excludes);
+
+		getLog().info("Calling P2 Manager application with arguments: " + arguments);
+		try (EclipseFramework framework = application.startFramework(workspace, arguments)) {
+			framework.start();
+		} catch (BundleException e) {
+			throw new MojoFailureException("Can't start framework!", e);
+		} catch (InvocationTargetException e) {
+			Throwable cause = e.getCause();
+			if (cause.getClass().getName().equals(CoreException.class.getName())
+					|| cause.getClass().getName().equals(ProvisionException.class.getName())) {
+				throw new MojoFailureException(cause.getMessage(), cause);
+			}
+			throw new MojoExecutionException(cause);
+		} catch (Exception e) {
+			throw new MojoExecutionException(e);
+		}
+	}
+
+	private void addOptionalParameter(List<String> arguments, String name, String value) {
+		if (value != null && !value.isEmpty()) {
+			arguments.add(name);
+			arguments.add(value);
+		}
+	}
+
+	private void addOptionalFile(List<String> arguments, String name, File file) {
+		if (file != null) {
+			arguments.add(name);
+			arguments.add(file.getAbsolutePath());
+		}
+	}
+
+	private void addListParameter(List<String> arguments, String name, List<String> values) {
+		if (values != null && !values.isEmpty()) {
+			for (String value : values) {
+				if (value != null && !value.trim().isEmpty()) {
+					arguments.add(name);
+					arguments.add(value.trim());
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Introduces P2ManagerMojo in tycho-p2-extras-plugin that wraps the P2 Manager application from JustJ Tools, providing a convenient Maven goal for maintaining public Eclipse p2 update sites.

The mojo automates the full update site lifecycle:
- Promoting nightly, milestone, and release builds
- Generating composite p2 repositories at each level
- Managing repository history (configurable nightly retention)
- Publishing to remote servers via rsync
- Generating browsable HTML index pages with branding options
- Promoting Tycho-built product archives alongside the repository

The new ManagingP2Sites.md documentation page covers the update site anatomy (nightly/milestone/release folder structure), the build type promotion workflow, remote publishing, version determination, and a complete parameter reference.

Documentation changes:
- src/site/markdown/ManagingP2Sites.md: new dedicated page
- src/site/markdown/BuildingSites.md: brief intro section + link
- src/site/markdown/Category.md: restored to redirect-only stub
- src/site/site.xml: added 'Managing P2 Update Sites' nav entry and 'P2 Manager Mojo' reference under 'Building P2 Update Sites'
- RELEASE_NOTES.md: release note for the new mojo