### PR TITLE
Test CI-friendly major, minor, micro versions

### DIFF
--- a/src/site/markdown/TychoCiFriendly.md
+++ b/src/site/markdown/TychoCiFriendly.md
@@ -36,7 +36,11 @@ That way you can configure your POM in the following way:
 ```
 
 What will result in the usual `1.0.0-SNAPSHOT` for a regular `mvn clean install`, if you want to do a release, you can now simply call `mvn -Dtycho.buildqualifier.format=yyyyMMddHHmm clean deploy`
-and your artifact will get the `1.0.0-<formatted qualifier>` version when published! This also is supported if you use pomless build.
+and your artifact will get the `1.0.0-<formatted qualifier>` version when published! This also is supported if you use pomless build. To change release version, disable "tycho.strictVersions" check to ignore conflict with MANIFEST.MF and feature.xml:
+
+```
+mvn -Dtycho.buildqualifier.format=yyyyMMddHHmm -DreleaseVersion=2.0.0 -Dtycho.strictVersions=false clean deploy
+```
 
 To use this new feature you need to enable the tycho-build extension with the `.mvn/extensions.xml` file in the root of your project directory:
 

--- a/tycho-its/projects/ci-friendly/validateVersion/.mvn/extensions.xml
+++ b/tycho-its/projects/ci-friendly/validateVersion/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>${tycho-version}</version>
+	</extension>
+</extensions>

--- a/tycho-its/projects/ci-friendly/validateVersion/bundles/org.example.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/ci-friendly/validateVersion/bundles/org.example.bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Example Bundle
+Bundle-SymbolicName: org.example.bundle
+Bundle-Version: 0.0.6.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Automatic-Module-Name: org.example.bundle

--- a/tycho-its/projects/ci-friendly/validateVersion/bundles/org.example.bundle/build.properties
+++ b/tycho-its/projects/ci-friendly/validateVersion/bundles/org.example.bundle/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/ci-friendly/validateVersion/bundles/org.example.bundle/pom.xml
+++ b/tycho-its/projects/ci-friendly/validateVersion/bundles/org.example.bundle/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>tycho-its-project.ci-friendly.validateVersion</groupId>
+		<artifactId>parent</artifactId>
+		<version>${revision}</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.example.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/ci-friendly/validateVersion/features/org.example.feature/build.properties
+++ b/tycho-its/projects/ci-friendly/validateVersion/features/org.example.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/ci-friendly/validateVersion/features/org.example.feature/feature.xml
+++ b/tycho-its/projects/ci-friendly/validateVersion/features/org.example.feature/feature.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.example.feature"
+      label="Example Feature"
+      version="0.0.6.qualifier">
+
+   <description url="https://github.com/eclipse-tycho/tycho">
+      Test feature for CI-friendly version validation.
+   </description>
+
+</feature>

--- a/tycho-its/projects/ci-friendly/validateVersion/features/org.example.feature/pom.xml
+++ b/tycho-its/projects/ci-friendly/validateVersion/features/org.example.feature/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>tycho-its-project.ci-friendly.validateVersion</groupId>
+		<artifactId>parent</artifactId>
+		<version>${revision}</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.example.feature</artifactId>
+	<packaging>eclipse-feature</packaging>
+</project>

--- a/tycho-its/projects/ci-friendly/validateVersion/pom.xml
+++ b/tycho-its/projects/ci-friendly/validateVersion/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>tycho-its-project.ci-friendly.validateVersion</groupId>
+	<artifactId>parent</artifactId>
+	<version>${revision}</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<revision>0.0.6-SNAPSHOT</revision>
+	</properties>
+
+	<modules>
+		<module>bundles/org.example.bundle</module>
+		<module>features/org.example.feature</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.List;
@@ -24,6 +26,7 @@ import java.util.TimeZone;
 import java.util.jar.JarFile;
 
 import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
 import org.osgi.framework.Constants;
@@ -116,4 +119,96 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 			assertEquals(expectedVersion, jarFile.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION));
 		}
 	}
+
+	@Test
+	public void testValidateVersionDefaultRevision() throws Exception {
+		Verifier verifier = getVerifier("ci-friendly/validateVersion", false);
+		Path basedir = Path.of(verifier.getBasedir());
+
+		// Pre-build: verify source MANIFEST.MF and feature.xml have 0.0.6.qualifier
+		Path manifest = basedir.resolve("bundles/org.example.bundle/META-INF/MANIFEST.MF");
+		assertTrue("MANIFEST.MF should contain 0.0.6.qualifier",
+				Files.readString(manifest).contains("Bundle-Version: 0.0.6.qualifier"));
+		Path featureXml = basedir.resolve("features/org.example.feature/feature.xml");
+		Feature sourceFeature = Feature.read(featureXml.toFile());
+		assertEquals("0.0.6.qualifier", sourceFeature.getVersion());
+
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+
+		// Post-build: verify built bundle jar has expanded Bundle-Version
+		Path bundleJar = basedir.resolve("bundles/org.example.bundle/target/org.example.bundle-0.0.6-SNAPSHOT.jar");
+		assertTrue("Bundle jar not found: " + bundleJar, Files.isRegularFile(bundleJar));
+		try (JarFile jar = new JarFile(bundleJar.toFile())) {
+			String bundleVersion = jar.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION);
+			assertTrue("Bundle-Version should start with 0.0.6: " + bundleVersion, bundleVersion.startsWith("0.0.6."));
+		}
+
+		// Post-build: verify built feature jar has expanded version
+		Path featureJar = basedir.resolve("features/org.example.feature/target/org.example.feature-0.0.6-SNAPSHOT.jar");
+		assertTrue("Feature jar not found: " + featureJar, Files.isRegularFile(featureJar));
+		Feature builtFeature = Feature.readJar(featureJar.toFile());
+		assertTrue("Feature version should start with 0.0.6: " + builtFeature.getVersion(),
+				builtFeature.getVersion().startsWith("0.0.6."));
+	}
+
+	@Test
+	public void testValidateVersionOverriddenRevisionFeature() throws Exception {
+		Verifier verifier = getVerifier("ci-friendly/validateVersion", false);
+		verifier.addCliOption("-Drevision=0.0.7-SNAPSHOT");
+		verifier.addCliOption("-Dtycho.strictVersions=false");
+		verifier.addCliOption("-pl features/org.example.feature -am");
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+
+		Path basedir = Path.of(verifier.getBasedir());
+		Path featureJar = basedir.resolve("features/org.example.feature/target/org.example.feature-0.0.7-SNAPSHOT.jar");
+		assertTrue("Feature jar not found: " + featureJar, Files.isRegularFile(featureJar));
+		Feature builtFeature = Feature.readJar(featureJar.toFile());
+		assertTrue("Feature version should start with 0.0.7: " + builtFeature.getVersion(),
+				builtFeature.getVersion().startsWith("0.0.7."));
+	}
+
+	@Test
+	public void testValidateVersionOverriddenRevisionBundle() throws Exception {
+		Verifier verifier = getVerifier("ci-friendly/validateVersion", false);
+		verifier.addCliOption("-Drevision=0.0.7-SNAPSHOT");
+		verifier.addCliOption("-Dtycho.strictVersions=false");
+		verifier.addCliOption("-pl bundles/org.example.bundle -am");
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+
+		Path basedir = Path.of(verifier.getBasedir());
+		Path bundleJar = basedir.resolve("bundles/org.example.bundle/target/org.example.bundle-0.0.7-SNAPSHOT.jar");
+		assertTrue("Bundle jar not found: " + bundleJar, Files.isRegularFile(bundleJar));
+		try (JarFile jar = new JarFile(bundleJar.toFile())) {
+			String bundleVersion = jar.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION);
+			assertTrue("Bundle-Version should start with 0.0.7: " + bundleVersion, bundleVersion.startsWith("0.0.7."));
+		}
+	}
+
+	@Test
+	public void testValidateVersionOverriddenRevisionFullReactor() throws Exception {
+		Verifier verifier = getVerifier("ci-friendly/validateVersion", false);
+		verifier.addCliOption("-Drevision=0.0.7-SNAPSHOT");
+		verifier.addCliOption("-Dtycho.strictVersions=false");
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+
+		Path basedir = Path.of(verifier.getBasedir());
+
+		Path bundleJar = basedir.resolve("bundles/org.example.bundle/target/org.example.bundle-0.0.7-SNAPSHOT.jar");
+		assertTrue("Bundle jar not found: " + bundleJar, Files.isRegularFile(bundleJar));
+		try (JarFile jar = new JarFile(bundleJar.toFile())) {
+			String bundleVersion = jar.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION);
+			assertTrue("Bundle-Version should start with 0.0.7: " + bundleVersion, bundleVersion.startsWith("0.0.7."));
+		}
+
+		Path featureJar = basedir.resolve("features/org.example.feature/target/org.example.feature-0.0.7-SNAPSHOT.jar");
+		assertTrue("Feature jar not found: " + featureJar, Files.isRegularFile(featureJar));
+		Feature builtFeature = Feature.readJar(featureJar.toFile());
+		assertTrue("Feature version should start with 0.0.7: " + builtFeature.getVersion(),
+				builtFeature.getVersion().startsWith("0.0.7."));
+	}
+
 }


### PR DESCRIPTION
Ensure CI-friendly versions override any version information from OSGI manifests.

These tests demonstrate, that using `tycho.strictVersions=false` is enough to achieve dynamic P2 artifact version override.

Update documentation to clarify the need for `strictVersions`.

See #6041
