### PR TITLE
Pass the test method filter to the test provider

### DIFF
--- a/tycho-its/projects/surefire.testSelection/src/bundle/MixedTest.java
+++ b/tycho-its/projects/surefire.testSelection/src/bundle/MixedTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2026 others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package bundle;
+
+import org.junit.Test;
+
+public class MixedTest
+{
+    @Test
+    public void working()
+    {
+    }
+
+    @Test
+    public void broken()
+    {
+        throw new RuntimeException();
+    }
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/RunSingleTestTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/RunSingleTestTest.java
@@ -26,4 +26,17 @@ public class RunSingleTestTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("integration-test");
 		verifier.verifyErrorFreeLog();
 	}
+
+	@Test
+	public void testSingleMethod() throws Exception {
+		Verifier verifier = getVerifier("surefire.testSelection");
+
+		// the method suffix must reach the test provider, see
+		// https://github.com/eclipse-tycho/tycho/issues/6217; MixedTest#broken throws, so a dropped
+		// suffix fails the log check
+		verifier.addCliOption("-Dtest=bundle.MixedTest#working");
+		verifier.executeGoal("integration-test");
+		verifier.verifyErrorFreeLog();
+		verifier.verifyTextInLog("Tests run: 1");
+	}
 }

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
@@ -202,8 +202,12 @@ public class OsgiSurefireBooter {
         DirectoryScannerParameters dirScannerParams = new DirectoryScannerParameters(testClassesDir,
                 Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), runOrder);
         ReporterConfiguration reporterConfig = new ReporterConfiguration(reportsDir, trimStackTrace);
-        TestRequest testRequest = new TestRequest(suiteXmlFiles, testClassesDir,
-                TestListResolver.getEmptyTestListResolver(), rerunFailingTestsCount);
+        String requestedTest = testProps.getProperty("requestedTest");
+        TestListResolver testListResolver = requestedTest == null || requestedTest.trim().isEmpty()
+                ? TestListResolver.getEmptyTestListResolver()
+                : new TestListResolver(requestedTest);
+        TestRequest testRequest = new TestRequest(suiteXmlFiles, testClassesDir, testListResolver,
+                rerunFailingTestsCount);
         ProviderConfiguration providerConfiguration = new ProviderConfiguration(dirScannerParams,
                 new RunOrderParameters(runOrder, null), reporterConfig, null, testRequest,
                 extractProviderProperties(testProps), null, false, Collections.emptyList(), skipAfterFailureCount,

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractEclipseTestMojo.java
@@ -923,6 +923,12 @@ public abstract class AbstractEclipseTestMojo extends AbstractTestMojo {
         wrapper.setProperty("trimStackTrace", String.valueOf(trimStackTrace));
         wrapper.setProperty("skipAfterFailureCount", String.valueOf(skipAfterFailureCount));
         wrapper.setProperty("rerunFailingTestsCount", String.valueOf(rerunFailingTestsCount));
+        if (test != null && test.contains("#")) {
+            // only a method-qualified filter needs to reach the provider: plain class selection is
+            // already narrowed by the scan, and forwarding it unconditionally would change the
+            // established pattern semantics
+            wrapper.setProperty("requestedTest", test);
+        }
         wrapper.setProperty("printBundles", String.valueOf(printBundles));
         wrapper.setProperty("printWires", String.valueOf(printWires));
         wrapper.setProperty("classLoaderOrder", classLoaderOrder.toString());


### PR DESCRIPTION
Fixes #6217.

The test mojo accepts `-Dtest=Class#method`, and the scan resolves the class, but `OsgiSurefireBooter` builds the `TestRequest` with an unconditional `TestListResolver.getEmptyTestListResolver()`, so the provider never sees the method part and runs the whole class.

This change forwards the filter through the surefire properties and constructs a real `TestListResolver` from it in the booter. The filter only travels when it carries a `#` method suffix: plain class selection is already narrowed by the scan, and forwarding it unconditionally would change the established pattern semantics, so this stays the minimal slice discussed on the issue.

Validation:

- New IT case `RunSingleTestTest.testSingleMethod` selects `bundle.MixedTest#working` in a fixture whose other method throws, and additionally checks `Tests run: 1` in the log. It passes with the change and fails without it (the throwing method runs), so the case is two-sided.
- Verified end to end on the PDE reactor where #6217 was found: with this change, `-Dtest=HybridizeFunctionRefactoringProcessorTest#testSetInferInputSignatures` runs exactly that one test under the junit4 provider instead of the whole class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AM8pvSeP5UqDyyTn9h5E2P