### PR TITLE
Fix several issues with the P2ManagerMojo #6095

### DIFF
--- a/demo/promote-p2/.mvn/extensions.xml
+++ b/demo/promote-p2/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>${tycho-version}</version>
+  </extension>
+</extensions>
+

--- a/demo/promote-p2/README.md
+++ b/demo/promote-p2/README.md
@@ -1,0 +1,11 @@
+Promote Repository to Eclipse Update Site
+=========================================
+
+This example shows how to promote the created Eclipse repository using the p2 manager. For testing purposes, the update site is created locally and can be found under `promotion/target/updatesite`.
+
+It contains the following projects:
+
+- tycho.demo.plugin - the example plug-in project to be published to the update site
+- tycho.demo.feature - the example feature  project to be published to the update site
+- repository - responsible for creating the p2 repository
+- promotion - responsible for promoting to the update site

--- a/demo/promote-p2/features/tycho.demo.feature/build.properties
+++ b/demo/promote-p2/features/tycho.demo.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/demo/promote-p2/features/tycho.demo.feature/feature.xml
+++ b/demo/promote-p2/features/tycho.demo.feature/feature.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="tycho.demo.feature"
+      label="Tycho Demo Feature"
+      version="1.0.0.qualifier">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="tycho.demo.plugin"
+         version="0.0.0"/>
+
+</feature>

--- a/demo/promote-p2/plugins/tycho.demo.plugin/META-INF/MANIFEST.MF
+++ b/demo/promote-p2/plugins/tycho.demo.plugin/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tycho Demo Plugin
+Bundle-SymbolicName: tycho.demo.plugin
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: tycho.demo.plugin
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/demo/promote-p2/plugins/tycho.demo.plugin/build.properties
+++ b/demo/promote-p2/plugins/tycho.demo.plugin/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/demo/promote-p2/pom.xml
+++ b/demo/promote-p2/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>tycho-demo</groupId>
+	<artifactId>promote-p2-repository</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<tycho-version>5.0.3</tycho-version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+	
+	<modules>
+		<module>features</module>
+		<module>plugins</module>
+		<module>repository</module>
+		<module>promotion</module>
+	</modules>
+</project>

--- a/demo/promote-p2/promotion/pom.xml
+++ b/demo/promote-p2/promotion/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>promotion</artifactId>
+	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>tycho-demo</groupId>
+		<artifactId>promote-p2-repository</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	
+	<dependencies>
+		<dependency>
+			<groupId>tycho-demo</groupId>
+			<artifactId>repository.eclipse-repository</artifactId>
+			<version>${project.version}</version>
+			<type>eclipse-repository</type>
+		</dependency>
+	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-p2-extras-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>promote-build</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>p2-manager</goal>
+						</goals>
+						<configuration>
+							<root>${project.build.directory}/updatesite</root>
+							<promote>${project.baseUri}../repository/target/repository</promote>
+							<timestamp>${maven.build.timestamp}</timestamp>
+							<type>nightly</type>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/demo/promote-p2/repository/category.xml
+++ b/demo/promote-p2/repository/category.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature id="tycho.demo.feature"/>
+</site>

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/P2ManagerMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/P2ManagerMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Christoph Läubrich and others.
+ * Copyright (c) 2025, 2026 Christoph Läubrich and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,19 +18,21 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.maven.model.Repository;
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.tycho.MavenRepositoryLocation;
+import org.eclipse.tycho.TargetPlatform;
+import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.osgi.framework.Bundles;
-import org.eclipse.tycho.osgi.framework.DefaultEclipseApplicationManager;
 import org.eclipse.tycho.osgi.framework.EclipseApplication;
+import org.eclipse.tycho.osgi.framework.EclipseApplicationFactory;
 import org.eclipse.tycho.osgi.framework.EclipseApplicationManager;
 import org.eclipse.tycho.osgi.framework.EclipseFramework;
 import org.eclipse.tycho.osgi.framework.EclipseWorkspace;
