### PR TITLE
Import junit-bom to align JUnit artifact versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,10 +230,12 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-api</artifactId>
+				<!-- aligns junit-jupiter-*, junit-platform-* and junit-vintage-* on a single version -->
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
 				<version>${junit.version}</version>
-				<scope>test</scope>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.plexus</groupId>

--- a/tycho-extras/tycho-dependency-tools-plugin/pom.xml
+++ b/tycho-extras/tycho-dependency-tools-plugin/pom.xml
@@ -42,7 +42,6 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tycho-its/pom.xml
+++ b/tycho-its/pom.xml
@@ -176,23 +176,19 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${junit.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
-			<version>${junit.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-suite-engine</artifactId>
-			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tycho-surefire/org.eclipse.tycho.bnd.executionlistener/pom.xml
+++ b/tycho-surefire/org.eclipse.tycho.bnd.executionlistener/pom.xml
@@ -13,7 +13,6 @@
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>${junit.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/tycho-testing-harness/pom.xml
+++ b/tycho-testing-harness/pom.xml
@@ -71,12 +71,10 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<version>${junit.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.junit.platform</groupId>
 		    <artifactId>junit-platform-suite-engine</artifactId>
-		    <version>${junit.version}</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Every JUnit artifact declared ${junit.version} on its own. That lets the jupiter, platform and vintage artifacts drift apart as soon as one of them pulls in a transitive platform version, so import org.junit:junit-bom once and drop the individual <version> declarations.

The junit-jupiter-api dependencyManagement entry goes with them. Every consumer already declares <scope>test</scope> itself, and the managed test scope was forcing junit-jupiter-api down to test scope in tycho-testing-harness and tycho-its even though the junit-jupiter-params/junit-jupiter that pull it in transitively are compile scoped there.

No artifact version changes: junit 4.13.2, JUnit 6.1.2 and hamcrest 3.0 resolve exactly as before across the reactor.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])