### PR TITLE
Reduce Helios p2 repo usage in tests

### DIFF
--- a/tycho-its/projects/sourcePlugin/extra-source-bundles/pom.xml
+++ b/tycho-its/projects/sourcePlugin/extra-source-bundles/pom.xml
@@ -6,18 +6,11 @@
 	<artifactId>source-feature-parent</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
-
-
-	<properties>
-		<e342-repo>https://download.eclipse.org/releases/helios</e342-repo>
-	</properties>
-
-
 	<repositories>
 		<repository>
 			<id>eclipse</id>
 			<layout>p2</layout>
-			<url>${e342-repo}</url>
+			<url>${target-platform}</url>
 		</repository>
 	</repositories>
 

--- a/tycho-its/projects/sourcePlugin/remote-source-bundles/pom.xml
+++ b/tycho-its/projects/sourcePlugin/remote-source-bundles/pom.xml
@@ -6,18 +6,11 @@
 	<artifactId>source-feature-parent</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
-
-
-	<properties>
-		<e342-repo>https://download.eclipse.org/releases/helios</e342-repo>
-	</properties>
-
-
 	<repositories>
 		<repository>
 			<id>eclipse</id>
 			<layout>p2</layout>
-			<url>${e342-repo}</url>
+			<url>${target-platform}</url>
 		</repository>
 	</repositories>
 

--- a/tycho-its/projects/sourcePlugin/remote-source-bundles/sourcefeature.feature/feature.xml
+++ b/tycho-its/projects/sourcePlugin/remote-source-bundles/sourcefeature.feature/feature.xml
@@ -8,15 +8,15 @@
          id="org.junit"
          download-size="0"
          install-size="0"
-         version="3.8.2.qualifier"
+         version="4.13.2.qualifier"
          unpack="false"/>
 
 
    <plugin
-         id="org.junit"
+         id="org.hamcrest.core"
          download-size="0"
          install-size="0"
-         version="4.8.1.qualifier"
+         version="2.2.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/TychoSourcePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/TychoSourcePluginTest.java
@@ -102,8 +102,7 @@ public class TychoSourcePluginTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testExtraSourceBundles() throws Exception {
-		Verifier verifier = getVerifier("/sourcePlugin/extra-source-bundles", false, false);
-		verifier.addCliOption("-De342-url=" + ECLIPSE_342.toString());
+		Verifier verifier = getVerifier("/sourcePlugin/extra-source-bundles", true, false);
 		verifier.executeGoals(List.of("clean", "install"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(),
@@ -138,15 +137,14 @@ public class TychoSourcePluginTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testRemoteSourceBundles() throws Exception {
-		Verifier verifier = getVerifier("/sourcePlugin/remote-source-bundles", false, false);
-		verifier.addCliOption("-De342-url=" + ECLIPSE_342.toString());
+		Verifier verifier = getVerifier("/sourcePlugin/remote-source-bundles", true, false);
 		verifier.executeGoals(List.of("clean", "install"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(),
-				"sourcefeature.repository/target/repository/plugins/org.junit.source_3.8.2.v3_8_2_v20100427-1100.jar");
+				"sourcefeature.repository/target/repository/plugins/org.junit.source_4.13.2.v20240929-1000.jar");
 		assertTrue("Missing expected file " + file.getName(), file.canRead());
 		file = new File(verifier.getBasedir(),
-				"sourcefeature.repository/target/repository/plugins/org.junit.source_4.8.1.v4_8_1_v20100427-1100.jar");
+				"sourcefeature.repository/target/repository/plugins/org.hamcrest.core.source_2.2.0.v20230809-1000.jar");
 		assertTrue("Missing expected file " + file.getName(), file.canRead());
 
 	}


### PR DESCRIPTION
Switch the source bundle integration fixtures from the old Helios-era p2 repository to the build target platform. Update the remote source-bundle expectations to the latest org.junit and org.hamcrest source artifacts and use the target-platform verifier path in the tests.