### PR TITLE
Add debugPort parameter to bnd-test Mojo

### DIFF
--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/BndTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/BndTestMojo.java
@@ -192,6 +192,13 @@ public class BndTestMojo extends AbstractTestMojo {
     @Parameter(defaultValue = ENGINES_DEFAULT, required = true)
     private String testEngines;
 
+    /**
+     * Set this parameter to suspend the test JVM waiting for a client to open a remote debug
+     * session on the specified port.
+     */
+    @Parameter(property = "debugPort")
+    private int debugPort;
+
     @Inject
     private BundleReader bundleReader;
 
@@ -230,6 +237,9 @@ public class BndTestMojo extends AbstractTestMojo {
         properties.setProperty(Constants.RUNTRACE, String.valueOf(trace));
         properties.setProperty(Constants.RUNFW, runfw);
         properties.setProperty(Constants.RUNPROPERTIES, buildRunProperties());
+        if (debugPort > 0) {
+            properties.setProperty("-runjdb", "+localhost:" + debugPort);
+        }
         try {
             ReproducibleUtils.storeProperties(properties, runfile.toPath());
             String javaExecutable = getJavaExecutable();


### PR DESCRIPTION
Similar to the existing `debugPort` parameter of the other `test`/`verify` mojo of this `tycho-surefire-plugin`.