### PR TITLE
Bug: 5982 Fix spurious error and improve mirror-target-platform for non-Tycho projects

### DIFF
--- a/src/site/markdown/TargetPlatform.md
+++ b/src/site/markdown/TargetPlatform.md
@@ -43,6 +43,50 @@ Background: In a normal (i.e. non-Tycho) Maven project, one can configure Maven 
 Tycho can use p2 repositories for resolving OSGi dependencies.
 The p2 repositories need to be marked with layout=p2. (The normal Maven dependency resolution ignores repositories with layout=p2.)
 
+### Using a p2 repository deployed to a Maven repository
+
+Tycho supports the `mvn:` URL scheme to reference a p2 repository that has been packaged as a zip and deployed to a Maven repository.
+This works for any zip artifact that contains a valid p2 repository (i.e. `content.xml`/`content.jar` and `artifacts.xml`/`artifacts.jar`), regardless of how the zip was produced.
+
+The URL format is:
+
+```
+mvn:groupId:artifactId:version:zip:classifier
+```
+
+There are two ways to use such a Maven-deployed p2 zip.
+
+**Option 1 – POM `<repositories>` section (adds the whole site to the target platform):**
+
+```xml
+<repository>
+   <id>my-p2-site</id>
+   <url>mvn:com.example:target-platform:1.0.0:zip:p2site</url>
+   <layout>p2</layout>
+</repository>
+```
+
+**Option 2 – `.target` file `InstallableUnit` location (recommended; allows fine-grained unit selection):**
+
+```xml
+<location includeAllPlatforms="false" includeConfigurePhase="true"
+          includeMode="planner" includeSource="true" type="InstallableUnit">
+   <repository location="mvn:com.example:target-platform:1.0.0:zip:p2site"/>
+   <unit id="com.example.mybundle" version="0.0.0"/>
+</location>
+```
+
+**Important notes:**
+
+- The Maven artifact (`groupId:artifactId:version:zip:classifier`) must be resolvable from the local Maven repository or from a remote repository configured in the project's `<repositories>` section of the POM.
+The `mvn:` URL itself does **not** carry repository authentication or location information.
+- In Eclipse IDE, `mvn:` URLs in `.target` files require [m2e](https://eclipse.dev/m2e/) to be installed.
+- Do **not** use `<location type="Maven">` for this use case.
+`type="Maven"` resolves Maven JARs as plain OSGi bundles; it is not intended for consuming p2 repositories.
+
+Tycho's `assemble-maven-repository` goal (from `tycho-p2-repository-plugin`) produces exactly this kind of Maven-deployable p2 zip.
+See the [assemble-maven-repository mojo reference](tycho-p2-repository-plugin/assemble-maven-repository-mojo.html) for details on producing such a site.
+
 ### Target files
 
 The PDE target definition file format (`*.target`) allows to select a subset of units (bundles, features, etc.).

--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/MirrorTargetPlatformMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/MirrorTargetPlatformMojo.java
@@ -44,6 +44,7 @@ import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.TargetPlatform;
 import org.eclipse.tycho.TargetPlatformService;
+import org.eclipse.tycho.core.TychoProjectManager;
 import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 import org.eclipse.tycho.p2.repository.ListCompositeMetadataRepository;
 import org.eclipse.tycho.p2.repository.PublishingRepository;
@@ -55,9 +56,17 @@ import org.eclipse.tycho.p2maven.SlicingOptions;
 import org.eclipse.tycho.repository.registry.facade.ReactorRepositoryManager;
 
 /**
- * Supports mirroring the computed target platform of the current project, this behaves similar to
- * what PDE offers with its export deployable feature / plug-in and assembles an update site that
- * contains everything this particular project depends on.
+ * Supports mirroring the computed target platform of the current project. For
+ * {@code eclipse-plugin}, {@code eclipse-feature}, and similar Tycho packaging types this behaves
+ * similar to what PDE offers with its export deployable feature / plug-in and assembles an update
+ * site that contains everything this particular project depends on.
+ * <p>
+ * For projects that are purely a target platform definition (i.e., contain a {@code .target} file
+ * and no code artifacts), use {@code &lt;packaging&gt;eclipse-target-definition&lt;/packaging&gt;}.
+ * This will mirror the entire target platform instead of only the project's transitive
+ * dependencies. Using a different packaging type (e.g., the default {@code jar}) with this goal on
+ * a target-only project will produce an empty or incomplete repository because no installable units
+ * are published for that project.
  */
 @Mojo(name = "mirror-target-platform", threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.PACKAGE)
 public class MirrorTargetPlatformMojo extends AbstractMojo {
@@ -120,9 +129,18 @@ public class MirrorTargetPlatformMojo extends AbstractMojo {
     @Inject
     private InstallableUnitSlicer installableUnitSlicer;
 
+    @Inject
+    private TychoProjectManager tychoProjectManager;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         ReactorProject reactorProject = DefaultReactorProject.adapt(project);
+        if (tychoProjectManager.getTychoProject(project).isEmpty()) {
+            getLog().info("Project '" + project.getId() + "' (packaging '" + project.getPackaging()
+                    + "') is not a Tycho project, skipping mirror-target-platform."
+                    + " Use <packaging>eclipse-target-definition</packaging> to mirror a target platform.");
+            return;
+        }
         TargetPlatform targetPlatform = platformService.getTargetPlatform(reactorProject).orElse(null);
         if (targetPlatform == null) {
             getLog().info("Project has no target platform, skip execution.");

--- a/tycho-its/projects/p2mavensite/consumer-targetfile/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2mavensite/consumer-targetfile/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Test-mvn-updatesite-targetfile
+Bundle-SymbolicName: test.mvn.updatesite.targetfile
+Bundle-Version: 1.0.0
+Automatic-Module-Name: test.mvn.updatesite.targetfile
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: org.eclipse.jetty.http

--- a/tycho-its/projects/p2mavensite/consumer-targetfile/build.properties
+++ b/tycho-its/projects/p2mavensite/consumer-targetfile/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/p2mavensite/consumer-targetfile/pom.xml
+++ b/tycho-its/projects/p2mavensite/consumer-targetfile/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<parent>
+		<groupId>org.eclipse.tycho.it</groupId>
+		<artifactId>mvn-p2-site-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>test.mvn.updatesite.targetfile</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>test.target</file>
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2mavensite/consumer-targetfile/test.target
+++ b/tycho-its/projects/p2mavensite/consumer-targetfile/test.target
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="test" sequenceNumber="1">
+  <locations>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="mvn:org.eclipse.tycho.it:producer:1.0.0:zip:p2site"/>
+      <unit id="org.eclipse.jetty.http" version="0.0.0"/>
+    </location>
+  </locations>
+</target>

--- a/tycho-its/projects/p2mavensite/mirror-jar-packaging/mirror-test.target
+++ b/tycho-its/projects/p2mavensite/mirror-jar-packaging/mirror-test.target
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="mirror-test" sequenceNumber="1">
+  <locations>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+      <repository location="mvn:org.eclipse.tycho.it:producer:1.0.0:zip:p2site"/>
+      <unit id="org.eclipse.jetty.http" version="0.0.0"/>
+    </location>
+  </locations>
+</target>

--- a/tycho-its/projects/p2mavensite/mirror-jar-packaging/pom.xml
+++ b/tycho-its/projects/p2mavensite/mirror-jar-packaging/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<parent>
+		<groupId>org.eclipse.tycho.it</groupId>
+		<artifactId>mvn-p2-site-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>mirror-jar-packaging</artifactId>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>mirror-test.target</file>
+					</target>
+				</configuration>
+				<executions>
+					<execution>
+						<id>mirror-tp</id>
+						<goals>
+							<goal>mirror-target-platform</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2mavensite/mirror-target-definition/mirror-test.target
+++ b/tycho-its/projects/p2mavensite/mirror-target-definition/mirror-test.target
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="mirror-test" sequenceNumber="1">
+  <locations>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+      <repository location="mvn:org.eclipse.tycho.it:producer:1.0.0:zip:p2site"/>
+      <unit id="org.eclipse.jetty.http" version="0.0.0"/>
+    </location>
+  </locations>
+</target>

--- a/tycho-its/projects/p2mavensite/mirror-target-definition/pom.xml
+++ b/tycho-its/projects/p2mavensite/mirror-target-definition/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<parent>
+		<groupId>org.eclipse.tycho.it</groupId>
+		<artifactId>mvn-p2-site-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>mirror-target-definition</artifactId>
+	<packaging>eclipse-target-definition</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>mirror-tp</id>
+						<goals>
+							<goal>mirror-target-platform</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
+++ b/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
@@ -100,27 +100,52 @@ import org.eclipse.tycho.p2maven.tools.TychoFeaturesAndBundlesPublisherApplicati
  * <b>Please note:</b> Only valid OSGi bundles are included, there is no way to automatically wrap
  * plain jars and they are silently ignored. This is intentional, as the goal of a p2-maven-site is
  * to use exactly the same artifact that is deployed in the maven repository.
+ * </p>
  * <p>
- * The produced p2-maven-site can then be consumed by Tycho or PDE targets (m2eclipse is required
- * for this), in the following way: A tycho-repository section:
+ * The produced p2-maven-site can then be consumed by Tycho or PDE targets in the following ways.
+ * Note that m2eclipse is required for IDE (PDE Target Editor) support.
+ * </p>
+ * <p>
+ * <b>Option 1 – POM {@code <repositories>} section</b> (adds the entire site to the target
+ * platform):
  *
  * <pre>
- *     &lt;repository&gt;
- *     &lt;id&gt;my-p2-maven-site&lt;/id&gt;
- *         &lt;url&gt;mvn:[groupId]:[artifactId]:[version]:zip:p2site&lt;/url&gt;
- *         &lt;layout&gt;p2&lt;/layout&gt;
- *     &lt;/repository&gt;
+    &lt;repository&gt;
+        &lt;id&gt;my-p2-maven-site&lt;/id&gt;
+        &lt;url&gt;mvn:[groupId]:[artifactId]:[version]:zip:p2site&lt;/url&gt;
+        &lt;layout&gt;p2&lt;/layout&gt;
+    &lt;/repository&gt;
  * </pre>
- *
- * A target location of type software-site:
+ * </p>
+ * <p>
+ * <b>Option 2 – {@code .target} file {@code InstallableUnit} location</b> (recommended; allows
+ * fine-grained unit selection):
  *
  * <pre>
- *  &lt;location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit"&gt;
- *     &lt;repository location="mvn:[groupId]:[artifactId]:[version]:zip:p2site"/&gt;
- *     -- list desired units here --
+ *  &lt;location includeAllPlatforms="false" includeConfigurePhase="true"
+ *            includeMode="planner" includeSource="true" type="InstallableUnit"&gt;
+ *      &lt;repository location="mvn:[groupId]:[artifactId]:[version]:zip:p2site"/&gt;
+ *      &lt;!-- list desired units here --&gt;
  *  &lt;/location&gt;
  * </pre>
  *
+ * The same {@code mvn:} URL scheme works for <em>any</em> zip artifact that contains a valid p2
+ * repository (i.e. {@code content.xml}/{@code content.jar} and {@code artifacts.xml}/
+ * {@code artifacts.jar}), not only for zips produced by this goal. This means you can also consume
+ * a self-contained p2 repository zip that was exported from the Eclipse IDE or built with another
+ * tool, as long as it was deployed to a Maven repository.
+ * </p>
+ * <p>
+ * <b>Important:</b> Do <em>not</em> use {@code &lt;location type="Maven"&gt;} for this purpose.
+ * That location type resolves Maven JARs as plain OSGi bundles and is not intended for consuming p2
+ * repositories.
+ * </p>
+ * <p>
+ * The Maven artifact referenced by a {@code mvn:} URL must be resolvable from the local Maven
+ * repository or from a remote repository configured in the project's {@code <repositories>}
+ * section. The {@code mvn:} URL itself does not carry repository location or authentication
+ * information.
+ * </p>
  */
 @Mojo(name = "assemble-maven-repository", requiresDependencyResolution = ResolutionScope.COMPILE)
 public class MavenP2SiteMojo extends AbstractMojo {


### PR DESCRIPTION
 When mirror-target-platform runs on a non-Tycho project (e.g. jar
 packaging), it called getPublishingRepository() which triggered a
 generateMetaData() fallback, causing ModuleArtifactRepository to
 log a spurious [ERROR] about a missing p2artifacts classifier.

 Fix by checking TychoProjectManager.getTychoProject() early in
 execute(): if the project is not a Tycho project, log an info message
 pointing to eclipse-target-definition packaging and skip execution.

 Also improve mojo Javadoc and add integration tests covering both
 eclipse-target-definition mirroring and the jar-packaging skip case.