@@ -46,18 +48,28 @@ import org.osgi.framework.BundleException;
  */
 @Mojo(name = "p2-manager", threadSafe = true, requiresProject = false)
 public class P2ManagerMojo extends AbstractMojo {
+	private static final String JUST_TOOLS_NIGHTLY = "https://download.eclipse.org/justj/tools/updates/nightly/latest";
 
-	@Component
+	@Inject
 	private EclipseWorkspaceManager workspaceManager;
 
-	@Component
+	@Inject
 	private EclipseApplicationManager applicationManager;
+
+	@Inject
+	private EclipseApplicationFactory applicationFactory;
 
 	/**
 	 * The repository where the P2 Manager application should be sourced from
 	 */
 	@Parameter
 	private Repository managerRepository;
+
+	/**
+	 * The repository where the Eclipse IDE should be sourced from
+	 */
+	@Parameter
+	private Repository eclipseRepository;
 
 	/**
 	 * Whether to print progress during the activities (opposite of -quiet flag)
@@ -98,7 +110,7 @@ public class P2ManagerMojo extends AbstractMojo {
 	/**
 	 * Relative target folder within the root
 	 */
-	@Parameter(property = "p2manager.relative")
+	@Parameter(property = "p2manager.relative", defaultValue = "updates")
 	private String relative;
 
 	/**
@@ -275,11 +287,14 @@ public class P2ManagerMojo extends AbstractMojo {
 			throw new MojoFailureException("The 'root' parameter must be specified");
 		}
 
-		MavenRepositoryLocation repository = DefaultEclipseApplicationManager.getRepository(managerRepository,
-				URI.create("https://download.eclipse.org/justj/tools/updates/"));
-		EclipseApplication application = applicationManager.getApplication(repository, Bundles.of(), Features.of(),
-				"P2 Manager");
-		application.addFeature("org.eclipse.justj.p2.feature.group");
+		MavenRepositoryLocation eclipseLocation = getEclipseLocation();
+		MavenRepositoryLocation repository = getManagerLocation();
+		TargetPlatform targetPlatform = applicationFactory.createTargetPlatform(
+				List.of(eclipseLocation, repository));
+		EclipseApplication application = applicationManager.getApplication(
+				targetPlatform, Bundles.of(), Features.of(), "P2 Manager");
+		application.addBundle("org.eclipse.justj.p2");
+		application.addBundle("org.apache.felix.scr");
 		EclipseWorkspace<?> workspace = workspaceManager.getWorkspace(repository.getURL(), this);
 
 		List<String> arguments = new ArrayList<>();
@@ -329,9 +344,11 @@ public class P2ManagerMojo extends AbstractMojo {
 		arguments.add("-summary-iu-pattern");
 		arguments.add(summaryIUPattern);
 
+		arguments.add("-relative");
+		arguments.add(relative);
+
 		// Add optional parameters
 		addOptionalParameter(arguments, "-build-url", buildUrl);
-		addOptionalParameter(arguments, "-relative", relative);
 		addOptionalParameter(arguments, "-remote", remote);
 		addOptionalParameter(arguments, "-promote", promote);
 		addOptionalFile(arguments, "-promote-products", promoteProducts);
@@ -395,5 +412,23 @@ public class P2ManagerMojo extends AbstractMojo {
 				}
 			}
 		}
+	}
+
+	private MavenRepositoryLocation getManagerLocation() {
+		if (managerRepository == null) {
+			return new MavenRepositoryLocation(null,
+					URI.create(JUST_TOOLS_NIGHTLY));
+		}
+		return new MavenRepositoryLocation(managerRepository.getId(),
+				managerRepository.getLocation());
+	}
+
+	private MavenRepositoryLocation getEclipseLocation() {
+		if (eclipseRepository == null) {
+			return new MavenRepositoryLocation(null,
+					URI.create(TychoConstants.ECLIPSE_LATEST));
+		}
+		return new MavenRepositoryLocation(eclipseRepository.getId(),
+				eclipseRepository.getLocation());
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/DemoTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/DemoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Christoph Läubrich and others.
+ * Copyright (c) 2023, 2026 Christoph Läubrich and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -150,6 +150,15 @@ public class DemoTest extends AbstractTychoIntegrationTest {
 	@Test
 	public void testTychoPublishP2Demo() throws Exception {
 		runDemo("publish-p2");
+	}
+
+	@Test
+	public void testTychoPromoteP2Demo() throws Exception {
+		Verifier verifier = runDemo("promote-p2");
+		String expectedLocation = "promotion/target/updatesite/updates/index.html";
+		Path indexHtml = Path.of(verifier.getBasedir(), expectedLocation);
+		assertTrue("Did not find HTML page for update site at expected location: " + expectedLocation,
+				Files.exists(indexHtml));
 	}
 
 	@Test


### PR DESCRIPTION
Trying to start the P2 Manager for promoting a repository using the P2ManagerMojo currently fails for the following reason:

- The URL for fetching the JustJ tools doesn't point to a valid p2 repository. This is now customizable via already existing
`managerRepository` property, where consumers can specify the update site to use. By default, the latest JustJ tools are used.

- In order to launch the JustJ tools, a version of the Eclipse IDE needs to be specified as well. This can now be customized via the new `eclipseRepository` property and falls back to the "latest" release by default.

- The `relative` parameter is required. If not set, `updates` is used as relative path.

- The P2 Manager application must require the `org.eclipse.justj.p2` and the `org.apache.felix.scr` plug-ins, instead of the non-existing `org.eclipse.justj.p2.feature.group` feature.

Closes https://github.com/eclipse-tycho/tycho/issues/6095
