### PR TITLE
Run tycho-artifactcomparator tests on JUnit Jupiter

### DIFF
--- a/tycho-artifactcomparator/pom.xml
+++ b/tycho-artifactcomparator/pom.xml
@@ -46,8 +46,8 @@
 			<artifactId>plexus-component-annotations</artifactId>
 		</dependency>
 		<dependency>
-			<artifactId>junit</artifactId>
-			<groupId>junit</groupId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tycho-artifactcomparator/src/test/java/org/eclipse/tycho/jarcomparator/tests/CompoundArtifactDeltaTest.java
+++ b/tycho-artifactcomparator/src/test/java/org/eclipse/tycho/jarcomparator/tests/CompoundArtifactDeltaTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.jarcomparator.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 import java.util.TreeMap;
@@ -20,7 +20,7 @@ import java.util.TreeMap;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 import org.eclipse.tycho.zipcomparator.internal.CompoundArtifactDelta;
 import org.eclipse.tycho.zipcomparator.internal.SimpleArtifactDelta;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompoundArtifactDeltaTest {
 

--- a/tycho-artifactcomparator/src/test/java/org/eclipse/tycho/jarcomparator/tests/ContentsComparatorTest.java
+++ b/tycho-artifactcomparator/src/test/java/org/eclipse/tycho/jarcomparator/tests/ContentsComparatorTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.jarcomparator.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileInputStream;
 import java.io.InputStream;

--- a/tycho-artifactcomparator/src/test/java/org/eclipse/tycho/zipcomparator/internal/TextComparatorTest.java
+++ b/tycho-artifactcomparator/src/test/java/org/eclipse/tycho/zipcomparator/internal/TextComparatorTest.java
@@ -1,7 +1,7 @@
 package org.eclipse.tycho.zipcomparator.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -10,7 +10,7 @@ import java.util.List;
 import org.eclipse.tycho.artifactcomparator.ArtifactComparator.ComparisonData;
 import org.eclipse.tycho.artifactcomparator.ArtifactDelta;
 import org.eclipse.tycho.artifactcomparator.ComparatorInputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TextComparatorTest {
     private static final String NL = System.lineSeparator();


### PR DESCRIPTION
ContentsComparatorTest was already a Jupiter @PlexusTest that pulled its assertions from org.junit.Assert, while CompoundArtifactDeltaTest and TextComparatorTest were plain JUnit 4. Move all three to the Jupiter API and replace the junit:junit test dependency with the junit-jupiter aggregate, which leaves JUnit 4 and hamcrest off this module's test classpath entirely, so any future org.junit import here is a compile error rather than a silently skipped test.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])