### PR TITLE
Override CycloneDX components

### DIFF
--- a/tycho-build/src/main/resources/META-INF/maven/extension.xml
+++ b/tycho-build/src/main/resources/META-INF/maven/extension.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension>
+  <exportedPackages>
+    <exportedPackage>com.google.inject.*</exportedPackage>
+    <exportedPackage>com.google.inject.binder.*</exportedPackage>
+    <exportedPackage>com.google.inject.matcher.*</exportedPackage>
+    <exportedPackage>com.google.inject.name.*</exportedPackage>
+    <exportedPackage>com.google.inject.spi.*</exportedPackage>
+    <exportedPackage>com.google.inject.util.*</exportedPackage>
+    <exportedPackage>com.google.inject.internal.*</exportedPackage>
+  </exportedPackages>
+</extension>

--- a/tycho-its/projects/sbom/.mvn/maven.config
+++ b/tycho-its/projects/sbom/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dtycho-version=5.0.0-SNAPSHOT
+-Dtycho-version=6.0.0-SNAPSHOT

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/categories/SBOM.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/categories/SBOM.java
@@ -1,0 +1,4 @@
+package org.eclipse.tycho.test.categories;
+
+public @interface SBOM {
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/reactor/BomCreationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/reactor/BomCreationTest.java
@@ -30,9 +30,12 @@ import org.cyclonedx.model.Dependency;
 import org.cyclonedx.parsers.Parser;
 import org.cyclonedx.parsers.XmlParser;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.eclipse.tycho.test.categories.SBOM;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SBOM.class)
 public class BomCreationTest extends AbstractTychoIntegrationTest {
 	private static Verifier verifier;
 
@@ -43,6 +46,7 @@ public class BomCreationTest extends AbstractTychoIntegrationTest {
 			// CycloneDX is logging an excessive amount of data on DEBUG level.
 			// Way too much for the verifier to handle properly...
 			verifier.getCliOptions().remove("-X");
+			verifier.addCliOption("-Dsisu.debug");
 			verifier.executeGoal("verify");
 			verifyErrorFreeLog(verifier);
 		}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sbom/SbomPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sbom/SbomPluginTest.java
@@ -21,9 +21,12 @@ import java.util.List;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.eclipse.tycho.test.categories.SBOM;
 import org.eclipse.tycho.test.util.EnvironmentUtil;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SBOM.class)
 public class SbomPluginTest extends AbstractTychoIntegrationTest {
 
 	@Test

--- a/tycho-sbom/pom.xml
+++ b/tycho-sbom/pom.xml
@@ -41,15 +41,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.plexus</groupId>
-				<artifactId>plexus-component-metadata</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>generate-metadata</goal>
-						</goals>
-					</execution>
-				</executions>
+				<groupId>org.eclipse.sisu</groupId>
+				<artifactId>sisu-maven-plugin</artifactId>
 			</plugin>
 
 			<plugin>

--- a/tycho-sbom/src/main/java/org/eclipse/tycho/sbom/TychoModelConverter.java
+++ b/tycho-sbom/src/main/java/org/eclipse/tycho/sbom/TychoModelConverter.java
@@ -21,14 +21,13 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.annotations.Component;
 import org.cyclonedx.maven.DefaultModelConverter;
-import org.cyclonedx.maven.ModelConverter;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
@@ -52,14 +51,14 @@ import org.slf4j.LoggerFactory;
 /**
  * Custom implementation of the CycloneDX model converter with support for both
  * Maven and p2 artifacts. The generated PURL is usually of the form:
- * 
+ *
  * <pre>
  * pkg:/p2/&lt;id&gt;@&lt;version&gt;?classifier=&lt;classifier&gt;&amp;location=&lt;download-url&gt;
  * </pre>
- * 
+ *
  * This converter can be used with the {@code cyclonedx-maven-plugin} by adding
  * it as a dependency as follows:
- * 
+ *
  * <pre>
  * &lt;plugin>
  *   &lt;groupId&gt;org.cyclonedx&lt;/groupId&gt;
@@ -73,7 +72,6 @@ import org.slf4j.LoggerFactory;
  * &lt;/plugin&gt;
  * </pre>
  */
-@Component(role = ModelConverter.class)
 public class TychoModelConverter extends DefaultModelConverter {
 	private static final String KEY_CONTEXT = TychoSBOMConfiguration.class.toString();
 	private static final Logger LOG = LoggerFactory.getLogger(TychoModelConverter.class);
@@ -82,10 +80,10 @@ public class TychoModelConverter extends DefaultModelConverter {
 	private P2RepositoryManager repositoryManager;
 
 	@Inject
-	private TychoProjectManager projectManager;
+	private Provider<TychoProjectManager> projectManagerProvider;
 
 	@Inject
-	private TychoReactorReader reactorReader;
+	private Provider<TychoReactorReader> reactorReaderProvider;
 
 	@Inject
 	private LegacySupport legacySupport;
@@ -134,6 +132,7 @@ public class TychoModelConverter extends DefaultModelConverter {
 	private String generatePackageUrl(Artifact artifact, boolean withVersion, boolean withClassifier,
 			Supplier<String> fallback) {
 		TychoSBOMConfiguration sbomConfig = getOrCreateCurrentProjectConfiguration();
+		TychoReactorReader reactorReader = reactorReaderProvider.get();
 		if (sbomConfig.getIncludedPackagingTypes().contains(reactorReader.getPackagingType(artifact))) {
 			ArtifactKey artifactKey = getQualifiedArtifactKey(artifact);
 			IArtifactKey p2artifactKey = ArtifactTypeHelper.toP2ArtifactKey(artifactKey);
@@ -261,7 +260,7 @@ public class TychoModelConverter extends DefaultModelConverter {
 	 */
 	private ArtifactKey getQualifiedArtifactKey(Artifact artifact) {
 		String expandedVersion = artifact.getVersion();
-
+		TychoReactorReader reactorReader = reactorReaderProvider.get();
 		MavenProject mavenProject = reactorReader.getTychoReactorProject(artifact).orElse(null);
 		if (mavenProject != null) {
 			ReactorProject reactorProject = DefaultReactorProject.adapt(mavenProject);
@@ -286,6 +285,7 @@ public class TychoModelConverter extends DefaultModelConverter {
 	 * @return An unmodifiable list of all target repositories.
 	 */
 	private List<Repository> getTargetRepositories(MavenProject currentProject) {
+		TychoProjectManager projectManager = projectManagerProvider.get();
 		TargetPlatformConfiguration targetConfiguration = projectManager.getTargetPlatformConfiguration(currentProject);
 		List<Repository> p2repositories = new ArrayList<>();
 

--- a/tycho-sbom/src/main/java/org/eclipse/tycho/sbom/TychoProjectDependenciesConverter.java
+++ b/tycho-sbom/src/main/java/org/eclipse/tycho/sbom/TychoProjectDependenciesConverter.java
@@ -28,7 +28,6 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.project.MavenProject;
 import org.cyclonedx.maven.DefaultProjectDependenciesConverter;
-import org.cyclonedx.maven.ProjectDependenciesConverter;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.Metadata;
@@ -43,7 +42,6 @@ import org.eclipse.tycho.p2.tools.P2DependencyTreeGenerator.DependencyTreeNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@org.codehaus.plexus.component.annotations.Component(role = ProjectDependenciesConverter.class)
 public class TychoProjectDependenciesConverter extends DefaultProjectDependenciesConverter {
 	private static final Logger LOG = LoggerFactory.getLogger(TychoProjectDependenciesConverter.class);
 

--- a/tycho-sbom/src/main/java/org/eclipse/tycho/sbom/TychoSBOMOverrides.java
+++ b/tycho-sbom/src/main/java/org/eclipse/tycho/sbom/TychoSBOMOverrides.java
@@ -1,0 +1,33 @@
+package org.eclipse.tycho.sbom;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+import org.cyclonedx.maven.ModelConverter;
+import org.cyclonedx.maven.ProjectDependenciesConverter;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * The problem is not component definition (it is JSR330), but component injection point. It is happening in a Mojo,
+ * that uses third annotation (plugin component annotations {@code @Component}) that is nor a Plexus annotation nor is
+ * JSR330 annotation. The trace to injection existing ONLY in plugin.xml (that is EXTENDING component.xml), and
+ * is manually pushed into Plexus container. So all that Plexus can do (as it really has only descriptor, field is
+ * without any hint or annotation) is to blindly follow Plexus XML.
+ *
+ * Hence, we need to <em>bind these components exactly the same way as Plexus Shim would do</em>. This is why
+ * we do this "dance" with Guice binds.
+ *
+ * If CycloneDX project would abstain of using Maven Plugin API {@code @Component}, but would use standard {@link @Inject},
+ * none of this would be needed.
+ */
+@Named
+public class TychoSBOMOverrides extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(Key.get(TypeLiteral.get(ModelConverter.class), Names.named("default"))).to(TychoModelConverter.class).in(Singleton.class);
+        bind(Key.get(TypeLiteral.get(ProjectDependenciesConverter.class), Names.named("default"))).to(TychoProjectDependenciesConverter.class);
+    }
+}


### PR DESCRIPTION
This is just a draft, interested in ITs.

Rework of https://github.com/eclipse-tycho/tycho/pull/6191

ITs has added category of `SBOM` so for quick turnaround this works:
```
mvn -f tycho-its/ clean verify -Dgroups=org.eclipse.tycho.test.categories.SBOM
```