### PR TITLE
Only require IDE application bundle for UI harness default application

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,12 @@ If you are reading this in the browser, then you can quickly jump to specific ve
 
 ## 6.0.0 (under development)
 
+### UI test harness no longer requires the IDE application bundle when a custom application is configured
+
+Previously `tycho-surefire-plugin` always added a requirement on the `org.eclipse.ui.ide.application` bundle to the test runtime when `useUIHarness` was enabled, even if a custom `application` was configured.
+This made it impossible to run UI tests against RCP applications whose target platform does not contain the Eclipse IDE bundles.
+The `org.eclipse.ui.ide.application` bundle is now only required if no `application` is configured and the default application `org.eclipse.ui.ide.workbench` is used, otherwise only `org.eclipse.ui.workbench` is required.
+
 ### new `tycho-p2-extras:p2-manager` mojo for managing P2 update sites
 
 The new `tycho-p2-extras:p2-manager` goal provides a convenient way to maintain, update, and manage the integrity of public update sites. This mojo wraps the [P2 Manager application from JustJ Tools](https://eclipse.dev/justj/?page=tools) and makes it much easier to use compared to the previous approach using the eclipse-run goal.

--- a/tycho-its/projects/surefire.uiHarness.customApplication/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.uiHarness.customApplication/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: UI harness with custom application
+Bundle-SymbolicName: tycho.its.surefire.uiharness.customapp
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Require-Bundle: org.junit,
+ org.eclipse.core.runtime

--- a/tycho-its/projects/surefire.uiHarness.customApplication/build.properties
+++ b/tycho-its/projects/surefire.uiHarness.customApplication/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/surefire.uiHarness.customApplication/pom.xml
+++ b/tycho-its/projects/surefire.uiHarness.customApplication/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project.surefire.uiharness.customapplication</groupId>
+	<artifactId>tycho.its.surefire.uiharness.customapp</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-test-plugin</packaging>
+
+	<repositories>
+		<repository>
+			<id>platform</id>
+			<url>${target-platform}</url>
+			<layout>p2</layout>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<filters>
+						<!-- an RCP target platform without the Eclipse IDE bundles -->
+						<filter>
+							<type>eclipse-plugin</type>
+							<id>org.eclipse.ui.ide.application</id>
+							<removeAll />
+						</filter>
+					</filters>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<useUIHarness>true</useUIHarness>
+					<application>tycho.its.uiharness.customapp</application>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/surefire.uiHarness.customApplication/src/tycho/its/uiharness/CustomApplicationTest.java
+++ b/tycho-its/projects/surefire.uiHarness.customApplication/src/tycho/its/uiharness/CustomApplicationTest.java
@@ -1,0 +1,18 @@
+package tycho.its.uiharness;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.core.runtime.Platform;
+import org.junit.Test;
+
+/**
+ * Not executed by this integration test, the configured application does not exist, but the test
+ * runtime must contain at least one test class to be launched at all.
+ */
+public class CustomApplicationTest {
+
+	@Test
+	public void platformIsRunning() {
+		assertNotNull(Platform.getBundle("org.eclipse.core.runtime"));
+	}
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/UIHarnessCustomApplicationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/UIHarnessCustomApplicationTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Lars Vogel - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.surefire;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a UI test runtime with a custom application resolves and starts without the Eclipse
+ * IDE bundles, as required by RCP applications.
+ */
+public class UIHarnessCustomApplicationTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testCustomApplicationDoesNotRequireIdeBundles() throws Exception {
+		Verifier verifier = getVerifier("surefire.uiHarness.customApplication");
+		verifier.addCliOption("-Dtycho.printBundles=true");
+
+		// the configured application does not exist, so the launch fails once the runtime is up
+		assertThrows(VerificationException.class, () -> verifier.executeGoal("integration-test"));
+		verifier.verifyTextInLog("Could not find application \"tycho.its.uiharness.customapp\"");
+
+		List<String> installedBundles = installedBundles(verifier);
+		assertFalse(installedBundles.isEmpty(), "test runtime did not report its installed bundles");
+		assertTrue(installedBundles.stream().anyMatch(line -> line.contains("org.eclipse.ui.workbench ")),
+				"UI test harness requires org.eclipse.ui.workbench: " + installedBundles);
+		assertFalse(installedBundles.stream().anyMatch(line -> line.contains("org.eclipse.ui.ide.application ")),
+				"test runtime must not contain the IDE application bundle: " + installedBundles);
+	}
+
+	private static List<String> installedBundles(Verifier verifier) throws VerificationException {
+		List<String> lines = verifier.loadFile(verifier.getBasedir(), verifier.getLogFileName(), false);
+		int start = indexOfLineContaining(lines, "====== Installed Bundles ========", 0);
+		if (start < 0) {
+			return List.of();
+		}
+		int end = indexOfLineContaining(lines, "=================================", start + 1);
+		return lines.subList(start + 1, end < 0 ? lines.size() : end);
+	}
+
+	private static int indexOfLineContaining(List<String> lines, String text, int fromIndex) {
+		for (int i = fromIndex; i < lines.size(); i++) {
+			if (lines.get(i).contains(text)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+}

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -890,7 +890,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         return dependencies;
     }
 
-    private List<ArtifactKey> getTestDependencies() {
+    List<ArtifactKey> getTestDependencies() {
         ArrayList<ArtifactKey> result = new ArrayList<>();
 
         // The test harness dependencies must be satisfiable from the external target platform
@@ -898,10 +898,14 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         // where the harness bundles are part of the same reactor (e.g. when building eclipse.platform.ui)
         result.add(newBundleDependency("org.eclipse.osgi"));
         result.add(newBundleDependency(DefaultEquinoxInstallationDescription.EQUINOX_LAUNCHER));
+        result.add(newBundleDependency("org.eclipse.core.runtime"));
         if (useUIHarness) {
-            result.add(newBundleDependency("org.eclipse.ui.ide.application"));
-        } else {
-            result.add(newBundleDependency("org.eclipse.core.runtime"));
+            if (application == null) {
+                // only the default application org.eclipse.ui.ide.workbench needs the IDE bundles
+                result.add(newBundleDependency("org.eclipse.ui.ide.application"));
+            } else {
+                result.add(newBundleDependency("org.eclipse.ui.workbench"));
+            }
         }
 
         return result;

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -898,7 +898,7 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         return dependencies;
     }
 
-    private List<ArtifactKey> getTestDependencies() {
+    List<ArtifactKey> getTestDependencies() {
         ArrayList<ArtifactKey> result = new ArrayList<>();
 
         // The test harness dependencies must be satisfiable from the external target platform
@@ -906,10 +906,14 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         // where the harness bundles are part of the same reactor (e.g. when building eclipse.platform.ui)
         result.add(newBundleDependency("org.eclipse.osgi"));
         result.add(newBundleDependency(DefaultEquinoxInstallationDescription.EQUINOX_LAUNCHER));
+        result.add(newBundleDependency("org.eclipse.core.runtime"));
         if (useUIHarness) {
-            result.add(newBundleDependency("org.eclipse.ui.ide.application"));
-        } else {
-            result.add(newBundleDependency("org.eclipse.core.runtime"));
+            if (application == null) {
+                // only the default application org.eclipse.ui.ide.workbench needs the IDE bundles
+                result.add(newBundleDependency("org.eclipse.ui.ide.application"));
+            } else {
+                result.add(newBundleDependency("org.eclipse.ui.workbench"));
+            }
         }
 
         return result;

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.util.ReflectionUtils;
 import org.eclipse.sisu.equinox.launching.DefaultEquinoxInstallationDescription;
 import org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxInstallation;
 import org.eclipse.sisu.equinox.launching.internal.EquinoxLaunchConfiguration;
+import org.eclipse.tycho.ArtifactKey;
 import org.junit.Test;
 
 public class TestMojoTest {
@@ -186,6 +187,33 @@ public class TestMojoTest {
         assertEquals("both", providerProperties.get(ProviderParameterNames.PARALLEL_PROP));
         assertEquals("1", providerProperties.get(ProviderParameterNames.THREADCOUNT_PROP));
         assertEquals("true", providerProperties.get("perCoreThreadCount"));
+    }
+
+    @Test
+    public void testHeadlessHarnessDoesNotRequireIdeApplication() throws Exception {
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
+        assertFalse(containsBundle(testMojo.getTestDependencies(), "org.eclipse.ui.ide.application"));
+    }
+
+    @Test
+    public void testUIHarnessWithDefaultApplicationRequiresIdeApplication() throws Exception {
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
+        setParameter(testMojo, "useUIHarness", Boolean.TRUE);
+        assertTrue(containsBundle(testMojo.getTestDependencies(), "org.eclipse.ui.ide.application"));
+    }
+
+    @Test
+    public void testUIHarnessWithCustomApplicationDoesNotRequireIdeApplication() throws Exception {
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
+        setParameter(testMojo, "useUIHarness", Boolean.TRUE);
+        setParameter(testMojo, "application", "org.example.custom.application");
+        List<ArtifactKey> dependencies = testMojo.getTestDependencies();
+        assertFalse(containsBundle(dependencies, "org.eclipse.ui.ide.application"));
+        assertTrue(containsBundle(dependencies, "org.eclipse.ui.workbench"));
+    }
+
+    private boolean containsBundle(List<ArtifactKey> dependencies, String bundleId) {
+        return dependencies.stream().anyMatch(key -> bundleId.equals(key.getId()));
     }
 
     public ScanResult createDirectoryAndScanForTests(List<String> includes, List<String> excludes) throws Exception {

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.util.ReflectionUtils;
 import org.eclipse.sisu.equinox.launching.DefaultEquinoxInstallationDescription;
 import org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxInstallation;
 import org.eclipse.sisu.equinox.launching.internal.EquinoxLaunchConfiguration;
+import org.eclipse.tycho.ArtifactKey;
 import org.junit.jupiter.api.Test;
 
 public class TestMojoTest {
@@ -186,6 +187,33 @@ public class TestMojoTest {
         assertEquals("both", providerProperties.get(ProviderParameterNames.PARALLEL_PROP));
         assertEquals("1", providerProperties.get(ProviderParameterNames.THREADCOUNT_PROP));
         assertEquals("true", providerProperties.get("perCoreThreadCount"));
+    }
+
+    @Test
+    public void testHeadlessHarnessDoesNotRequireIdeApplication() throws Exception {
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
+        assertFalse(containsBundle(testMojo.getTestDependencies(), "org.eclipse.ui.ide.application"));
+    }
+
+    @Test
+    public void testUIHarnessWithDefaultApplicationRequiresIdeApplication() throws Exception {
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
+        setParameter(testMojo, "useUIHarness", Boolean.TRUE);
+        assertTrue(containsBundle(testMojo.getTestDependencies(), "org.eclipse.ui.ide.application"));
+    }
+
+    @Test
+    public void testUIHarnessWithCustomApplicationDoesNotRequireIdeApplication() throws Exception {
+        AbstractEclipseTestMojo testMojo = new TestPluginMojo();
+        setParameter(testMojo, "useUIHarness", Boolean.TRUE);
+        setParameter(testMojo, "application", "org.example.custom.application");
+        List<ArtifactKey> dependencies = testMojo.getTestDependencies();
+        assertFalse(containsBundle(dependencies, "org.eclipse.ui.ide.application"));
+        assertTrue(containsBundle(dependencies, "org.eclipse.ui.workbench"));
+    }
+
+    private boolean containsBundle(List<ArtifactKey> dependencies, String bundleId) {
+        return dependencies.stream().anyMatch(key -> bundleId.equals(key.getId()));
     }
 
     public ScanResult createDirectoryAndScanForTests(List<String> includes, List<String> excludes) throws Exception {


### PR DESCRIPTION
When `useUIHarness` is enabled, tycho-surefire-plugin unconditionally adds `org.eclipse.ui.ide.application` to the test runtime requirements, even when a custom `application` is configured. This makes it impossible to run UI tests against RCP applications whose target platform does not contain the Eclipse IDE bundles, because dependency resolution fails before the configured application is ever considered.

With this change the IDE application bundle is only required when no `application` is configured, i.e. when the harness can actually fall back to the default `org.eclipse.ui.ide.workbench`. For a custom application only `org.eclipse.ui.workbench` is required, which the UI test harness itself needs. This allows RCP products to run UI tests without pulling the Eclipse IDE into their target platform.

The integration test `surefire.uiHarness.customApplication` demonstrates this: its target platform filters out `org.eclipse.ui.ide.application` and it configures a custom application. Without the fix the build already fails while resolving the test runtime; with it the runtime resolves, Equinox starts and reports `org.eclipse.ui.workbench` but no IDE bundle, and the launch only stops at the intentionally unknown application id. The test is headless, since actually running tests in a custom RCP application would need a real workbench and therefore an X display, which the ITS job does not provide.
