### PR TITLE
fix: Report the artifact path when feature metadata parsing fails

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/p2resolver/P2GeneratorImpl.java
@@ -277,6 +277,10 @@ public class P2GeneratorImpl extends AbstractMetadataGenerator implements P2Gene
             }
         } else if (PackagingType.TYPE_ECLIPSE_FEATURE.equals(packaging)) {
             Feature feature = new FeatureParser().parse(location);
+            if (feature == null) {
+                throw new IllegalArgumentException(
+                        "Unable to read feature metadata from " + location.getAbsolutePath());
+            }
             feature.setLocation(location.getAbsolutePath());
             if (dependenciesOnly) {
                 actions.add(new FeatureDependenciesAction(feature));

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataGeneratorImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataGeneratorImplTest.java
@@ -13,7 +13,10 @@
 package org.eclipse.tycho.p2resolver;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -96,5 +99,36 @@ public class P2MetadataGeneratorImplTest {
                 environments, options);
         assertEquals("org.eclipse.tycho.p2.impl.test.bundle/1.0.0.qualifier",
                 metadata.getArtifactDescriptors().iterator().next().getProperty("download.stats"));
+    }
+
+    @Test
+    public void generateFeatureMetadata() throws Exception {
+        P2GeneratorImpl impl = new P2GeneratorImpl(false);
+        impl.setMavenContext(new MockMavenContext(null, logVerifier.getLogger()));
+        impl.setBuildPropertiesParser(new BuildPropertiesParserForTesting());
+        File location = new File("src/test/resources/generator/feature").getCanonicalFile();
+
+        DependencyMetadata metadata = impl.generateMetadata(new ArtifactMock(location,
+                "org.eclipse.tycho.p2.impl.test", "feature", "1.0.0-SNAPSHOT", PackagingType.TYPE_ECLIPSE_FEATURE),
+                List.of(), new PublisherOptions());
+
+        assertTrue(metadata.getInstallableUnits().stream()
+                .anyMatch(unit -> "org.eclipse.tycho.p2.impl.test.feature.feature.group".equals(unit.getId())));
+    }
+
+    @Test
+    public void reportFeatureLocationWhenMetadataCannotBeRead() throws Exception {
+        P2GeneratorImpl impl = new P2GeneratorImpl(false);
+        impl.setMavenContext(new MockMavenContext(null, logVerifier.getLogger()));
+        impl.setBuildPropertiesParser(new BuildPropertiesParserForTesting());
+        File location = new File("src/test/resources/generator/bundle").getCanonicalFile();
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> impl.generateMetadata(new ArtifactMock(location, "org.eclipse.tycho.p2.impl.test", "feature",
+                        "1.0.0-SNAPSHOT", PackagingType.TYPE_ECLIPSE_FEATURE), List.of(), new PublisherOptions()));
+
+        assertTrue(exception.getMessage().contains("Unable to read feature metadata"));
+        assertTrue(exception.getMessage().contains(location.getAbsolutePath()));
+        assertFalse(exception.getMessage().contains("Feature.setLocation"));
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataGeneratorImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataGeneratorImplTest.java
@@ -13,7 +13,10 @@
 package org.eclipse.tycho.p2resolver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -96,5 +99,36 @@ public class P2MetadataGeneratorImplTest {
                 environments, options);
         assertEquals("org.eclipse.tycho.p2.impl.test.bundle/1.0.0.qualifier",
                 metadata.getArtifactDescriptors().iterator().next().getProperty("download.stats"));
+    }
+
+    @Test
+    public void generateFeatureMetadata() throws Exception {
+        P2GeneratorImpl impl = new P2GeneratorImpl(false);
+        impl.setMavenContext(new MockMavenContext(null, logVerifier.getLogger()));
+        impl.setBuildPropertiesParser(new BuildPropertiesParserForTesting());
+        File location = new File("src/test/resources/generator/feature").getCanonicalFile();
+
+        DependencyMetadata metadata = impl.generateMetadata(new ArtifactMock(location,
+                "org.eclipse.tycho.p2.impl.test", "feature", "1.0.0-SNAPSHOT", PackagingType.TYPE_ECLIPSE_FEATURE),
+                List.of(), new PublisherOptions());
+
+        assertTrue(metadata.getInstallableUnits().stream()
+                .anyMatch(unit -> "org.eclipse.tycho.p2.impl.test.feature.feature.group".equals(unit.getId())));
+    }
+
+    @Test
+    public void reportFeatureLocationWhenMetadataCannotBeRead() throws Exception {
+        P2GeneratorImpl impl = new P2GeneratorImpl(false);
+        impl.setMavenContext(new MockMavenContext(null, logVerifier.getLogger()));
+        impl.setBuildPropertiesParser(new BuildPropertiesParserForTesting());
+        File location = new File("src/test/resources/generator/bundle").getCanonicalFile();
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> impl.generateMetadata(new ArtifactMock(location, "org.eclipse.tycho.p2.impl.test", "feature",
+                        "1.0.0-SNAPSHOT", PackagingType.TYPE_ECLIPSE_FEATURE), List.of(), new PublisherOptions()));
+
+        assertTrue(exception.getMessage().contains("Unable to read feature metadata"));
+        assertTrue(exception.getMessage().contains(location.getAbsolutePath()));
+        assertFalse(exception.getMessage().contains("Feature.setLocation"));
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataGeneratorImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataGeneratorImplTest.java
@@ -100,35 +100,4 @@ public class P2MetadataGeneratorImplTest {
         assertEquals("org.eclipse.tycho.p2.impl.test.bundle/1.0.0.qualifier",
                 metadata.getArtifactDescriptors().iterator().next().getProperty("download.stats"));
     }
