### PR TITLE
Fix double URL-encoding of paths with spaces in category-p2-metadata

### DIFF
--- a/tycho-its/projects/categoryP2Metadata.pathWithSpaces/build.properties
+++ b/tycho-its/projects/categoryP2Metadata.pathWithSpaces/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/categoryP2Metadata.pathWithSpaces/category.xml
+++ b/tycho-its/projects/categoryP2Metadata.pathWithSpaces/category.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature url="features/category.pathwithspaces_1.0.0.jar" id="category.pathwithspaces" version="1.0.0">
+      <category name="custom"/>
+   </feature>
+   <category-def name="custom" label="Custom Category"/>
+</site>

--- a/tycho-its/projects/categoryP2Metadata.pathWithSpaces/feature.xml
+++ b/tycho-its/projects/categoryP2Metadata.pathWithSpaces/feature.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="category.pathwithspaces"
+      label="Category Path With Spaces Feature"
+      version="1.0.0">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+</feature>

--- a/tycho-its/projects/categoryP2Metadata.pathWithSpaces/pom.xml
+++ b/tycho-its/projects/categoryP2Metadata.pathWithSpaces/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>tycho-its-project.category.pathWithSpaces</groupId>
+  <artifactId>category.pathwithspaces</artifactId>
+  <version>1.0.0</version>
+  <packaging>eclipse-feature</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <environments>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+          </environments>
+        </configuration>
+        <executions>
+          <execution>
+            <id>inject</id>
+            <goals>
+              <goal>mirror-target-platform</goal>
+            </goals>
+            <configuration>
+              <!-- update site path contains a space to reproduce the double URL-encoding
+                   in category-p2-metadata (space -> %20 -> %2520) -->
+              <destination>${project.build.directory}/site with space</destination>
+              <includeCategories>false</includeCategories>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <executions>
+          <execution>
+            <id>category</id>
+            <goals>
+              <goal>category-p2-metadata</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <target>${project.build.directory}/site with space</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/CategoryP2MetadataPathWithSpacesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/CategoryP2MetadataPathWithSpacesTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.test;
+
+import java.io.File;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.apache.maven.it.Verifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.Element;
+
+/**
+ * category-p2-metadata must also work when the update site path contains a space
+ * (e.g. a Jenkins workspace named "My Build"). The mojo passes the site location
+ * as an already-encoded URI string to URIUtil.fromString, which is documented for
+ * unencoded strings, so a naive toURI() double-encodes the space (%20 -&gt; %2520)
+ * and the publisher fails with "P2 publisher return code was 1".
+ */
+public class CategoryP2MetadataPathWithSpacesTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testCategoryWithSpaceInPath() throws Exception {
+		Verifier verifier = getVerifier("categoryP2Metadata.pathWithSpaces");
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+
+		File site = new File(verifier.getBasedir(), "target/site with space");
+		Assert.assertTrue(site.getAbsolutePath() + " is not a directory!", site.isDirectory());
+
+		File content = new File(site, "content.jar");
+		Assert.assertTrue(content.getAbsolutePath() + " is not a file!", content.isFile());
+
+		boolean found = false;
+		Document document;
+		try (ZipFile contentJar = new ZipFile(content)) {
+			ZipEntry contentXmlEntry = contentJar.getEntry("content.xml");
+			document = Document.of(contentJar.getInputStream(contentXmlEntry));
+		}
+		Element repository = document.root();
+		all_units: for (Element unit : repository.childElement("units").orElse(null).childElements("unit").toList()) {
+			for (Element property : unit.childElement("properties").orElse(null).childElements("property").toList()) {
+				if ("org.eclipse.equinox.p2.type.category".equals(property.attribute("name"))
+						&& Boolean.parseBoolean(property.attribute("value"))) {
+					found = true;
+					break all_units;
+				}
+			}
+		}
+
+		Assert.assertTrue("Custom category is missing: " + content.getAbsolutePath(), found);
+	}
+
+}

--- a/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/CategoryP2MetadataMojo.java
+++ b/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/CategoryP2MetadataMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.internal.repository.tools.XZCompressor;
 import org.eclipse.tycho.p2tools.copiedfromp2.CategoryPublisherApplication;
@@ -51,9 +52,9 @@ public class CategoryP2MetadataMojo extends AbstractP2MetadataMojo {
     protected void addArguments(List<String> arguments) throws IOException, MalformedURLException {
         File location = getUpdateSiteLocation();
         arguments.add("-metadataRepository");
-        arguments.add(location.toURI().toURL().toExternalForm());
+        arguments.add(URIUtil.toUnencodedString(location.toURI()));
         arguments.add("-categoryDefinition");
-        arguments.add(categoryDefinition.toURI().toURL().toExternalForm());
+        arguments.add(URIUtil.toUnencodedString(categoryDefinition.toURI()));
     }
 
     @Override


### PR DESCRIPTION
## Problem
  `tycho-p2-plugin:category-p2-metadata` fails when the build/output path contains a space
  (or any character requiring percent-encoding), e.g. a Jenkins workspace named `My Build`:

  ProvisionException: Error reading update site file:/.../my%2520site/category.xml
   -> "P2 publisher return code was 1"

  ## Root cause
  `CategoryP2MetadataMojo#addArguments` emits the `-metadataRepository` / `-categoryDefinition`
  arguments via `toURI().toURL().toExternalForm()` — an **encoded** URI string (space → `%20`).
  `CategoryPublisherApplication` / `AbstractPublisherApplication` then parse them with
  `org.eclipse.core.runtime.URIUtil.fromString(String)`, whose javadoc states it is for
  **unencoded** strings and:

  > *This method must not be called with a string that already contains an encoded URI,
  > since this will result in the URI escape character ('%') being escaped itself.*

  So `%20` is re-encoded to `%2520`, and the publisher looks for a non-existent directory
  literally named `my%20site`.

  ## Fix
  Use `URIUtil.toUnencodedString(URI)` — the documented counterpart of `URIUtil.fromString` —
  so producer and consumer use the matching encoding convention. Verified that the same
  `fromString` logic then yields correct single-encoding on both Windows and Linux.

  ## Reproduction (independent of any wrapper plugin)
  1. Take a p2 metadata repo (`content.jar` + `artifacts.jar`) and a `category.xml`, placed under
     a directory whose absolute path contains a space, e.g. `.../my site/repository/`.
  2. Run `tycho-p2-plugin:category-p2-metadata` with `target` = that repo dir and
     `categoryDefinition` = that `category.xml`.
  3. It fails as above; the same inputs under a space-free path succeed.

  ## Affected
  Reproduced with 5.0.3; the offending code is unchanged on `main`.

  Related: #5939, #652 (same family of path-encoding issues, different code path).