### PR TITLE
Run tycho-surefire-plugin tests on JUnit Jupiter

### DIFF
--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.tycho.surefire;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -33,7 +33,7 @@ import org.codehaus.plexus.util.ReflectionUtils;
 import org.eclipse.sisu.equinox.launching.DefaultEquinoxInstallationDescription;
 import org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxInstallation;
 import org.eclipse.sisu.equinox.launching.internal.EquinoxLaunchConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestMojoTest {
 
@@ -135,8 +135,8 @@ public class TestMojoTest {
     public void testParallelModeMissingThreadCountParameter() throws Exception {
         AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
-        assertThrows("MojoExecutionException expected since threadCount parameter is missing",
-                MojoExecutionException.class, () -> testMojo.getMergedProviderProperties());
+        assertThrows(MojoExecutionException.class, () -> testMojo.getMergedProviderProperties(),
+                "MojoExecutionException expected since threadCount parameter is missing");
     }
 
     @Test
@@ -144,8 +144,8 @@ public class TestMojoTest {
         AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "threadCount", 1);
-        assertThrows("MojoExecutionException expected since threadCount parameter is missing",
-                MojoExecutionException.class, () -> testMojo.getMergedProviderProperties());
+        assertThrows(MojoExecutionException.class, () -> testMojo.getMergedProviderProperties(),
+                "MojoExecutionException expected since threadCount parameter is missing");
     }
 
     @Test
@@ -168,12 +168,12 @@ public class TestMojoTest {
         assertEquals("true", providerProperties.get("useUnlimitedThreads"));
     }
 
-    @Test(expected = MojoExecutionException.class)
+    @Test
     public void testParallelModeWithPerCoreThreadCountMissingCount() throws Exception {
         AbstractEclipseTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "perCoreThreadCount", true);
-        testMojo.getMergedProviderProperties();
+        assertThrows(MojoExecutionException.class, () -> testMojo.getMergedProviderProperties());
     }
 
     @Test

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/AbstractJUnitProviderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/AbstractJUnitProviderTest.java
@@ -13,8 +13,8 @@
 
 package org.eclipse.tycho.surefire.provider.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,8 +23,8 @@ import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.core.osgitools.DefaultClasspathEntry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractJUnitProviderTest {
 
@@ -35,7 +35,7 @@ public abstract class AbstractJUnitProviderTest {
 
     protected abstract AbstractJUnitProvider createJUnitProvider();
 
-    @Before
+    @BeforeEach
     public void setup() {
         junitProvider = createJUnitProvider();
     }

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/JUnit6ProviderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/JUnit6ProviderTest.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.tycho.surefire.provider.impl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JUnit6ProviderTest extends AbstractJUnitProviderTest {
 

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/Junit47ProviderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/Junit47ProviderTest.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.tycho.surefire.provider.impl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Junit47ProviderTest extends AbstractJUnitProviderTest {
 

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/ProviderHelperTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provider/impl/ProviderHelperTest.java
@@ -15,35 +15,36 @@ package org.eclipse.tycho.surefire.provider.impl;
 
 import static java.util.Collections.emptyList;
 import static org.eclipse.tycho.surefire.provider.impl.AbstractJUnitProviderTest.classPath;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import javax.inject.Inject;
+
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.testing.PlexusTest;
 import org.eclipse.tycho.ClasspathEntry;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
 
-public class ProviderHelperTest extends TychoPlexusTestCase {
+@PlexusTest
+public class ProviderHelperTest {
 
+    @Inject
+    private PlexusContainer container;
+
+    @Inject
     private ProviderHelper providerHelper;
-
-    @Before
-    public void setUpTest() throws Exception {
-        this.providerHelper = lookup(ProviderHelper.class);
-    }
 
     @Test
     public void testSelectJunit47() throws Exception {
@@ -129,7 +130,6 @@ public class ProviderHelperTest extends TychoPlexusTestCase {
                 return VersionRange.valueOf("1.0");
             }
         };
-        PlexusContainer container = getContainer();
         container.addComponent(anotherProvider, TestFrameworkProvider.class, "another_test_fwk");
         ProviderHelper providerSelector = container.lookup(ProviderHelper.class);
         try {

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilderTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/provisioning/ProvisionedInstallationBuilderTest.java
@@ -12,15 +12,17 @@
  *******************************************************************************/
 package org.eclipse.tycho.surefire.provisioning;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.tycho.PlatformPropertiesUtils;
 import org.eclipse.tycho.TargetEnvironment;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ProvisionedInstallationBuilderTest {
 
@@ -29,14 +31,14 @@ public class ProvisionedInstallationBuilderTest {
     private static final TargetEnvironment ENV_MACOS = new TargetEnvironment(PlatformPropertiesUtils.OS_MACOSX,
             PlatformPropertiesUtils.WS_COCOA, PlatformPropertiesUtils.ARCH_X86_64);
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir
+    Path tempDir;
 
     @Test
     public void setDestination_LayoutNormal() throws Exception {
         ProvisionedInstallationBuilder builder = new ProvisionedInstallationBuilder(null, null);
 
-        File work = tempDir.newFolder("work");
+        File work = newFolder("work");
         builder.setTargetEnvironment(ENV_LINUX);
         builder.setDestination(work);
         assertEquals(work, builder.getEffectiveDestination());
@@ -46,7 +48,7 @@ public class ProvisionedInstallationBuilderTest {
     public void setDestination_LayoutMacOS_NoAppBundleGiven() throws Exception {
         ProvisionedInstallationBuilder builder = new ProvisionedInstallationBuilder(null, null);
 
-        File work = tempDir.newFolder("work");
+        File work = newFolder("work");
         builder.setTargetEnvironment(ENV_MACOS);
         builder.setDestination(work);
         File destinationExpected = new File(work, "Eclipse.app/Contents/Eclipse");
@@ -57,7 +59,7 @@ public class ProvisionedInstallationBuilderTest {
     public void setDestination_LayoutMacOS_AppBundleRootGiven() throws Exception {
         ProvisionedInstallationBuilder builder = new ProvisionedInstallationBuilder(null, null);
 
-        File work = tempDir.newFolder("work.app");
+        File work = newFolder("work.app");
         builder.setTargetEnvironment(ENV_MACOS);
         builder.setDestination(work);
         File destinationExpected = new File(work, "Contents/Eclipse");
@@ -68,10 +70,14 @@ public class ProvisionedInstallationBuilderTest {
     public void setDestination_LayoutMacOS_InstallAreaInsideAppBundleGiven() throws Exception {
         ProvisionedInstallationBuilder builder = new ProvisionedInstallationBuilder(null, null);
 
-        File work = tempDir.newFolder("work.app/Contents/Eclipse");
+        File work = newFolder("work.app/Contents/Eclipse");
         builder.setTargetEnvironment(ENV_MACOS);
         builder.setDestination(work);
         assertEquals(work, builder.getEffectiveDestination());
+    }
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempDir.resolve(path)).toFile();
     }
 
 }


### PR DESCRIPTION
ProviderHelperTest becomes a plain @PlexusTest.

AbstractJUnitProviderTest converts together with Junit47ProviderTest and JUnit6ProviderTest, which inherit its setup and one of its tests.

ProvisionedInstallationBuilderTest uses @TempDir, and two assertThrows calls in TestMojoTest had the JUnit 4 message-first argument order.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])