-
-    @Test
-    public void generateFeatureMetadata() throws Exception {
-        P2GeneratorImpl impl = new P2GeneratorImpl(false);
-        impl.setMavenContext(new MockMavenContext(null, logVerifier.getLogger()));
-        impl.setBuildPropertiesParser(new BuildPropertiesParserForTesting());
-        File location = new File("src/test/resources/generator/feature").getCanonicalFile();
-
-        DependencyMetadata metadata = impl.generateMetadata(new ArtifactMock(location,
-                "org.eclipse.tycho.p2.impl.test", "feature", "1.0.0-SNAPSHOT", PackagingType.TYPE_ECLIPSE_FEATURE),
-                List.of(), new PublisherOptions());
-
-        assertTrue(metadata.getInstallableUnits().stream()
-                .anyMatch(unit -> "org.eclipse.tycho.p2.impl.test.feature.feature.group".equals(unit.getId())));
-    }
-
-    @Test
-    public void reportFeatureLocationWhenMetadataCannotBeRead() throws Exception {
-        P2GeneratorImpl impl = new P2GeneratorImpl(false);
-        impl.setMavenContext(new MockMavenContext(null, logVerifier.getLogger()));
-        impl.setBuildPropertiesParser(new BuildPropertiesParserForTesting());
-        File location = new File("src/test/resources/generator/bundle").getCanonicalFile();
-
-        RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> impl.generateMetadata(new ArtifactMock(location, "org.eclipse.tycho.p2.impl.test", "feature",
-                        "1.0.0-SNAPSHOT", PackagingType.TYPE_ECLIPSE_FEATURE), List.of(), new PublisherOptions()));
-
-        assertTrue(exception.getMessage().contains("Unable to read feature metadata"));
-        assertTrue(exception.getMessage().contains(location.getAbsolutePath()));
-        assertFalse(exception.getMessage().contains("Feature.setLocation"));
-    }
 }

--- a/tycho-its/projects/feature.invalidMetadata/feature.xml
+++ b/tycho-its/projects/feature.invalidMetadata/feature.xml
@@ -1,1 +1,1 @@
-<feature
+<invalid-feature id="feature.invalidMetadata" version="1.0.0"/>

--- a/tycho-its/projects/feature.invalidMetadata/feature.xml
+++ b/tycho-its/projects/feature.invalidMetadata/feature.xml
@@ -1,0 +1,1 @@
+<feature

--- a/tycho-its/projects/feature.invalidMetadata/pom.xml
+++ b/tycho-its/projects/feature.invalidMetadata/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>tycho-its-project.feature.invalid-metadata</groupId>
+	<artifactId>feature.invalidMetadata</artifactId>
+	<version>1.0.0</version>
+	<packaging>eclipse-feature</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/feature/InvalidFeatureMetadataTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/feature/InvalidFeatureMetadataTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.test.feature;
+
+import static org.junit.Assert.assertThrows;
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class InvalidFeatureMetadataTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void reportsFeatureLocationWhenMetadataCannotBeRead() throws Exception {
+		Verifier verifier = getVerifier("feature.invalidMetadata", false);
+		assertThrows(VerificationException.class, () -> verifier.executeGoal("package"));
+		verifier.verifyTextInLog("Unable to read feature metadata from " + verifier.getBasedir());
+	}
+}


### PR DESCRIPTION
In the existing `eclipse-feature` branch of `P2GeneratorImpl.getPublisherActions`, validate the result returned by `FeatureParser` before creating publisher actions. Feature metadata generation can fail semi-randomly when `FeatureParser` cannot produce a feature model for an `eclipse-feature` artifact, reportedly in Tycho 4.0.13 and 5.0.3.

Generate metadata for the existing valid feature fixture and confirm feature publishing still succeeds, protecting the normal `eclipse-feature` path from regression; Generate metadata for an `eclipse-feature` artifact whose location cannot be parsed into a feature model and assert that generation fails with a message containing that artifact's canonical or absolute path.

Fixes #6169
