### PR TITLE
Run the tycho-core p2resolver tests without shared rules on JUnit Jupiter

### DIFF
--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CompositeArtifactProviderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CompositeArtifactProviderTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.net.URI;
@@ -28,7 +28,7 @@ import org.eclipse.tycho.p2.repository.ArtifactTransferPolicy;
 import org.eclipse.tycho.p2.repository.CompositeArtifactProvider;
 import org.eclipse.tycho.p2.repository.FileRepositoryArtifactProvider;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompositeArtifactProviderTest extends CompositeArtifactProviderTestBase<IRawArtifactFileProvider> {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CompositeArtifactProviderTestBase.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CompositeArtifactProviderTestBase.java
@@ -35,10 +35,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -61,9 +61,9 @@ import org.eclipse.tycho.test.util.ProbeOutputStream;
 import org.eclipse.tycho.test.util.ProbeRawArtifactSink;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactProvider> extends TychoPlexusTestCase {
 
@@ -76,19 +76,19 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
 
     protected abstract T createCompositeArtifactProvider(URI... repositoryURLs) throws Exception;
 
-    @Before
+    @BeforeEach
     public void initContextAndSubject() throws Exception {
         subject = createCompositeArtifactProvider(TestRepositoryContent.REPO2_BUNDLE_A,
                 TestRepositoryContent.REPO_BUNDLE_AB);
     }
 
-    @After
+    @AfterEach
     public void checkStreamNotClosed() {
         // none of the tested methods should close the stream
         assertFalse(testOutputStream.isClosed());
     }
 
-    @After
+    @AfterEach
     public void checkStatusAndSinkConsistency() {
         if (testSink != null) {
             testSink.checkConsistencyWithStatus(status);

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CustomEEResolutionHintsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CustomEEResolutionHintsTest.java
@@ -14,9 +14,10 @@
 package org.eclipse.tycho.p2resolver;
 
 import static org.eclipse.tycho.core.test.utils.ResourceUtil.resourceFile;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Set;
 
@@ -28,7 +29,7 @@ import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.tycho.core.ee.impl.CustomEEResolutionHints;
 import org.eclipse.tycho.core.ee.impl.InvalidEENameException;
 import org.eclipse.tycho.test.util.InstallableUnitUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CustomEEResolutionHintsTest {
 
@@ -56,14 +57,14 @@ public class CustomEEResolutionHintsTest {
         assertFalse(subject.isEESpecificationUnit(CUSTOM_PROFILE_IU_OTHER_VERSION));
     }
 
-    @Test(expected = InvalidEENameException.class)
+    @Test
     public void testProfileNameWithoutVersion() {
-        subject = new CustomEEResolutionHints("Virgo/Java6");
+        assertThrows(InvalidEENameException.class, () -> subject = new CustomEEResolutionHints("Virgo/Java6"));
     }
 
-    @Test(expected = InvalidEENameException.class)
+    @Test
     public void testProfileNameWithInvalidVersion() {
-        subject = new CustomEEResolutionHints("Virgo/Java-1.6a");
+        assertThrows(InvalidEENameException.class, () -> subject = new CustomEEResolutionHints("Virgo/Java-1.6a"));
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/DuplicateFilteringLoggingProgressMonitorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/DuplicateFilteringLoggingProgressMonitorTest.java
@@ -1,17 +1,17 @@
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.tycho.core.shared.DuplicateFilteringLoggingProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DuplicateFilteringLoggingProgressMonitorTest {
 
     private DuplicateFilteringLoggingProgressMonitor monitor;
 
-    @Before
+    @BeforeEach
     public void before() {
         monitor = new DuplicateFilteringLoggingProgressMonitor(null);
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootAdviceFilesTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootAdviceFilesTest.java
@@ -22,8 +22,9 @@ import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.WINDOWS_SPEC_FO
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createAdvice;
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createBuildPropertiesWithDefaultRootFiles;
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createBuildPropertiesWithoutRootKeys;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.Properties;
@@ -33,7 +34,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils.IPathComputer;
 import org.eclipse.equinox.p2.publisher.actions.IFeatureRootAdvice;
 import org.eclipse.tycho.p2.publisher.rootfiles.FileToPathMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeatureRootAdviceFilesTest {
 
@@ -179,7 +180,7 @@ public class FeatureRootAdviceFilesTest {
     private static void assertRootFileEntry(FileToPathMap winFilesMap, String expectedPathInSources,
             String expectedPathInInstallation) {
         IPath actualPathInInstallation = winFilesMap.get(getResourceFile(expectedPathInSources));
-        assertFalse("File not included as root file: " + expectedPathInSources, actualPathInInstallation == null);
+        assertNotNull(actualPathInInstallation, "File not included as root file: " + expectedPathInSources);
         assertFalse(actualPathInInstallation.isAbsolute());
         assertEquals(new Path(expectedPathInInstallation), actualPathInInstallation);
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootAdviceLinksTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootAdviceLinksTest.java
@@ -20,12 +20,13 @@ import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.callGetDescript
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createAdvice;
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createBuildPropertiesWithDefaultRootFiles;
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createBuildPropertiesWithoutRootKeys;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Properties;
 
 import org.eclipse.equinox.p2.publisher.actions.IFeatureRootAdvice;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeatureRootAdviceLinksTest {
     @Test
@@ -77,39 +78,38 @@ public class FeatureRootAdviceLinksTest {
         assertEquals("file1.txt,alias1.txt,dir/file3.txt,alias2.txt,file2.txt,alias3.txt", actualLinks);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWrongRootfilesLinksKey() throws Exception {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
 
         buildProperties.put("root.link.addedTooMuch", "file1.txt,alias.txt");
-        createAdvice(buildProperties);
+        assertThrows(IllegalArgumentException.class, () -> createAdvice(buildProperties));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGlobalLinkButNoFiles() throws Exception {
         Properties buildProperties = createBuildPropertiesWithoutRootKeys();
         buildProperties.put("root.link", "file1.txt,alias.txt");
 
         IFeatureRootAdvice advice = createAdvice(buildProperties);
-        callGetDescriptorsForAllConfigurations(advice);
+        assertThrows(IllegalArgumentException.class, () -> callGetDescriptorsForAllConfigurations(advice));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSpecificLinkButNoFiles() throws Exception {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root." + WINDOWS_SPEC_FOR_PROPERTIES_KEY + ".link", "file1.txt,alias.txt");
 
         IFeatureRootAdvice advice = createAdvice(buildProperties);
-        callGetDescriptorsForAllConfigurations(advice);
+        assertThrows(IllegalArgumentException.class, () -> callGetDescriptorsForAllConfigurations(advice));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLinkValueNotInPairs() throws Exception {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root.link", "file1.txt,alias1.txt,file2.txt");
 
-        IFeatureRootAdvice advice = createAdvice(buildProperties);
-        callGetDescriptorsForAllConfigurations(advice);
+        assertThrows(IllegalArgumentException.class, () -> createAdvice(buildProperties));
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootAdvicePermissionsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootAdvicePermissionsTest.java
@@ -20,7 +20,8 @@ import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.callGetDescript
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createAdvice;
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createBuildPropertiesWithDefaultRootFiles;
 import static org.eclipse.tycho.p2resolver.FeatureRootAdviceTest.createBuildPropertiesWithoutRootKeys;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,8 +31,8 @@ import java.util.List;
 import java.util.Properties;
 
 import org.eclipse.equinox.p2.publisher.actions.IFeatureRootAdvice;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class FeatureRootAdvicePermissionsTest {
 
@@ -83,44 +84,44 @@ public class FeatureRootAdvicePermissionsTest {
         assertPermissionEntry("file2.txt", "755", list.get(2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGlobalPermissionsChmodMissing() throws Exception {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root.permissions", "file1.txt");
-        createAdvice(buildProperties).getDescriptor(GLOBAL_SPEC);
+        assertThrows(IllegalArgumentException.class, () -> createAdvice(buildProperties).getDescriptor(GLOBAL_SPEC));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSpecificPermissionsChmodMissing() throws Exception {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root." + WINDOWS_SPEC_FOR_PROPERTIES_KEY + ".permissions", "rootfiles/file1.txt");
-        createAdvice(buildProperties).getDescriptor(GLOBAL_SPEC);
+        assertThrows(IllegalArgumentException.class, () -> createAdvice(buildProperties).getDescriptor(GLOBAL_SPEC));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGlobalPermissionsButNoFiles() throws Exception {
         Properties buildProperties = createBuildPropertiesWithoutRootKeys();
         buildProperties.put("root.permissions.644", "file2.txt");
 
         IFeatureRootAdvice advice = createAdvice(buildProperties);
-        callGetDescriptorsForAllConfigurations(advice);
+        assertThrows(IllegalArgumentException.class, () -> callGetDescriptorsForAllConfigurations(advice));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSpecificPermissionsButNoFiles() throws Exception {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root." + LINUX_SPEC_FOR_PROPERTIES_KEY + ".permissions.644", "file2.txt");
 
         IFeatureRootAdvice advice = createAdvice(buildProperties);
-        callGetDescriptorsForAllConfigurations(advice);
+        assertThrows(IllegalArgumentException.class, () -> callGetDescriptorsForAllConfigurations(advice));
     }
 
-    @Ignore
-    @Test(expected = IllegalArgumentException.class)
+    @Disabled
+    @Test
     public void testPermissionsChmodInvalidValue() throws Exception {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root.permissions.og-rwx", "file1.txt");
-        createAdvice(buildProperties).getDescriptor(GLOBAL_SPEC);
+        assertThrows(IllegalArgumentException.class, () -> createAdvice(buildProperties).getDescriptor(GLOBAL_SPEC));
     }
 
     private static List<String[]> createAdviceAndGetPermissions(Properties buildProperties, String configSpec) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootAdviceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootAdviceTest.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,8 +28,8 @@ import org.eclipse.tycho.core.BuildPropertiesImpl;
 import org.eclipse.tycho.p2.publisher.rootfiles.FeatureRootAdvice;
 import org.eclipse.tycho.test.util.ArtifactMock;
 import org.eclipse.tycho.test.util.BuildPropertiesParserForTesting;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class FeatureRootAdviceTest {
     static final String GLOBAL_SPEC = "";
@@ -129,29 +130,29 @@ public class FeatureRootAdviceTest {
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testParseBuildPropertiesInvalidConfigs() {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root.invalid.key", "file:rootfiles/file1.txt");
 
-        createAdvice(buildProperties);
+        assertThrows(IllegalArgumentException.class, () -> createAdvice(buildProperties));
     }
 
-    @Ignore("No check that config specs are valid")
-    @Test(expected = IllegalArgumentException.class)
+    @Disabled("No check that config specs are valid")
+    @Test
     public void testParseBuildPropertiesInvalidConfigs2() {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root.ws.os.arch", "file:rootfiles/file1.txt");
 
-        createAdvice(buildProperties);
+        assertThrows(IllegalArgumentException.class, () -> createAdvice(buildProperties));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testParseBuildPropertiesWithTrailingDots() {
         Properties buildProperties = createBuildPropertiesWithDefaultRootFiles();
         buildProperties.put("root..", "file:rootfiles/file1.txt");
 
-        createAdvice(buildProperties);
+        assertThrows(IllegalArgumentException.class, () -> createAdvice(buildProperties));
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootfileArtifactRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootfileArtifactRepositoryTest.java
@@ -12,8 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -32,19 +36,18 @@ import org.eclipse.tycho.p2.metadata.IP2Artifact;
 import org.eclipse.tycho.p2.publisher.rootfiles.FeatureRootAdvice;
 import org.eclipse.tycho.p2maven.advices.MavenPropertiesAdvice;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class FeatureRootfileArtifactRepositoryTest extends TychoPlexusTestCase {
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+    @TempDir
+    Path tempFolder;
 
     @Test
     public void testRepoWithAttachedArtifacts() throws Exception {
         FeatureRootfileArtifactRepository subject = new FeatureRootfileArtifactRepository(createPublisherInfo(true),
-                tempFolder.newFolder("testrootfiles"));
+                newFolder("testrootfiles"));
 
         IArtifactDescriptor artifactDescriptor = createArtifactDescriptor(PublisherHelper.BINARY_ARTIFACT_CLASSIFIER,
                 "org.eclipse.tycho.test.p2");
@@ -54,7 +57,7 @@ public class FeatureRootfileArtifactRepositoryTest extends TychoPlexusTestCase {
         assertAttachedArtifact(subject.getPublishedArtifacts(), 1, "root", "org.eclipse.tycho.test.p2-1.0.0-root.zip");
 
         Set<IArtifactDescriptor> artifactDescriptors = subject.getArtifactDescriptors();
-        Assert.assertEquals(1, artifactDescriptors.size());
+        Assertions.assertEquals(1, artifactDescriptors.size());
 
         IArtifactDescriptor descriptor = artifactDescriptors.iterator().next();
         assertMavenProperties(descriptor, "root");
@@ -63,7 +66,7 @@ public class FeatureRootfileArtifactRepositoryTest extends TychoPlexusTestCase {
     @Test
     public void testRepoWithAttachedArtifactsAndConfigurations() throws Exception {
         FeatureRootfileArtifactRepository subject = new FeatureRootfileArtifactRepository(createPublisherInfo(true),
-                tempFolder.newFolder("testrootfiles"));
+                newFolder("testrootfiles"));
 
         IArtifactDescriptor artifactDescriptor = createArtifactDescriptor(PublisherHelper.BINARY_ARTIFACT_CLASSIFIER,
                 "org.eclipse.tycho.test.p2.win32.win32.x86");
@@ -74,7 +77,7 @@ public class FeatureRootfileArtifactRepositoryTest extends TychoPlexusTestCase {
                 "org.eclipse.tycho.test.p2.win32.win32.x86-1.0.0-root.zip");
 
         Set<IArtifactDescriptor> artifactDescriptors = subject.getArtifactDescriptors();
-        Assert.assertEquals(1, artifactDescriptors.size());
+        Assertions.assertEquals(1, artifactDescriptors.size());
 
         IArtifactDescriptor descriptor = artifactDescriptors.iterator().next();
         assertMavenProperties(descriptor, "root.win32.win32.x86");
@@ -83,7 +86,7 @@ public class FeatureRootfileArtifactRepositoryTest extends TychoPlexusTestCase {
     @Test
     public void testRepoWithoutMavenAdvice() throws Exception {
         FeatureRootfileArtifactRepository subject = new FeatureRootfileArtifactRepository(createPublisherInfo(false),
-                tempFolder.newFolder("testrootfiles"));
+                newFolder("testrootfiles"));
 
         IArtifactDescriptor artifactDescriptor = createArtifactDescriptor(PublisherHelper.BINARY_ARTIFACT_CLASSIFIER,
                 "org.eclipse.tycho.test.p2");
@@ -93,37 +96,37 @@ public class FeatureRootfileArtifactRepositoryTest extends TychoPlexusTestCase {
     @Test
     public void testRepoForNonBinaryArtifacts() throws Exception {
         FeatureRootfileArtifactRepository subject = new FeatureRootfileArtifactRepository(createPublisherInfo(true),
-                tempFolder.newFolder("testrootfiles"));
+                newFolder("testrootfiles"));
 
         IArtifactDescriptor artifactDescriptor = createArtifactDescriptor("non-binary-classifier",
                 "org.eclipse.tycho.test.p2");
         subject.getOutputStream(artifactDescriptor).close();
 
         Map<String, IP2Artifact> attachedArtifacts = subject.getPublishedArtifacts();
-        Assert.assertEquals(0, attachedArtifacts.size());
+        Assertions.assertEquals(0, attachedArtifacts.size());
     }
 
     @Test
     public void testRepoWithInitEmptyAttachedArtifacts() {
         FeatureRootfileArtifactRepository subject = new FeatureRootfileArtifactRepository(null, null);
-        Assert.assertEquals(0, subject.getPublishedArtifacts().size());
+        Assertions.assertEquals(0, subject.getPublishedArtifacts().size());
     }
 
     private void assertMavenProperties(IArtifactDescriptor descriptor, String root) {
-        Assert.assertEquals("artifactGroupId", descriptor.getProperty("maven-groupId"));
-        Assert.assertEquals("artifactId", descriptor.getProperty("maven-artifactId"));
-        Assert.assertEquals("artifactVersion", descriptor.getProperty("maven-version"));
-        Assert.assertEquals(root, descriptor.getProperty("maven-classifier"));
-        Assert.assertEquals("zip", descriptor.getProperty("maven-extension"));
+        Assertions.assertEquals("artifactGroupId", descriptor.getProperty("maven-groupId"));
+        Assertions.assertEquals("artifactId", descriptor.getProperty("maven-artifactId"));
+        Assertions.assertEquals("artifactVersion", descriptor.getProperty("maven-version"));
+        Assertions.assertEquals(root, descriptor.getProperty("maven-classifier"));
+        Assertions.assertEquals("zip", descriptor.getProperty("maven-extension"));
     }
 
     private void assertAttachedArtifact(Map<String, IP2Artifact> attachedArtifacts, int expectedSize,
             String expectedClassifier, String expectedLocationFileName) {
-        Assert.assertEquals(1, attachedArtifacts.size());
+        Assertions.assertEquals(1, attachedArtifacts.size());
 
         IP2Artifact artifactFacade = attachedArtifacts.get(expectedClassifier);
 
-        Assert.assertEquals(artifactFacade.getLocation().getName(), expectedLocationFileName);
+        Assertions.assertEquals(artifactFacade.getLocation().getName(), expectedLocationFileName);
     }
 
     private PublisherInfo createPublisherInfo(boolean addMavenPropertyAdvice) {
@@ -159,4 +162,8 @@ public class FeatureRootfileArtifactRepositoryTest extends TychoPlexusTestCase {
         return new BuildPropertiesImpl(buildProperties);
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempFolder.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FileRepositoryArtifactProviderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FileRepositoryArtifactProviderTest.java
@@ -15,8 +15,8 @@ package org.eclipse.tycho.p2resolver;
 
 import static org.eclipse.tycho.test.util.TestRepositoryContent.BUNDLE_A_KEY;
 import static org.eclipse.tycho.test.util.TestRepositoryContent.REPO_BUNDLE_AB;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
@@ -34,8 +34,8 @@ import org.eclipse.tycho.p2.repository.ArtifactTransferPolicy;
 import org.eclipse.tycho.p2.repository.FileRepositoryArtifactProvider;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FileRepositoryArtifactProviderTest extends TychoPlexusTestCase {
 
@@ -43,7 +43,7 @@ public class FileRepositoryArtifactProviderTest extends TychoPlexusTestCase {
 
     private IRawArtifactFileProvider subject;
 
-    @Before
+    @BeforeEach
     public void initContextAndSubject() throws Exception {
         subject = new FileRepositoryArtifactProvider(
                 Arrays.asList(TestRepositoryContent.REPO2_BUNDLE_A, REPO_BUNDLE_AB), TRANSFER_POLICY,

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FileSetTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FileSetTest.java
@@ -18,84 +18,84 @@ import java.io.File;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.tycho.p2.publisher.rootfiles.FileSet;
 import org.eclipse.tycho.p2.publisher.rootfiles.FileToPathMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class FileSetTest {
 
     @Test
     public void testDoubleStar() {
         FileSet doubleStarAtEnd = new FileSet(null, "test/**");
-        Assert.assertTrue(doubleStarAtEnd.matches(new Path("test/me/foo.txt")));
-        Assert.assertFalse(doubleStarAtEnd.matches(new Path("me/foo.txt")));
+        Assertions.assertTrue(doubleStarAtEnd.matches(new Path("test/me/foo.txt")));
+        Assertions.assertFalse(doubleStarAtEnd.matches(new Path("me/foo.txt")));
 
         FileSet doubleStarWithSlashAtEnd = new FileSet(null, "test/**/");
-        Assert.assertTrue(doubleStarWithSlashAtEnd.matches(new Path("test/me/foo.txt")));
-        Assert.assertFalse(doubleStarWithSlashAtEnd.matches(new Path("me/foo.txt")));
+        Assertions.assertTrue(doubleStarWithSlashAtEnd.matches(new Path("test/me/foo.txt")));
+        Assertions.assertFalse(doubleStarWithSlashAtEnd.matches(new Path("me/foo.txt")));
 
         FileSet doubleStarAtBeginning = new FileSet(null, "**/FILE");
-        Assert.assertTrue(doubleStarAtBeginning.matches(new Path("test/me/FILE")));
+        Assertions.assertTrue(doubleStarAtBeginning.matches(new Path("test/me/FILE")));
 
         FileSet doubleStarAtBeginningAndEnd = new FileSet(null, "**/DIR/**");
-        Assert.assertTrue(doubleStarAtBeginningAndEnd.matches(new Path("test/me/DIR/bar/test.txt")));
-        Assert.assertFalse(doubleStarAtBeginningAndEnd.matches(new Path("test/me/foobar/test.txt")));
-        Assert.assertFalse(doubleStarAtBeginningAndEnd.matches(new Path("test/me/DIR")));
+        Assertions.assertTrue(doubleStarAtBeginningAndEnd.matches(new Path("test/me/DIR/bar/test.txt")));
+        Assertions.assertFalse(doubleStarAtBeginningAndEnd.matches(new Path("test/me/foobar/test.txt")));
+        Assertions.assertFalse(doubleStarAtBeginningAndEnd.matches(new Path("test/me/DIR")));
     }
 
     @Test
     public void testSingleStar() {
         FileSet starAtBeginning = new FileSet(null, "*.txt");
-        Assert.assertTrue(starAtBeginning.matches(new Path("foo.txt")));
+        Assertions.assertTrue(starAtBeginning.matches(new Path("foo.txt")));
 
         FileSet starAtEnd = new FileSet(null, "bar*");
-        Assert.assertTrue(starAtEnd.matches(new Path("barfoo")));
-        Assert.assertFalse(starAtEnd.matches(new Path("foobar")));
+        Assertions.assertTrue(starAtEnd.matches(new Path("barfoo")));
+        Assertions.assertFalse(starAtEnd.matches(new Path("foobar")));
 
         FileSet starInMiddle = new FileSet(null, "bar*foo");
-        Assert.assertTrue(starInMiddle.matches(new Path("bar_test_foo")));
-        Assert.assertFalse(starInMiddle.matches(new Path("bar_test_fooX")));
+        Assertions.assertTrue(starInMiddle.matches(new Path("bar_test_foo")));
+        Assertions.assertFalse(starInMiddle.matches(new Path("bar_test_fooX")));
     }
 
     @Test
     public void testQuestionMark() {
         FileSet questionMarkPattern = new FileSet(null, "foo?.txt");
-        Assert.assertTrue(questionMarkPattern.matches(new Path("fooX.txt")));
-        Assert.assertFalse(questionMarkPattern.matches(new Path("fooXY.txt")));
-        Assert.assertFalse(questionMarkPattern.matches(new Path("XfooY.txt")));
+        Assertions.assertTrue(questionMarkPattern.matches(new Path("fooX.txt")));
+        Assertions.assertFalse(questionMarkPattern.matches(new Path("fooXY.txt")));
+        Assertions.assertFalse(questionMarkPattern.matches(new Path("XfooY.txt")));
     }
 
     @Test
     public void testCombined() {
         FileSet recursiveTxtPattern = new FileSet(null, "**/*.txt");
-        Assert.assertTrue(recursiveTxtPattern.matches(new Path("tmp/foo.txt")));
-        Assert.assertTrue(recursiveTxtPattern.matches(new Path("foo.txt")));
-        Assert.assertFalse(recursiveTxtPattern.matches(new Path("foo.txt_")));
+        Assertions.assertTrue(recursiveTxtPattern.matches(new Path("tmp/foo.txt")));
+        Assertions.assertTrue(recursiveTxtPattern.matches(new Path("foo.txt")));
+        Assertions.assertFalse(recursiveTxtPattern.matches(new Path("foo.txt_")));
         FileSet recursiveFilePrefixPattern = new FileSet(null, "**/prefix*");
-        Assert.assertTrue(recursiveFilePrefixPattern.matches(new Path("tmp/prefixfoo.txt")));
+        Assertions.assertTrue(recursiveFilePrefixPattern.matches(new Path("tmp/prefixfoo.txt")));
     }
 
     @Test
     public void testDefaultExcludes() {
         FileSet recursiveFileSet = new FileSet(null, "test/**");
-        Assert.assertTrue(recursiveFileSet.matches(new Path("test/me/foo.txt")));
-        Assert.assertFalse(recursiveFileSet.matches(new Path("test/CVS/foo.txt")));
-        Assert.assertFalse(recursiveFileSet.matches(new Path("test/.git/foo.txt")));
-        Assert.assertFalse(recursiveFileSet.matches(new Path("test/.svn/foo.txt")));
-        Assert.assertFalse(recursiveFileSet.matches(new Path("test/me/.svn")));
+        Assertions.assertTrue(recursiveFileSet.matches(new Path("test/me/foo.txt")));
+        Assertions.assertFalse(recursiveFileSet.matches(new Path("test/CVS/foo.txt")));
+        Assertions.assertFalse(recursiveFileSet.matches(new Path("test/.git/foo.txt")));
+        Assertions.assertFalse(recursiveFileSet.matches(new Path("test/.svn/foo.txt")));
+        Assertions.assertFalse(recursiveFileSet.matches(new Path("test/me/.svn")));
     }
 
     @Test
     public void testNoDefaultExcludes() {
         FileSet recursiveFileSet = new FileSet(null, "test/**", "", false);
-        Assert.assertTrue(recursiveFileSet.matches(new Path("test/CVS/foo.txt")));
-        Assert.assertTrue(recursiveFileSet.matches(new Path("test/.git/foo.txt")));
-        Assert.assertTrue(recursiveFileSet.matches(new Path("test/.svn/foo.txt")));
+        Assertions.assertTrue(recursiveFileSet.matches(new Path("test/CVS/foo.txt")));
+        Assertions.assertTrue(recursiveFileSet.matches(new Path("test/.git/foo.txt")));
+        Assertions.assertTrue(recursiveFileSet.matches(new Path("test/.svn/foo.txt")));
     }
 
     @Test
     public void testScan() {
         FileSet txtFileset = new FileSet(new File("src/test/resources/rootfiles"), "**/*.txt");
         FileToPathMap result = txtFileset.scan();
-        Assert.assertEquals(4, result.keySet().size());
+        Assertions.assertEquals(4, result.keySet().size());
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FileToPathMapTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FileToPathMapTest.java
@@ -12,21 +12,21 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.core.runtime.Path;
 import org.eclipse.tycho.p2.publisher.rootfiles.FileToPathMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FileToPathMapTest {
 
     private FileToPathMap map;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.map = new FileToPathMap();
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/GAVArtifactDescriptorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/GAVArtifactDescriptorTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
@@ -23,7 +23,7 @@ import org.eclipse.tycho.p2.repository.GAV;
 import org.eclipse.tycho.p2.repository.GAVArtifactDescriptor;
 import org.eclipse.tycho.p2.repository.MavenRepositoryCoordinates;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GAVArtifactDescriptorTest {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactTransferPolicyTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactTransferPolicyTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.util.HashSet;
@@ -32,7 +32,7 @@ import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2.repository.ArtifactTransferPolicy;
 import org.eclipse.tycho.p2.repository.LocalArtifactTransferPolicy;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalArtifactTransferPolicyTest extends TychoPlexusTestCase {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalMetadataRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalMetadataRepositoryTest.java
@@ -42,8 +42,8 @@ import org.eclipse.tycho.p2.repository.TychoRepositoryIndex;
 import org.eclipse.tycho.test.util.MockMavenContext;
 import org.eclipse.tycho.test.util.NoopFileLockService;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LocalMetadataRepositoryTest extends TychoPlexusTestCase {
     private IProgressMonitor monitor = new NullProgressMonitor();
@@ -54,7 +54,7 @@ public class LocalMetadataRepositoryTest extends TychoPlexusTestCase {
         createRepository(location);
 
         IMetadataRepository repository = loadRepository(location);
-        Assert.assertNotNull(repository);
+        Assertions.assertNotNull(repository);
     }
 
     protected IMetadataRepository loadRepository(File location) throws ProvisionException, ComponentLookupException {
@@ -107,14 +107,14 @@ public class LocalMetadataRepositoryTest extends TychoPlexusTestCase {
 
         IQueryResult<IInstallableUnit> result = repository.query(QueryUtil.ALL_UNITS, monitor);
         ArrayList<IInstallableUnit> allius = new ArrayList<>(result.toSet());
-        Assert.assertEquals(2, allius.size());
+        Assertions.assertEquals(2, allius.size());
 
         // as of e3.5.2 Collector uses HashSet internally and does not guarantee collected results order
         // 3.6 IQueryResult, too, is backed by HashSet. makes no sense.
-        // Assert.assertEquals( iu.getId(), allius.get( 0 ).getId() );
+        // Assertions.assertEquals( iu.getId(), allius.get( 0 ).getId() );
 
         Set<IInstallableUnit> ius = repository.getGAVs().get(RepositoryLayoutHelper.getGAV(iu.getProperties()));
-        Assert.assertEquals(1, ius.size());
+        Assertions.assertEquals(1, ius.size());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class LocalMetadataRepositoryTest extends TychoPlexusTestCase {
 
         // check: the artifact is in the index
         TychoRepositoryIndex metaIndex = createMetadataIndex(location);
-        Assert.assertFalse(metaIndex.getProjectGAVs().isEmpty());
+        Assertions.assertFalse(metaIndex.getProjectGAVs().isEmpty());
 
         // delete artifact from file system
         deleteDir(new File(location, "group"));
@@ -143,7 +143,7 @@ public class LocalMetadataRepositoryTest extends TychoPlexusTestCase {
         repository = (LocalMetadataRepository) loadRepository(location);
         repository.save();
         metaIndex = createMetadataIndex(location);
-        Assert.assertTrue(metaIndex.getProjectGAVs().isEmpty());
+        Assertions.assertTrue(metaIndex.getProjectGAVs().isEmpty());
 
     }
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MavenPropertiesAdviceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MavenPropertiesAdviceTest.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
 
 import org.eclipse.equinox.p2.metadata.MetadataFactory.InstallableUnitDescription;
 import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.p2maven.advices.MavenPropertiesAdvice;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MavenPropertiesAdviceTest {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MetadataSerializableImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MetadataSerializableImplTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -34,14 +34,14 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.p2tools.MetadataSerializableImpl;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MetadataSerializableImplTest extends TychoPlexusTestCase {
 
     private IProvisioningAgent agent;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         agent = lookup(IProvisioningAgent.class);
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleArtifactRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleArtifactRepositoryTest.java
@@ -15,9 +15,10 @@ package org.eclipse.tycho.p2resolver;
 import static org.eclipse.tycho.test.util.ArtifactRepositoryTestUtils.allKeysIn;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
@@ -25,6 +26,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
@@ -42,10 +45,9 @@ import org.eclipse.tycho.WriteSessionContext;
 import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2.repository.module.ModuleArtifactRepository;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
 
@@ -66,12 +68,12 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
 
     private static File existingModuleDir;
 
-    @Rule
-    public TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
     private ModuleArtifactRepository subject;
 
-    @BeforeClass
+    @BeforeAll
     public static void initBasicRepository() throws Exception {
         // this folder contains a ModuleArtifactRepository with BUNDLE_ARTIFACT_KEY and SOURCE_ARTIFACT_KEY ...
         existingModuleDir = ResourceUtil.resourceFile("repositories/module/basic/target");
@@ -95,32 +97,29 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
         assertEquals(1, subject.getArtifactDescriptors(SOURCE_ARTIFACT_KEY).length);
     }
 
-    @Test(expected = ProvisionException.class)
+    @Test
     public void testLoadRepositoryWithMissingGAVProperties() throws Exception {
         // repository with a missing groupId in one of the descriptors -> loading should fail
         File corruptRepository = ResourceUtil.resourceFile("repositories/module/missingGAV/target");
         generateDefaultRepositoryArtifacts(corruptRepository);
 
-        try {
-            subject = (ModuleArtifactRepository) loadRepositoryViaAgent(corruptRepository);
-        } catch (ProvisionException e) {
-            assertEquals(ProvisionException.REPOSITORY_FAILED_READ, e.getStatus().getCode());
-            assertThat(e.getStatus().getMessage(), containsString("Error while reading repository"));
-            assertThat(e.getStatus().getMessage(), containsString("Maven coordinate properties are missing"));
-            throw e;
-        }
+        ProvisionException e = assertThrows(ProvisionException.class,
+                () -> loadRepositoryViaAgent(corruptRepository));
+        assertEquals(ProvisionException.REPOSITORY_FAILED_READ, e.getStatus().getCode());
+        assertThat(e.getStatus().getMessage(), containsString("Error while reading repository"));
+        assertThat(e.getStatus().getMessage(), containsString("Maven coordinate properties are missing"));
     }
 
     @Test
     public void testCreateRepository() throws Exception {
-        subject = ModuleArtifactRepository.createInstance(null, tempManager.newFolder("targetDir"));
+        subject = ModuleArtifactRepository.createInstance(null, newFolder("targetDir"));
 
         assertTrue(allKeysIn(subject).isEmpty());
     }
 
     @Test
     public void testWriteToRepository() throws Exception {
-        subject = ModuleArtifactRepository.createInstance(null, tempManager.newFolder("targetDir"));
+        subject = ModuleArtifactRepository.createInstance(null, newFolder("targetDir"));
         subject.setGAV("", "", ""); // TODO this should not be necessary
 
         IArtifactSink sink = subject.newAddingArtifactSink(BINARY_ARTIFACT_KEY, new WriteSessionStub());
@@ -133,7 +132,7 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
     @SuppressWarnings("deprecation")
     @Test
     public void testWriteToRepositoryViaStream() throws Exception {
-        subject = ModuleArtifactRepository.createInstance(null, tempManager.newFolder("targetDir"));
+        subject = ModuleArtifactRepository.createInstance(null, newFolder("targetDir"));
 
         OutputStream outputStream = subject.getOutputStream(newDescriptor(BINARY_ARTIFACT_KEY));
         writeAndClose(outputStream, BINARY_ARTIFACT_SIZE);
@@ -143,7 +142,7 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testPersistEmptyRepository() throws Exception {
-        File repoDir = tempManager.newFolder("targetDir");
+        File repoDir = newFolder("targetDir");
         subject = ModuleArtifactRepository.createInstance(null, repoDir);
 
         IArtifactRepository result = loadRepositoryViaAgent(repoDir);
@@ -152,7 +151,7 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testPersistRepository() throws Exception {
-        File repoDir = tempManager.newFolder("targetDir");
+        File repoDir = newFolder("targetDir");
         subject = ModuleArtifactRepository.createInstance(null, repoDir);
 
         // TODO write via sink
@@ -178,7 +177,7 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
     @Test
     public void testRemovingWithOtherDescriptorType() throws Exception {
         // existingModuleDir points to the original source files -> use temporary repository instead so that we don't edit source files
-        subject = ModuleArtifactRepository.createInstance(null, tempManager.newFolder("targetDir"));
+        subject = ModuleArtifactRepository.createInstance(null, newFolder("targetDir"));
         // TODO write via sink
         OutputStream outputStream = subject.getOutputStream(newDescriptor(BINARY_ARTIFACT_KEY));
         writeAndClose(outputStream, BINARY_ARTIFACT_SIZE);
@@ -251,5 +250,9 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
         public ClassifierAndExtension getClassifierAndExtensionForNewKey(IArtifactKey key) {
             return new ClassifierAndExtension(key.getId(), "jar");
         }
+    }
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleMetadataRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleMetadataRepositoryTest.java
@@ -14,9 +14,12 @@ package org.eclipse.tycho.p2resolver;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -36,10 +39,9 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2.repository.module.ModuleMetadataRepository;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
 
@@ -48,12 +50,12 @@ public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
 
     private static File moduleDir;
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+    @TempDir
+    Path tempFolder;
 
     private IMetadataRepository subject;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() throws Exception {
         moduleDir = ResourceUtil.resourceFile("repositories/module/basic/target");
     }
@@ -76,7 +78,7 @@ public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testCreateRepository() throws Exception {
-        File targetFolder = tempFolder.newFolder("target");
+        File targetFolder = newFolder("target");
 
         subject = new ModuleMetadataRepository(null, targetFolder);
 
@@ -85,7 +87,7 @@ public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testUpdateRepository() throws Exception {
-        File targetFolder = tempFolder.newFolder("target");
+        File targetFolder = newFolder("target");
 
         subject = new ModuleMetadataRepository(null, targetFolder);
         subject.addInstallableUnits(createIUs(BUNDLE_UNIT));
@@ -95,7 +97,7 @@ public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testPersistEmptyRepository() throws Exception {
-        File targetFolder = tempFolder.newFolder("target");
+        File targetFolder = newFolder("target");
 
         subject = new ModuleMetadataRepository(null, targetFolder);
 
@@ -105,7 +107,7 @@ public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testPersistModifiedRepository() throws Exception {
-        File targetFolder = tempFolder.newFolder("target");
+        File targetFolder = newFolder("target");
 
         subject = new ModuleMetadataRepository(null, targetFolder);
         subject.addInstallableUnits(createIUs(SOURCE_UNIT));
@@ -141,5 +143,9 @@ public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
         IMetadataRepositoryManager repoManager = lookup(IProvisioningAgent.class)
                 .getService(IMetadataRepositoryManager.class);
         return repoManager.loadRepository(location.toURI(), null);
+    }
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempFolder.resolve(path)).toFile();
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataMojoTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataMojoTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -21,9 +21,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class P2MetadataMojoTest {
     private static final File MAIN_ARTIFACT = new File("bin.jar");
@@ -34,13 +34,13 @@ public class P2MetadataMojoTest {
 
     File testFile;
 
-    @Before
+    @BeforeEach
     public void init() throws Exception {
         testFile = File.createTempFile(this.getClass().getName(), ".properties");
         testFile.delete();
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         testFile.delete();
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ProviderOnlyArtifactRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ProviderOnlyArtifactRepositoryTest.java
@@ -19,9 +19,9 @@ import static org.eclipse.tycho.test.util.TestRepositoryContent.BUNDLE_A_FILES;
 import static org.eclipse.tycho.test.util.TestRepositoryContent.BUNDLE_A_KEY;
 import static org.eclipse.tycho.test.util.TestRepositoryContent.REPO_BUNDLE_AB;
 import static org.eclipse.tycho.test.util.TestRepositoryContent.REPO_BUNLDE_AB_PACK_CORRUPT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 
@@ -34,8 +34,8 @@ import org.eclipse.tycho.p2.repository.ProviderOnlyArtifactRepository;
 import org.eclipse.tycho.test.util.ProbeOutputStream;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class ProviderOnlyArtifactRepositoryTest extends TychoPlexusTestCase {
 
@@ -45,7 +45,7 @@ public class ProviderOnlyArtifactRepositoryTest extends TychoPlexusTestCase {
 
     private ProviderOnlyArtifactRepository subject;
 
-    @After
+    @AfterEach
     public void checkStreamNotClosed() {
         // none of the tested methods should close the stream
         assertFalse(testOutputStream.isClosed());

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishingRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishingRepositoryTest.java
@@ -17,13 +17,15 @@ import static org.eclipse.tycho.test.util.ArtifactRepositoryTestUtils.allKeysIn;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
@@ -40,24 +42,23 @@ import org.eclipse.tycho.p2.repository.PublishingRepository;
 import org.eclipse.tycho.p2.repository.module.PublishingRepositoryImpl;
 import org.eclipse.tycho.test.util.ReactorProjectIdentitiesStub;
 import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class PublishingRepositoryTest extends TychoPlexusTestCase {
 
-    @Rule
-    public TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
     private PublishingRepository subject;
 
     // project the publishing repository belongs to
     private ReactorProjectIdentitiesStub project;
 
-    @Before
+    @BeforeEach
     public void initSubject() throws Exception {
-        project = new ReactorProjectIdentitiesStub(tempManager.newFolder("projectDir"));
+        project = new ReactorProjectIdentitiesStub(newFolder("projectDir"));
 
         subject = new PublishingRepositoryImpl(lookup(IProvisioningAgent.class), project);
     }
@@ -134,4 +135,8 @@ public class PublishingRepositoryTest extends TychoPlexusTestCase {
         }
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RepositoryArtifactProviderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RepositoryArtifactProviderTest.java
@@ -27,8 +27,8 @@ import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -52,7 +52,7 @@ import org.eclipse.tycho.p2.repository.AbstractArtifactRepository2;
 import org.eclipse.tycho.p2.repository.ArtifactTransferPolicies;
 import org.eclipse.tycho.p2.repository.ArtifactTransferPolicy;
 import org.eclipse.tycho.p2.repository.RepositoryArtifactProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RepositoryArtifactProviderTest extends CompositeArtifactProviderTestBase<IRawArtifactProvider> {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RepositoryLayoutHelperTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RepositoryLayoutHelperTest.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.tycho.p2.repository.GAV;
 import org.eclipse.tycho.p2.repository.RepositoryLayoutHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RepositoryLayoutHelperTest {
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RepositoryReferencesTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RepositoryReferencesTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.net.URI;
@@ -20,8 +20,8 @@ import java.util.List;
 
 import org.eclipse.tycho.p2.repository.RepositoryBlackboardKey;
 import org.eclipse.tycho.p2.tools.RepositoryReferences;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RepositoryReferencesTest {
     private static final File LOCATION_A = new File("a/location");
@@ -35,7 +35,7 @@ public class RepositoryReferencesTest {
 
     RepositoryReferences subject;
 
-    @Before
+    @BeforeEach
     public void initSubject() {
         subject = new RepositoryReferences();
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RootFilePathTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RootFilePathTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -23,7 +23,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.tycho.p2.publisher.rootfiles.FileSet;
 import org.eclipse.tycho.p2.publisher.rootfiles.RootFilePatternParser.RootFilePath;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RootFilePathTest {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/StatusToolTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/StatusToolTest.java
@@ -14,15 +14,15 @@ package org.eclipse.tycho.p2resolver;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.tycho.helper.StatusTool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatusToolTest {
     private static final String PLUGIN_ID = "test";

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionFileTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionFileTest.java
@@ -14,10 +14,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +32,7 @@ import org.eclipse.tycho.targetplatform.TargetDefinition.Location;
 import org.eclipse.tycho.targetplatform.TargetDefinition.ProfileLocation;
 import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
 import org.eclipse.tycho.targetplatform.TargetDefinitionSyntaxException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TargetDefinitionFileTest {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetPlatformTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetPlatformTest.java
@@ -15,10 +15,10 @@ package org.eclipse.tycho.p2resolver;
 import static org.eclipse.tycho.test.util.InstallableUnitUtil.createBundleIU;
 import static org.eclipse.tycho.test.util.InstallableUnitUtil.createFeatureIU;
 import static org.eclipse.tycho.test.util.InstallableUnitUtil.createProductIU;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -30,8 +30,8 @@ import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.DependencyResolutionException;
 import org.eclipse.tycho.IllegalArtifactReferenceException;
 import org.eclipse.tycho.TargetPlatform;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TargetPlatformTest {
 
@@ -40,7 +40,7 @@ public class TargetPlatformTest {
     private TargetPlatform subject;
     private LinkedHashSet<IInstallableUnit> candidateIUs;
 
-    @Before
+    @BeforeEach
     public void initDefaultTestData() {
         candidateIUs = createSet(createBundleIU("some.bundle", "1.1.0"), createBundleIU("some.bundle", "1.1.0.v2013"),
                 createBundleIU("some.bundle", "1.1.0.v2014"), createBundleIU("some.bundle", "1.2.0"),

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/VirtualFileSetTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/VirtualFileSetTest.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.tycho.p2.publisher.rootfiles.VirtualFileSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VirtualFileSetTest {
 


### PR DESCRIPTION
@Test(expected = ...) becomes assertThrows around the call that is meant to fail, @Rule TemporaryFolder becomes @TempDir, and one assertFalse on a null check becomes assertNotNull.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])