### PR TITLE
Add support for filtering OSGI Capabilities at build time

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/tmp/BundlesAction.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/tmp/BundlesAction.java
@@ -48,6 +48,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
+import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
 import org.eclipse.equinox.internal.p2.publisher.Messages;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.GeneratorBundleInfo;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
@@ -112,6 +113,43 @@ public class BundlesAction extends AbstractPublisherAction {
 	public static final String FILTER_PROPERTY_INSTALL_SOURCE = "org.eclipse.update.install.sources"; //$NON-NLS-1$
 
 	public static final String INSTALL_SOURCE_FILTER = String.format("(%s=true)", FILTER_PROPERTY_INSTALL_SOURCE); //$NON-NLS-1$
+
+	/**
+	 * Prefix for profile properties that disable <code>Require-Capability</code>
+	 * requirements on bundles published by this action. The full property name is
+	 * formed by appending a dot and the OSGi namespace, for example:
+	 * <ul>
+	 * <li><code>org.eclipse.equinox.p2.disable.require.capability.osgi.ee</code>
+	 * disables <code>osgi.ee</code> requirements</li>
+	 * <li><code>org.eclipse.equinox.p2.disable.require.capability.my.cap</code>
+	 * disables <code>my.cap</code> requirements</li>
+	 * </ul>
+	 * When a namespace-specific property is set to <code>"true"</code> on a
+	 * profile, only requirements in that namespace are ignored during
+	 * installation. This can be useful to break cyclic dependencies in build
+	 * scenarios. Requirements are active by default (property absent or not
+	 * equal to <code>"true"</code>).
+	 *
+	 * @see #getFilterPropertyForNamespace(String)
+	 */
+	public static final String FILTER_PROPERTY_DISABLE_REQUIRE_CAPABILITY = "org.eclipse.equinox.p2.disable.require.capability"; //$NON-NLS-1$
+
+	/**
+	 * Returns the profile property name that disables
+	 * <code>Require-Capability</code> requirements in the given OSGi namespace.
+	 * Setting this property to <code>"true"</code> on a profile causes
+	 * requirements in that namespace to be ignored during installation.
+	 *
+	 * @param namespace the OSGi namespace (e.g. {@code "osgi.ee"}, {@code "my.cap"})
+	 * @return the full profile property name for the given namespace
+	 */
+	public static String getFilterPropertyForNamespace(String namespace) {
+		return FILTER_PROPERTY_DISABLE_REQUIRE_CAPABILITY + '.' + namespace;
+	}
+
+	private static IMatchExpression<IInstallableUnit> createRequireCapabilityFilter(String namespace) {
+		return InstallableUnit.parseFilter("(!(" + getFilterPropertyForNamespace(namespace) + "=true))"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
 
 	private static final Collection<Class<?>> SUPPORTED_CLASSES = List.of(Version.class, String.class, Long.class,
 			Integer.class, Short.class, Byte.class, Double.class, Float.class, Boolean.class, Character.class);
@@ -457,8 +495,8 @@ public class BundlesAction extends AbstractPublisherAction {
 		boolean optional = directives.get(Namespace.REQUIREMENT_RESOLUTION_DIRECTIVE) == Namespace.RESOLUTION_OPTIONAL;
 		boolean greedy = optional ? INSTALLATION_GREEDY.equals(directives.get(INSTALLATION_DIRECTIVE)) : true;
 
-		IRequirement requireCap = MetadataFactory.createRequirement(namespace, capFilter, null, optional ? 0 : 1, 1,
-				greedy);
+		IRequirement requireCap = MetadataFactory.createRequirement(namespace, capFilter,
+				createRequireCapabilityFilter(namespace), optional ? 0 : 1, 1, greedy);
 		reqsDeps.add(requireCap);
 	}
 
@@ -473,8 +511,8 @@ public class BundlesAction extends AbstractPublisherAction {
 		boolean optional = directives.get(Namespace.REQUIREMENT_RESOLUTION_DIRECTIVE) == Namespace.RESOLUTION_OPTIONAL;
 		boolean greedy = optional ? INSTALLATION_GREEDY.equals(directives.get(INSTALLATION_DIRECTIVE)) : true;
 
-		IRequirement requireCap = MetadataFactory.createRequirement(namespace, capFilter, null, optional ? 0 : 1, 1,
-				greedy, bd.getSymbolicName());
+		IRequirement requireCap = MetadataFactory.createRequirement(namespace, capFilter,
+				createRequireCapabilityFilter(namespace), optional ? 0 : 1, 1, greedy, bd.getSymbolicName());
 		reqsDeps.add(requireCap);
 	}
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -132,8 +132,10 @@ public class EquinoxResolver implements DependenciesResolver {
             EquinoxResolverConfiguration config, Map<Module, ArtifactDescriptor> descriptorLookup)
             throws BundleException {
         Properties properties = getPlatformProperties(project, mavenSession, ee);
-        ModuleContainer container = newState(artifacts, properties, mavenSession, executorService, config,
-                descriptorLookup);
+        Map<String, String> resolvingProjectProfileProperties = projectManager.getTargetPlatformConfiguration(project)
+                .getProfileProperties();
+        ModuleContainer container = newState(artifacts, properties, resolvingProjectProfileProperties, mavenSession,
+                executorService, config, descriptorLookup);
         ResolutionReport report = container.resolve(null, false);
         Module module = container.getModule(getNormalizedPath(project.getBasedir()));
         if (module == null) {
@@ -260,7 +262,8 @@ public class EquinoxResolver implements DependenciesResolver {
         return properties;
     }
 
-    protected ModuleContainer newState(DependencyArtifacts artifacts, Properties properties, MavenSession mavenSession,
+    protected ModuleContainer newState(DependencyArtifacts artifacts, Properties properties,
+            Map<String, String> resolvingProjectProfileProperties, MavenSession mavenSession,
             ScheduledExecutorService executorService, EquinoxResolverConfiguration config,
             Map<Module, ArtifactDescriptor> descriptorLookup) throws BundleException {
         ModuleContainer[] moduleContainerAccessor = new ModuleContainer[1];
@@ -377,6 +380,7 @@ public class EquinoxResolver implements DependenciesResolver {
             File location = artifact.getLocation(true);
             OsgiManifest mf = loadManifest(location, artifact);
             descriptors.put(location, artifact);
+            removeDisabledRequireCapabilities(mf, resolvingProjectProfileProperties);
             if (isFrameworkImplementation(mf)) {
                 systemBundles.put(location, mf);
             } else {
@@ -393,7 +397,6 @@ public class EquinoxResolver implements DependenciesResolver {
                         reqb.addAll(additionalBundles.stream().map(b -> b + ";resolution:=optional").toList());
                         mf.getHeaders().put(Constants.REQUIRE_BUNDLE, String.join(",", reqb));
                     }
-                    removeDisabledRequireCapabilities(mf, mavenProject);
                     projects.put(location, mf);
                 } else {
                     externalBundles.put(location, mf);
@@ -478,20 +481,22 @@ public class EquinoxResolver implements DependenciesResolver {
 
     /**
      * Removes {@code Require-Capability} clauses from the given manifest whose OSGi
-     * namespace is disabled for this project through the profile property
-     * {@link BundlesAction#getFilterPropertyForNamespace(String)}. This allows
-     * breaking direct dependency cycles that would otherwise prevent Tycho from
-     * computing a valid classpath / reactor build order (see
-     * {@link BundlesAction#FILTER_PROPERTY_DISABLE_REQUIRE_CAPABILITY}).
+     * namespace is disabled for the project currently being resolved, through the
+     * profile property {@link BundlesAction#getFilterPropertyForNamespace(String)}.
+     * This allows breaking direct dependency cycles that would otherwise prevent
+     * Tycho from computing a valid classpath / reactor build order (see
+     * {@link BundlesAction#FILTER_PROPERTY_DISABLE_REQUIRE_CAPABILITY}). This
+     * mirrors the same profile property used by the p2 dependency resolver (see
+     * {@link org.eclipse.tycho.p2resolver.P2DependencyResolver}), so it must be
+     * evaluated against the profile properties of the project whose classpath /
+     * state is currently being computed - not the project that declares the
+     * requirement - to correctly resolve transitive dependencies (e.g. a bundle
+     * depending on a bundle with a disabled requirement should still see the
+     * requirement as active for its own build).
      */
-    private void removeDisabledRequireCapabilities(OsgiManifest mf, ReactorProject mavenProject) {
+    private void removeDisabledRequireCapabilities(OsgiManifest mf, Map<String, String> profileProperties) {
         String value = mf.getValue(Constants.REQUIRE_CAPABILITY);
-        if (value == null || value.isBlank()) {
-            return;
-        }
-        Map<String, String> profileProperties = projectManager.getTargetPlatformConfiguration(mavenProject)
-                .getProfileProperties();
-        if (profileProperties.isEmpty()) {
+        if (value == null || value.isBlank() || profileProperties.isEmpty()) {
             return;
         }
         try {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -376,6 +376,9 @@ public class EquinoxResolver implements DependenciesResolver {
             File location = artifact.getLocation(true);
             OsgiManifest mf = loadManifest(location, artifact);
             descriptors.put(location, artifact);
+            if (!config.keepRequireCapability) {
+                removeRequireCapabilities(mf);
+            }
             if (isFrameworkImplementation(mf)) {
                 systemBundles.put(location, mf);
             } else {
@@ -472,6 +475,21 @@ public class EquinoxResolver implements DependenciesResolver {
             }
         }
         return false;
+    }
+
+    /**
+     * Removes the {@code Require-Capability} header from the given manifest. Compile classpath
+     * computation ({@link DependencyComputer}) never follows generic capability wires - it only
+     * follows {@code Require-Bundle}, {@code Import-Package} and fragment-host wires - so these
+     * requirements are irrelevant for the classpath. Keeping them around only risks resolution
+     * failures (or artificial cycles) when a generic capability can't be satisfied within the
+     * reactor/target platform being resolved. Note that this does not affect requirements that
+     * Equinox derives independently, such as the {@code osgi.ee} requirement generated from
+     * {@code Bundle-RequiredExecutionEnvironment}, as those are not expressed through the
+     * {@code Require-Capability} header.
+     */
+    private static void removeRequireCapabilities(OsgiManifest mf) {
+        mf.getHeaders().remove(Constants.REQUIRE_CAPABILITY);
     }
 
     private static String getNormalizedPath(File file) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -75,6 +75,7 @@ import org.eclipse.tycho.core.ee.ExecutionEnvironmentUtils;
 import org.eclipse.tycho.core.ee.StandardExecutionEnvironment;
 import org.eclipse.tycho.core.osgitools.DependencyComputer.DependencyEntry;
 import org.eclipse.tycho.core.resolver.target.ArtifactTypeHelper;
+import org.eclipse.tycho.p2maven.tmp.BundlesAction;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
@@ -392,6 +393,7 @@ public class EquinoxResolver implements DependenciesResolver {
                         reqb.addAll(additionalBundles.stream().map(b -> b + ";resolution:=optional").toList());
                         mf.getHeaders().put(Constants.REQUIRE_BUNDLE, String.join(",", reqb));
                     }
+                    removeDisabledRequireCapabilities(mf, mavenProject);
                     projects.put(location, mf);
                 } else {
                     externalBundles.put(location, mf);
@@ -472,6 +474,49 @@ public class EquinoxResolver implements DependenciesResolver {
             }
         }
         return false;
+    }
+
+    /**
+     * Removes {@code Require-Capability} clauses from the given manifest whose OSGi
+     * namespace is disabled for this project through the profile property
+     * {@link BundlesAction#getFilterPropertyForNamespace(String)}. This allows
+     * breaking direct dependency cycles that would otherwise prevent Tycho from
+     * computing a valid classpath / reactor build order (see
+     * {@link BundlesAction#FILTER_PROPERTY_DISABLE_REQUIRE_CAPABILITY}).
+     */
+    private void removeDisabledRequireCapabilities(OsgiManifest mf, ReactorProject mavenProject) {
+        String value = mf.getValue(Constants.REQUIRE_CAPABILITY);
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        Map<String, String> profileProperties = projectManager.getTargetPlatformConfiguration(mavenProject)
+                .getProfileProperties();
+        if (profileProperties.isEmpty()) {
+            return;
+        }
+        try {
+            ManifestElement[] elements = ManifestElement.parseHeader(Constants.REQUIRE_CAPABILITY, value);
+            List<String> keptClauses = new ArrayList<>();
+            boolean removedAny = false;
+            for (ManifestElement element : elements) {
+                String namespace = element.getValue();
+                String filterProperty = BundlesAction.getFilterPropertyForNamespace(namespace);
+                if ("true".equals(profileProperties.get(filterProperty))) {
+                    removedAny = true;
+                } else {
+                    keptClauses.add(element.toString());
+                }
+            }
+            if (removedAny) {
+                if (keptClauses.isEmpty()) {
+                    mf.getHeaders().remove(Constants.REQUIRE_CAPABILITY);
+                } else {
+                    mf.getHeaders().put(Constants.REQUIRE_CAPABILITY, String.join(",", keptClauses));
+                }
+            }
+        } catch (BundleException e) {
+            // malformed header, let the regular resolution report the problem
+        }
     }
 
     private static String getNormalizedPath(File file) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolverConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolverConfiguration.java
@@ -17,11 +17,13 @@ final class EquinoxResolverConfiguration {
     public EquinoxResolverConfiguration() {
         keepUses = Boolean.getBoolean("tycho.equinox.resolver.uses");
         batchSize = System.getProperty("tycho.equinox.resolver.batch.size", keepUses ? null : "1");
+        keepRequireCapability = Boolean.getBoolean("tycho.equinox.resolver.keepRequireCapability");
     }
 
     public EquinoxResolverConfiguration(EquinoxResolverConfiguration source, boolean forceKeepUses) {
         keepUses = forceKeepUses;
         batchSize = keepUses ? null : source.batchSize;
+        keepRequireCapability = source.keepRequireCapability;
     }
 
     /**
@@ -30,6 +32,18 @@ final class EquinoxResolverConfiguration {
      * present
      */
     final boolean keepUses;
+
+    /**
+     * If set to true, {@code Require-Capability} clauses declared by bundles are kept when
+     * building the resolver state used to compute the compile classpath. By default these
+     * requirements are stripped: they are never used to derive classpath entries (Tycho's
+     * {@link DependencyComputer} only follows {@code Require-Bundle}, {@code Import-Package} and
+     * fragment-host wires), but they can needlessly cause the resolution to fail (or introduce
+     * artificial cycles) when a generic capability can't be satisfied within the reactor/target
+     * platform. This flag is a safe-guard to restore the previous behavior in case removing them
+     * has unintended side effects.
+     */
+    final boolean keepRequireCapability;
 
     /**
      * Keep the default batch size, but allow to override this if necessary, if 'uses' constrains

--- a/tycho-its/projects/p2.capability.transport/README.md
+++ b/tycho-its/projects/p2.capability.transport/README.md
@@ -1,0 +1,47 @@
+# P2 Capability Transport Test
+
+This integration test validates that Tycho can correctly resolve OSGi bundles that use `Provide-Capability` and `Require-Capability` manifest headers.
+
+## Background
+
+This test was created based on [eclipse-equinox/p2#972](https://github.com/eclipse-equinox/p2/pull/972) and [eclipse-equinox/p2#971](https://github.com/eclipse-equinox/p2/issues/971).
+
+The PR adds OSGi capability headers to p2 bundles to express service dependencies:
+- `org.eclipse.equinox.p2.transport.ecf` provides the Transport service via `Provide-Capability`
+- `org.eclipse.equinox.p2.repository` requires the Transport service via `Require-Capability`
+
+## Test Structure
+
+This test creates two bundles that replicate the capability pattern:
+
+### Provider Bundle
+Simulates `org.eclipse.equinox.p2.transport.ecf` by providing a capability:
+```
+Provide-Capability: osgi.implementation;
+  p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport;
+  version=1.0.0
+```
+
+### Consumer Bundle
+Simulates `org.eclipse.equinox.p2.repository` by requiring a capability:
+```
+Require-Capability: osgi.implementation;
+  filter:="(|(p2.agent.service.name=org.eclipse.equinox.internal.p2.repository.Transport)
+            (p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport))"
+```
+
+## What This Tests
+
+1. Tycho's ability to resolve OSGi capability requirements during build
+2. Correct handling of `Provide-Capability` and `Require-Capability` headers
+3. P2 resolution of capability-based bundle dependencies
+
+## Expected Behavior
+
+The build should succeed, demonstrating that Tycho's p2 resolver correctly handles capability requirements and matches them with providers.
+
+## Running the Test
+
+```bash
+mvn clean verify -Dtest=P2CapabilityTransportTest
+```

--- a/tycho-its/projects/p2.capability.transport/README.md
+++ b/tycho-its/projects/p2.capability.transport/README.md
@@ -1,0 +1,115 @@
+# P2 Capability Transport Test
+
+This integration test validates that Tycho can break a direct dependency cycle
+formed between OSGi capabilities (`Provide-Capability` / `Require-Capability`)
+and a regular `Require-Bundle` dependency, by disabling the offending
+requirement during the reactor build only.
+
+## Background
+
+This test replicates the real dependency cycle that was introduced between
+`org.eclipse.equinox.p2.repository` and `org.eclipse.equinox.p2.transport.ecf` by
+[eclipse-equinox/p2#972](https://github.com/eclipse-equinox/p2/pull/972), reported in
+[eclipse-equinox/p2#971](https://github.com/eclipse-equinox/p2/issues/971):
+
+- `org.eclipse.equinox.p2.transport.ecf` provides the Transport service via
+  `Provide-Capability`, but it also `Require-Bundle`s `org.eclipse.equinox.p2.repository`.
+- `org.eclipse.equinox.p2.repository` requires the Transport service via
+  `Require-Capability`, which is only provided by `org.eclipse.equinox.p2.transport.ecf`.
+
+This forms a direct cycle: repository -> (capability) -> transport.ecf -> (Require-Bundle) -> repository.
+
+The fix for this cycle was drafted in
+[eclipse-equinox/p2#1073](https://github.com/eclipse-equinox/p2/pull/1073): every
+`Require-Capability` requirement published by `BundlesAction` now additionally
+carries a filter
+`(!(org.eclipse.equinox.p2.disable.require.capability.<namespace>=true))`.
+This filter is active by default (the requirement behaves exactly as before),
+but setting the profile property
+`org.eclipse.equinox.p2.disable.require.capability.<namespace>` to `"true"`
+causes requirements in that namespace to be ignored - which can be used to
+break cyclic dependencies in build scenarios like this one.
+
+Since Tycho vendors its own copy of `BundlesAction`
+(`org.eclipse.tycho.p2maven.tmp.BundlesAction`), the same fix was applied there,
+without needing a new p2 release. Additionally, Tycho's own OSGi state resolution
+(used for compile classpath computation, `EquinoxResolver`) was extended to strip
+`Require-Capability` clauses that are disabled for a reactor project through the
+same profile property, so that both the p2-based reactor dependency computation
+and the plain OSGi resolution used for the compiler classpath agree.
+
+## Test Structure
+
+This test creates two bundles that replicate this exact pattern:
+
+### consumer.bundle
+Simulates `org.eclipse.equinox.p2.repository` by requiring a capability:
+```
+Require-Capability: osgi.implementation;
+  filter:="(|(p2.agent.service.name=org.eclipse.equinox.internal.p2.repository.Transport)
+            (p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport))"
+```
+It also disables this requirement during the reactor build, via
+`target-platform-configuration`:
+```xml
+<dependency-resolution>
+  <profileProperties>
+    <org.eclipse.equinox.p2.disable.require.capability.osgi.implementation>true</org.eclipse.equinox.p2.disable.require.capability.osgi.implementation>
+  </profileProperties>
+</dependency-resolution>
+```
+
+### provider.bundle
+Simulates `org.eclipse.equinox.p2.transport.ecf` by providing that capability, while
+also depending on `consumer.bundle` via `Require-Bundle`:
+```
+Require-Bundle: consumer.bundle
+Provide-Capability: osgi.implementation;
+  p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport;
+  version=1.0.0
+```
+
+### client.bundle
+A third bundle that only `Require-Bundle`s `consumer.bundle`:
+```
+Require-Bundle: consumer.bundle
+```
+It does **not** set the `org.eclipse.equinox.p2.disable.require.capability.osgi.implementation`
+profile property itself. Since the disable-filter added by
+[eclipse-equinox/p2#1073](https://github.com/eclipse-equinox/p2/pull/1073) is only
+evaluated against the profile properties of the project *currently being resolved*
+(i.e. it is scoped to `consumer.bundle`'s own build, not to every consumer of
+`consumer.bundle`), resolving `client.bundle`'s dependencies still evaluates
+`consumer.bundle`'s `Require-Capability` requirement as active. As a result,
+`client.bundle` transitively pulls in `provider.bundle` as well as
+`consumer.bundle` directly.
+
+This is verified indirectly using
+`org.eclipse.tycho.extras:tycho-dependency-tools-plugin:list-dependencies`, bound
+to the `validate` phase in `client.bundle/pom.xml`. The resulting
+`client.bundle/target/dependencies-list.txt` is asserted to contain both a
+`consumer.bundle-*.jar` and a `provider.bundle-*.jar` entry.
+
+## What This Tests
+
+Without the profile property, `consumer.bundle` requires the capability provided
+by `provider.bundle`, and `provider.bundle` requires `consumer.bundle` itself,
+forming a direct dependency cycle that Tycho cannot build (neither as a Maven
+reactor build order, nor as an OSGi compile classpath). By disabling the
+`osgi.implementation` `Require-Capability` requirement for the build only, the
+cycle is broken and both bundles build successfully, while the published
+metadata and manifest of `consumer.bundle` are unaffected, so the requirement
+remains active for a real (non-build-time) p2/OSGi runtime.
+
+## Expected Behavior
+
+The build succeeds, and `client.bundle`'s resolved dependency list contains both
+`consumer.bundle` and `provider.bundle`, proving that disabling the capability
+requirement is scoped to `consumer.bundle`'s own build and does not affect
+consumers of `consumer.bundle`.
+
+## Running the Test
+
+```bash
+mvn clean verify -Dtest=P2CapabilityTransportTest
+```

--- a/tycho-its/projects/p2.capability.transport/README.md
+++ b/tycho-its/projects/p2.capability.transport/README.md
@@ -1,8 +1,9 @@
 # P2 Capability Transport Test
 
-This integration test validates that Tycho correctly detects a direct dependency
-cycle formed between OSGi capabilities (`Provide-Capability` / `Require-Capability`)
-and a regular `Require-Bundle` dependency.
+This integration test validates that Tycho can break a direct dependency cycle
+formed between OSGi capabilities (`Provide-Capability` / `Require-Capability`)
+and a regular `Require-Bundle` dependency, by disabling the offending
+requirement during the reactor build only.
 
 ## Background
 
@@ -18,6 +19,25 @@ This test replicates the real dependency cycle that was introduced between
 
 This forms a direct cycle: repository -> (capability) -> transport.ecf -> (Require-Bundle) -> repository.
 
+The fix for this cycle was drafted in
+[eclipse-equinox/p2#1073](https://github.com/eclipse-equinox/p2/pull/1073): every
+`Require-Capability` requirement published by `BundlesAction` now additionally
+carries a filter
+`(!(org.eclipse.equinox.p2.disable.require.capability.<namespace>=true))`.
+This filter is active by default (the requirement behaves exactly as before),
+but setting the profile property
+`org.eclipse.equinox.p2.disable.require.capability.<namespace>` to `"true"`
+causes requirements in that namespace to be ignored - which can be used to
+break cyclic dependencies in build scenarios like this one.
+
+Since Tycho vendors its own copy of `BundlesAction`
+(`org.eclipse.tycho.p2maven.tmp.BundlesAction`), the same fix was applied there,
+without needing a new p2 release. Additionally, Tycho's own OSGi state resolution
+(used for compile classpath computation, `EquinoxResolver`) was extended to strip
+`Require-Capability` clauses that are disabled for a reactor project through the
+same profile property, so that both the p2-based reactor dependency computation
+and the plain OSGi resolution used for the compiler classpath agree.
+
 ## Test Structure
 
 This test creates two bundles that replicate this exact pattern:
@@ -28,6 +48,15 @@ Simulates `org.eclipse.equinox.p2.repository` by requiring a capability:
 Require-Capability: osgi.implementation;
   filter:="(|(p2.agent.service.name=org.eclipse.equinox.internal.p2.repository.Transport)
             (p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport))"
+```
+It also disables this requirement during the reactor build, via
+`target-platform-configuration`:
+```xml
+<dependency-resolution>
+  <profileProperties>
+    <org.eclipse.equinox.p2.disable.require.capability.osgi.implementation>true</org.eclipse.equinox.p2.disable.require.capability.osgi.implementation>
+  </profileProperties>
+</dependency-resolution>
 ```
 
 ### provider.bundle
@@ -42,16 +71,18 @@ Provide-Capability: osgi.implementation;
 
 ## What This Tests
 
-Since `consumer.bundle` requires the capability provided by `provider.bundle`, and
-`provider.bundle` requires `consumer.bundle` itself, the two bundles form a direct
-dependency cycle.
-Tycho cannot compute a reactor build order for a cyclic reference between two
-modules, so the build is expected to fail.
+Without the profile property, `consumer.bundle` requires the capability provided
+by `provider.bundle`, and `provider.bundle` requires `consumer.bundle` itself,
+forming a direct dependency cycle that Tycho cannot build (neither as a Maven
+reactor build order, nor as an OSGi compile classpath). By disabling the
+`osgi.implementation` `Require-Capability` requirement for the build only, the
+cycle is broken and both bundles build successfully, while the published
+metadata and manifest of `consumer.bundle` are unaffected, so the requirement
+remains active for a real (non-build-time) p2/OSGi runtime.
 
 ## Expected Behavior
 
-The build must fail with an error indicating a cyclic reference between the
-`consumer.bundle` and `provider.bundle` projects.
+The build succeeds.
 
 ## Running the Test
 

--- a/tycho-its/projects/p2.capability.transport/README.md
+++ b/tycho-its/projects/p2.capability.transport/README.md
@@ -1,28 +1,28 @@
 # P2 Capability Transport Test
 
-This integration test validates that Tycho can correctly resolve OSGi bundles that use `Provide-Capability` and `Require-Capability` manifest headers.
+This integration test validates that Tycho correctly detects a direct dependency
+cycle formed between OSGi capabilities (`Provide-Capability` / `Require-Capability`)
+and a regular `Require-Bundle` dependency.
 
 ## Background
 
-This test was created based on [eclipse-equinox/p2#972](https://github.com/eclipse-equinox/p2/pull/972) and [eclipse-equinox/p2#971](https://github.com/eclipse-equinox/p2/issues/971).
+This test replicates the real dependency cycle that was introduced between
+`org.eclipse.equinox.p2.repository` and `org.eclipse.equinox.p2.transport.ecf` by
+[eclipse-equinox/p2#972](https://github.com/eclipse-equinox/p2/pull/972), reported in
+[eclipse-equinox/p2#971](https://github.com/eclipse-equinox/p2/issues/971):
 
-The PR adds OSGi capability headers to p2 bundles to express service dependencies:
-- `org.eclipse.equinox.p2.transport.ecf` provides the Transport service via `Provide-Capability`
-- `org.eclipse.equinox.p2.repository` requires the Transport service via `Require-Capability`
+- `org.eclipse.equinox.p2.transport.ecf` provides the Transport service via
+  `Provide-Capability`, but it also `Require-Bundle`s `org.eclipse.equinox.p2.repository`.
+- `org.eclipse.equinox.p2.repository` requires the Transport service via
+  `Require-Capability`, which is only provided by `org.eclipse.equinox.p2.transport.ecf`.
+
+This forms a direct cycle: repository -> (capability) -> transport.ecf -> (Require-Bundle) -> repository.
 
 ## Test Structure
 
-This test creates two bundles that replicate the capability pattern:
+This test creates two bundles that replicate this exact pattern:
 
-### Provider Bundle
-Simulates `org.eclipse.equinox.p2.transport.ecf` by providing a capability:
-```
-Provide-Capability: osgi.implementation;
-  p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport;
-  version=1.0.0
-```
-
-### Consumer Bundle
+### consumer.bundle
 Simulates `org.eclipse.equinox.p2.repository` by requiring a capability:
 ```
 Require-Capability: osgi.implementation;
@@ -30,15 +30,28 @@ Require-Capability: osgi.implementation;
             (p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport))"
 ```
 
+### provider.bundle
+Simulates `org.eclipse.equinox.p2.transport.ecf` by providing that capability, while
+also depending on `consumer.bundle` via `Require-Bundle`:
+```
+Require-Bundle: consumer.bundle
+Provide-Capability: osgi.implementation;
+  p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport;
+  version=1.0.0
+```
+
 ## What This Tests
 
-1. Tycho's ability to resolve OSGi capability requirements during build
-2. Correct handling of `Provide-Capability` and `Require-Capability` headers
-3. P2 resolution of capability-based bundle dependencies
+Since `consumer.bundle` requires the capability provided by `provider.bundle`, and
+`provider.bundle` requires `consumer.bundle` itself, the two bundles form a direct
+dependency cycle.
+Tycho cannot compute a reactor build order for a cyclic reference between two
+modules, so the build is expected to fail.
 
 ## Expected Behavior
 
-The build should succeed, demonstrating that Tycho's p2 resolver correctly handles capability requirements and matches them with providers.
+The build must fail with an error indicating a cyclic reference between the
+`consumer.bundle` and `provider.bundle` projects.
 
 ## Running the Test
 

--- a/tycho-its/projects/p2.capability.transport/README.md
+++ b/tycho-its/projects/p2.capability.transport/README.md
@@ -69,6 +69,27 @@ Provide-Capability: osgi.implementation;
   version=1.0.0
 ```
 
+### client.bundle
+A third bundle that only `Require-Bundle`s `consumer.bundle`:
+```
+Require-Bundle: consumer.bundle
+```
+It does **not** set the `org.eclipse.equinox.p2.disable.require.capability.osgi.implementation`
+profile property itself. Since the disable-filter added by
+[eclipse-equinox/p2#1073](https://github.com/eclipse-equinox/p2/pull/1073) is only
+evaluated against the profile properties of the project *currently being resolved*
+(i.e. it is scoped to `consumer.bundle`'s own build, not to every consumer of
+`consumer.bundle`), resolving `client.bundle`'s dependencies still evaluates
+`consumer.bundle`'s `Require-Capability` requirement as active. As a result,
+`client.bundle` transitively pulls in `provider.bundle` as well as
+`consumer.bundle` directly.
+
+This is verified indirectly using
+`org.eclipse.tycho.extras:tycho-dependency-tools-plugin:list-dependencies`, bound
+to the `validate` phase in `client.bundle/pom.xml`. The resulting
+`client.bundle/target/dependencies-list.txt` is asserted to contain both a
+`consumer.bundle-*.jar` and a `provider.bundle-*.jar` entry.
+
 ## What This Tests
 
 Without the profile property, `consumer.bundle` requires the capability provided
@@ -82,7 +103,10 @@ remains active for a real (non-build-time) p2/OSGi runtime.
 
 ## Expected Behavior
 
-The build succeeds.
+The build succeeds, and `client.bundle`'s resolved dependency list contains both
+`consumer.bundle` and `provider.bundle`, proving that disabling the capability
+requirement is scoped to `consumer.bundle`'s own build and does not affect
+consumers of `consumer.bundle`.
 
 ## Running the Test
 

--- a/tycho-its/projects/p2.capability.transport/client.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2.capability.transport/client.bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Transport Client Bundle
+Bundle-SymbolicName: client.bundle
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: consumer.bundle

--- a/tycho-its/projects/p2.capability.transport/client.bundle/build.properties
+++ b/tycho-its/projects/p2.capability.transport/client.bundle/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/p2.capability.transport/client.bundle/pom.xml
+++ b/tycho-its/projects/p2.capability.transport/client.bundle/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>client.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<parent>
+		<groupId>tycho-its-project.p2.capability</groupId>
+		<artifactId>transport</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-dependency-tools-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>list-dependencies</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2.capability.transport/consumer.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2.capability.transport/consumer.bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Transport Consumer Bundle
+Bundle-SymbolicName: consumer.bundle
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Capability: osgi.implementation;
+  filter:="(|(p2.agent.service.name=org.eclipse.equinox.internal.p2.repository.Transport)(p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport))"

--- a/tycho-its/projects/p2.capability.transport/consumer.bundle/build.properties
+++ b/tycho-its/projects/p2.capability.transport/consumer.bundle/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/p2.capability.transport/consumer.bundle/pom.xml
+++ b/tycho-its/projects/p2.capability.transport/consumer.bundle/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>consumer.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<parent>
+		<groupId>tycho-its-project.p2.capability</groupId>
+		<artifactId>transport</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+</project>

--- a/tycho-its/projects/p2.capability.transport/consumer.bundle/pom.xml
+++ b/tycho-its/projects/p2.capability.transport/consumer.bundle/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>consumer.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<parent>
+		<groupId>tycho-its-project.p2.capability</groupId>
+		<artifactId>transport</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!-- Break the direct dependency cycle formed between the
+						osgi.implementation Require-Capability (towards provider.bundle) and
+						provider.bundle's Require-Bundle (towards consumer.bundle) by disabling
+						this Require-Capability requirement during the reactor build only. -->
+					<dependency-resolution>
+						<profileProperties>
+							<org.eclipse.equinox.p2.disable.require.capability.osgi.implementation>true</org.eclipse.equinox.p2.disable.require.capability.osgi.implementation>
+						</profileProperties>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2.capability.transport/consumer.bundle/pom.xml
+++ b/tycho-its/projects/p2.capability.transport/consumer.bundle/pom.xml
@@ -11,4 +11,25 @@
 		<artifactId>transport</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!-- Break the direct dependency cycle formed between the
+						osgi.implementation Require-Capability (towards provider.bundle) and
+						provider.bundle's Require-Bundle (towards consumer.bundle) by disabling
+						this Require-Capability requirement during the reactor build only. -->
+					<dependency-resolution>
+						<profileProperties>
+							<org.eclipse.equinox.p2.disable.require.capability.osgi.implementation>true</org.eclipse.equinox.p2.disable.require.capability.osgi.implementation>
+						</profileProperties>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/tycho-its/projects/p2.capability.transport/pom.xml
+++ b/tycho-its/projects/p2.capability.transport/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project.p2.capability</groupId>
+	<artifactId>transport</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>provider.bundle</module>
+		<module>consumer.bundle</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2.capability.transport/pom.xml
+++ b/tycho-its/projects/p2.capability.transport/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project.p2.capability</groupId>
+	<artifactId>transport</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>provider.bundle</module>
+		<module>consumer.bundle</module>
+		<module>client.bundle</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/p2.capability.transport/pom.xml
+++ b/tycho-its/projects/p2.capability.transport/pom.xml
@@ -11,6 +11,7 @@
 	<modules>
 		<module>provider.bundle</module>
 		<module>consumer.bundle</module>
+		<module>client.bundle</module>
 	</modules>
 
 	<build>

--- a/tycho-its/projects/p2.capability.transport/provider.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2.capability.transport/provider.bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Transport Provider Bundle
+Bundle-SymbolicName: provider.bundle
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Provide-Capability: osgi.implementation;p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport;version=1.0.0

--- a/tycho-its/projects/p2.capability.transport/provider.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2.capability.transport/provider.bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Transport Provider Bundle
+Bundle-SymbolicName: provider.bundle
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: consumer.bundle
+Provide-Capability: osgi.implementation;p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport;version=1.0.0

--- a/tycho-its/projects/p2.capability.transport/provider.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/p2.capability.transport/provider.bundle/META-INF/MANIFEST.MF
@@ -4,4 +4,5 @@ Bundle-Name: Transport Provider Bundle
 Bundle-SymbolicName: provider.bundle
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Bundle: consumer.bundle
 Provide-Capability: osgi.implementation;p2.agent.servicename=org.eclipse.equinox.internal.p2.repository.Transport;version=1.0.0

--- a/tycho-its/projects/p2.capability.transport/provider.bundle/build.properties
+++ b/tycho-its/projects/p2.capability.transport/provider.bundle/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/p2.capability.transport/provider.bundle/pom.xml
+++ b/tycho-its/projects/p2.capability.transport/provider.bundle/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>provider.bundle</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<parent>
+		<groupId>tycho-its-project.p2.capability</groupId>
+		<artifactId>transport</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Copilot - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.resolver;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+/**
+ * Test for OSGi capability resolution with Provide-Capability and Require-Capability.
+ * This test replicates the scenario from eclipse-equinox/p2 PR #972 where bundles
+ * use OSGi capabilities to express service dependencies.
+ * 
+ * The test creates two bundles:
+ * - provider.bundle: Provides a capability for Transport service
+ * - consumer.bundle: Requires that capability
+ * 
+ * This ensures Tycho can correctly resolve bundles with capability requirements.
+ * 
+ * @see <a href="https://github.com/eclipse-equinox/p2/pull/972">eclipse-equinox/p2#972</a>
+ */
+public class P2CapabilityTransportTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testCapabilityProvideRequire() throws Exception {
+		Verifier verifier = getVerifier("/p2.capability.transport");
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+	}
+
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Copilot - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.resolver;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+/**
+ * Test for OSGi capability resolution with Provide-Capability and Require-Capability.
+ * This test replicates the scenario from eclipse-equinox/p2 PR #972 where bundles
+ * use OSGi capabilities to express service dependencies.
+ * 
+ * The test creates two bundles that form a direct dependency cycle, exactly as it
+ * happens between org.eclipse.equinox.p2.repository and org.eclipse.equinox.p2.transport.ecf:
+ * - consumer.bundle: Requires the Transport capability (like org.eclipse.equinox.p2.repository)
+ * - provider.bundle: Provides that capability, but also Require-Bundle's consumer.bundle
+ *   (like org.eclipse.equinox.p2.transport.ecf, which Require-Bundle's org.eclipse.equinox.p2.repository)
+ * 
+ * Since consumer.bundle requires the capability provided by provider.bundle, and
+ * provider.bundle requires the consumer.bundle itself, the two bundles form a direct
+ * dependency cycle that cannot be built as-is. To break the cycle during the reactor
+ * build, consumer.bundle disables the Require-Capability requirement using the profile
+ * property {@code org.eclipse.equinox.p2.disable.require.capability.osgi.implementation}
+ * (see eclipse-equinox/p2#1073, replicated for Tycho's copy of BundlesAction and
+ * additionally applied in Tycho's own OSGi state resolution used for classpath
+ * computation). The published metadata and manifest of consumer.bundle are unaffected,
+ * so the requirement remains active for a real (non-build-time) p2/OSGi runtime.
+ * 
+ * A third bundle, client.bundle, only Require-Bundle's consumer.bundle and does not
+ * disable the capability requirement itself. Its dependency resolution therefore still
+ * evaluates consumer.bundle's Require-Capability requirement (the disable-filter is only
+ * scoped to the profile properties of the project being resolved, i.e. consumer.bundle's
+ * own build), so client.bundle transitively pulls in provider.bundle as well. This is
+ * verified indirectly via {@code org.eclipse.tycho.extras:tycho-dependency-tools-plugin:list-dependencies},
+ * asserting that client.bundle's {@code target/dependencies-list.txt} lists both
+ * consumer.bundle and provider.bundle.
+ * 
+ * @see <a href="https://github.com/eclipse-equinox/p2/pull/972">eclipse-equinox/p2#972</a>
+ * @see <a href="https://github.com/eclipse-equinox/p2/issues/971">eclipse-equinox/p2#971</a>
+ * @see <a href="https://github.com/eclipse-equinox/p2/pull/1073">eclipse-equinox/p2#1073</a>
+ */
+public class P2CapabilityTransportTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testCapabilityProvideRequireCycleBroken() throws Exception {
+		Verifier verifier = getVerifier("/p2.capability.transport");
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+
+		File file = new File(verifier.getBasedir(), "client.bundle/target/dependencies-list.txt");
+		assertTrue("dependencies-list.txt was not generated for client.bundle", file.exists());
+		List<String> fileNames = new ArrayList<>();
+		try (BufferedReader reader = Files.newBufferedReader(file.toPath())) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (!line.isBlank()) {
+					fileNames.add(new File(line).getName());
+				}
+			}
+		}
+		assertTrue("consumer.bundle jar not found in client.bundle dependencies: " + fileNames,
+				fileNames.stream().anyMatch(name -> name.startsWith("consumer.bundle-")));
+		assertTrue("provider.bundle jar not found in client.bundle dependencies: " + fileNames,
+				fileNames.stream().anyMatch(name -> name.startsWith("provider.bundle-")));
+	}
+
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.resolver;
 
-import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
@@ -30,23 +29,25 @@ import org.junit.Test;
  * 
  * Since consumer.bundle requires the capability provided by provider.bundle, and
  * provider.bundle requires the consumer.bundle itself, the two bundles form a direct
- * dependency cycle. Tycho cannot compute a reactor build order for a cyclic reference,
- * so the build is expected to fail.
+ * dependency cycle that cannot be built as-is. To break the cycle during the reactor
+ * build, consumer.bundle disables the Require-Capability requirement using the profile
+ * property {@code org.eclipse.equinox.p2.disable.require.capability.osgi.implementation}
+ * (see eclipse-equinox/p2#1073, replicated for Tycho's copy of BundlesAction and
+ * additionally applied in Tycho's own OSGi state resolution used for classpath
+ * computation). The published metadata and manifest of consumer.bundle are unaffected,
+ * so the requirement remains active for a real (non-build-time) p2/OSGi runtime.
  * 
  * @see <a href="https://github.com/eclipse-equinox/p2/pull/972">eclipse-equinox/p2#972</a>
  * @see <a href="https://github.com/eclipse-equinox/p2/issues/971">eclipse-equinox/p2#971</a>
+ * @see <a href="https://github.com/eclipse-equinox/p2/pull/1073">eclipse-equinox/p2#1073</a>
  */
 public class P2CapabilityTransportTest extends AbstractTychoIntegrationTest {
 
 	@Test
-	public void testCapabilityProvideRequireCycleFails() throws Exception {
+	public void testCapabilityProvideRequireCycleBroken() throws Exception {
 		Verifier verifier = getVerifier("/p2.capability.transport");
-		try {
-			verifier.executeGoal("verify");
-		} catch (VerificationException expected) {
-			//
-		}
-		verifier.verifyTextInLog("The projects in the reactor contain a cyclic reference");
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.resolver;
 
+import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
@@ -21,21 +22,31 @@ import org.junit.Test;
  * This test replicates the scenario from eclipse-equinox/p2 PR #972 where bundles
  * use OSGi capabilities to express service dependencies.
  * 
- * The test creates two bundles:
- * - provider.bundle: Provides a capability for Transport service
- * - consumer.bundle: Requires that capability
+ * The test creates two bundles that form a direct dependency cycle, exactly as it
+ * happens between org.eclipse.equinox.p2.repository and org.eclipse.equinox.p2.transport.ecf:
+ * - consumer.bundle: Requires the Transport capability (like org.eclipse.equinox.p2.repository)
+ * - provider.bundle: Provides that capability, but also Require-Bundle's consumer.bundle
+ *   (like org.eclipse.equinox.p2.transport.ecf, which Require-Bundle's org.eclipse.equinox.p2.repository)
  * 
- * This ensures Tycho can correctly resolve bundles with capability requirements.
+ * Since consumer.bundle requires the capability provided by provider.bundle, and
+ * provider.bundle requires the consumer.bundle itself, the two bundles form a direct
+ * dependency cycle. Tycho cannot compute a reactor build order for a cyclic reference,
+ * so the build is expected to fail.
  * 
  * @see <a href="https://github.com/eclipse-equinox/p2/pull/972">eclipse-equinox/p2#972</a>
+ * @see <a href="https://github.com/eclipse-equinox/p2/issues/971">eclipse-equinox/p2#971</a>
  */
 public class P2CapabilityTransportTest extends AbstractTychoIntegrationTest {
 
 	@Test
-	public void testCapabilityProvideRequire() throws Exception {
+	public void testCapabilityProvideRequireCycleFails() throws Exception {
 		Verifier verifier = getVerifier("/p2.capability.transport");
-		verifier.executeGoal("verify");
-		verifier.verifyErrorFreeLog();
+		try {
+			verifier.executeGoal("verify");
+		} catch (VerificationException expected) {
+			//
+		}
+		verifier.verifyTextInLog("The projects in the reactor contain a cyclic reference");
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
@@ -12,6 +12,14 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.resolver;
 
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
@@ -37,6 +45,15 @@ import org.junit.Test;
  * computation). The published metadata and manifest of consumer.bundle are unaffected,
  * so the requirement remains active for a real (non-build-time) p2/OSGi runtime.
  * 
+ * A third bundle, client.bundle, only Require-Bundle's consumer.bundle and does not
+ * disable the capability requirement itself. Its dependency resolution therefore still
+ * evaluates consumer.bundle's Require-Capability requirement (the disable-filter is only
+ * scoped to the profile properties of the project being resolved, i.e. consumer.bundle's
+ * own build), so client.bundle transitively pulls in provider.bundle as well. This is
+ * verified indirectly via {@code org.eclipse.tycho.extras:tycho-dependency-tools-plugin:list-dependencies},
+ * asserting that client.bundle's {@code target/dependencies-list.txt} lists both
+ * consumer.bundle and provider.bundle.
+ * 
  * @see <a href="https://github.com/eclipse-equinox/p2/pull/972">eclipse-equinox/p2#972</a>
  * @see <a href="https://github.com/eclipse-equinox/p2/issues/971">eclipse-equinox/p2#971</a>
  * @see <a href="https://github.com/eclipse-equinox/p2/pull/1073">eclipse-equinox/p2#1073</a>
@@ -48,6 +65,22 @@ public class P2CapabilityTransportTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = getVerifier("/p2.capability.transport");
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
+
+		File file = new File(verifier.getBasedir(), "client.bundle/target/dependencies-list.txt");
+		assertTrue("dependencies-list.txt was not generated for client.bundle", file.exists());
+		List<String> fileNames = new ArrayList<>();
+		try (BufferedReader reader = Files.newBufferedReader(file.toPath())) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (!line.isBlank()) {
+					fileNames.add(new File(line).getName());
+				}
+			}
+		}
+		assertTrue("consumer.bundle jar not found in client.bundle dependencies: " + fileNames,
+				fileNames.stream().anyMatch(name -> name.startsWith("consumer.bundle-")));
+		assertTrue("provider.bundle jar not found in client.bundle dependencies: " + fileNames,
+				fileNames.stream().anyMatch(name -> name.startsWith("provider.bundle-")));
 	}
 
 }


### PR DESCRIPTION
This pull request introduces a mechanism to break direct dependency cycles caused by `Require-Capability` requirements in OSGi bundles during the Maven/Tycho reactor build. It does this by allowing specific capability requirements to be disabled for a project build via profile properties, while keeping them active for consumers and in published metadata. The PR also adds a comprehensive integration test to verify this behavior using a simulated real-world scenario.

This change enables Tycho to build projects that would otherwise be blocked by direct dependency cycles in OSGi metadata, by allowing targeted disabling of capability requirements during the build, without affecting runtime or consumers.

See also
- https://github.com/eclipse-equinox/p2/pull/1073