### PR TITLE
Add missing version-ranges to implicit imports of tycho.surefire.junit5

### DIFF
--- a/tycho-surefire/org.eclipse.tycho.surefire.junit6/bnd.bnd
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit6/bnd.bnd
@@ -3,11 +3,11 @@
 # Apart from that the content in this bundle is only used to bootstrap
 # surefire and we include all we need for that as it does not comply with OSGi rules.
 Import-Package: \
- org.junit.platform.launcher, \
- org.junit.jupiter.api, \
- org.junit.jupiter.engine, \
- org.junit.platform.suite.api, \
- org.junit.platform.suite.engine;status=INTERNAL, \
+ org.junit.platform.launcher;version="[6,7)", \
+ org.junit.jupiter.api;version="[6,7)", \
+ org.junit.jupiter.engine;version="[6,7)", \
+ org.junit.platform.suite.api;version="[6,7)", \
+ org.junit.platform.suite.engine;status=INTERNAL;version="[6,7)", \
  java.*
 Fragment-Host: org.eclipse.tycho.surefire.osgibooter
 # The JUnit Runner is still compatible with Java 1.8, as all included upstream dependencies are.


### PR DESCRIPTION
Without them Junit-6+ (e.g. of a future JUnit-7) bundles would automatically be added to the test-runtime, even if the tested project actually only depends on junit-6 packages/bundles.
The only way to prevent it, was to add implicitly required platform and engine bundles explicitly to the test projects.

Currently this isn't a problem, but probably will be one if a future JUnit-7 will be released (assuming it uses the same package names), like it was a problem with JUnit-5 after the JUnit-6 release:
- https://github.com/eclipse-tycho/tycho/pull/5526