### PR TITLE
Publish the test results on the pull request again

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,4 +50,5 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          junit_files: "artifacts/**/*.xml"
+          files: "artifacts/**/*.xml"
+          search_pull_requests: true


### PR DESCRIPTION
The build takes hours, so a pull request is regularly merged before it ends. Its head commit is then no longer the head of any pull request and the lookup the action uses since v2.6.0 finds none, so the results end up as a check run without a comment on the pull request. Searching for the pull request finds it either way.

While at it, junit_files is deprecated in favour of files.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])