### PR TITLE
Run the tycho-core p2resolver and p2tools tests on JUnit Jupiter

### DIFF
--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CustomEEResolutionHandlerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CustomEEResolutionHandlerTest.java
@@ -15,15 +15,19 @@ package org.eclipse.tycho.p2resolver;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.tycho.ExecutionEnvironment;
 import org.eclipse.tycho.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.SystemCapability;
@@ -32,22 +36,25 @@ import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformConfigurationStub;
 import org.eclipse.tycho.p2.target.facade.TargetPlatformFactory;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
-public class CustomEEResolutionHandlerTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class CustomEEResolutionHandlerTest {
 
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
 
     private TargetPlatformFactory tpFactory;
     private TargetPlatformConfigurationStub tpConfig;
 
-    @Before
+    @BeforeEach
     public void setUpContext() throws Exception {
-        tpFactory = lookup(TargetPlatformFactory.class);
+        tpFactory = container.lookup(TargetPlatformFactory.class);
         tpConfig = new TargetPlatformConfigurationStub();
     }
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/DependencyCollectorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/DependencyCollectorTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,13 +30,13 @@ import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.tycho.osgi.adapters.MavenLoggerAdapter;
 import org.eclipse.tycho.test.util.ExecutionEnvironmentTestUtils;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
 public class DependencyCollectorTest {
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     @Test
@@ -68,16 +68,16 @@ public class DependencyCollectorTest {
                 () -> dc.resolve(Collections.emptyMap(), new NullProgressMonitor()));
         Throwable cause = e.getCause();
 
-        Assert.assertTrue(cause instanceof ProvisionException);
+        Assertions.assertTrue(cause instanceof ProvisionException);
 
         ProvisionException pe = (ProvisionException) cause;
 
-        Assert.assertTrue(pe.getStatus().isMultiStatus());
+        Assertions.assertTrue(pe.getStatus().isMultiStatus());
 
         MultiStatus status = (MultiStatus) pe.getStatus();
 
-        Assert.assertEquals(1, status.getChildren().length);
+        Assertions.assertEquals(1, status.getChildren().length);
 
-        Assert.assertTrue(e.toString().contains("this.is.a.missing.iu"));
+        Assertions.assertTrue(e.toString().contains("this.is.a.missing.iu"));
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactRepositoryFactoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactRepositoryFactoryTest.java
@@ -12,10 +12,14 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
@@ -25,19 +29,22 @@ import org.eclipse.tycho.p2.repository.LocalArtifactRepository;
 import org.eclipse.tycho.p2.repository.LocalArtifactRepositoryFactory;
 import org.eclipse.tycho.p2.repository.LocalRepositoryP2Indices;
 import org.eclipse.tycho.test.util.TemporaryLocalMavenRepository;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
-public class LocalArtifactRepositoryFactoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class LocalArtifactRepositoryFactoryTest {
 
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @RegisterExtension
     public TemporaryLocalMavenRepository tempLocalMavenRepository = new TemporaryLocalMavenRepository();
     private LocalArtifactRepositoryFactory subject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subject = new LocalArtifactRepositoryFactory() {
 
@@ -55,16 +62,16 @@ public class LocalArtifactRepositoryFactoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testLoadWrongLocation() throws ProvisionException {
-        Assert.assertNull(subject.load(URI.create("file:/testFileUri"), 0, new NullProgressMonitor()));
+        Assertions.assertNull(subject.load(URI.create("file:/testFileUri"), 0, new NullProgressMonitor()));
     }
 
     @Test
     public void testLoad() throws ProvisionException, ComponentLookupException {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 tempLocalMavenRepository.getLocalRepositoryIndex());
         repo.save();
         IArtifactRepository repo2 = subject.load(tempLocalMavenRepository.getLocalRepositoryRoot().toURI(), 0,
                 new NullProgressMonitor());
-        Assert.assertEquals(repo, repo2);
+        Assertions.assertEquals(repo, repo2);
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactRepositoryP2APITest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactRepositoryP2APITest.java
@@ -21,11 +21,12 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.OutputStream;
@@ -34,6 +35,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.provisional.p2.repository.IStateful;
@@ -59,11 +64,10 @@ import org.eclipse.tycho.test.util.ProbeOutputStream;
 import org.eclipse.tycho.test.util.ProbeRawArtifactSink;
 import org.eclipse.tycho.test.util.TemporaryLocalMavenRepository;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests of the general requirements from the {@link IRawArtifactFileProvider} and p2
@@ -73,7 +77,11 @@ import org.junit.Test;
  * The characteristics specific to the {@link LocalArtifactRepository} implementation are tested in
  * {@link LocalArtifactRepositoryTest}.
  */
-public class LocalArtifactRepositoryP2APITest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class LocalArtifactRepositoryP2APITest {
+
+    @Inject
+    protected PlexusContainer container;
 
     // bundle already in local repository
     private static final IArtifactKey ARTIFACT_A_KEY = TestRepositoryContent.BUNDLE_A_KEY;
@@ -104,7 +112,7 @@ public class LocalArtifactRepositoryP2APITest extends TychoPlexusTestCase {
     private static final Set<IArtifactDescriptor> ORIGINAL_DESCRIPTORS = Set.of( //
             ARTIFACT_A_CANONICAL, ARTIFACT_B_CANONICAL);
 
-    @Rule
+    @RegisterExtension
     public TemporaryLocalMavenRepository temporaryLocalMavenRepo = new TemporaryLocalMavenRepository();
 
     private ProbeArtifactSink testSink;
@@ -114,7 +122,7 @@ public class LocalArtifactRepositoryP2APITest extends TychoPlexusTestCase {
     private LocalArtifactRepository subject;
     private IStatus status;
 
-    @Before
+    @BeforeEach
     public void initSubject() throws Exception {
         temporaryLocalMavenRepo.initContentFromResourceFolder(ResourceUtil.resourceFile("repositories/local"));
         subject = new LocalArtifactRepository(null, temporaryLocalMavenRepo.getLocalRepositoryIndex());
@@ -122,13 +130,13 @@ public class LocalArtifactRepositoryP2APITest extends TychoPlexusTestCase {
         testOutputStream = new ProbeOutputStream();
     }
 
-    @After
+    @AfterEach
     public void checkStreamNotClosed() {
         // none of the tested methods should close the stream
         assertFalse(testOutputStream.isClosed());
     }
 
-    @After
+    @AfterEach
     public void checkStatusAndSinkConsistency() {
         if (testSink != null) {
             testSink.checkConsistencyWithStatus(status);
@@ -323,7 +331,7 @@ public class LocalArtifactRepositoryP2APITest extends TychoPlexusTestCase {
         assertThat(status, is(errorStatus()));
     }
 
-    @Test(expected = ArtifactSinkException.class)
+    @Test
     public void testGetArtifactToBrokenSink() throws Exception {
         IArtifactSink brokenSink = new IArtifactSink() {
             @Override
@@ -351,12 +359,12 @@ public class LocalArtifactRepositoryP2APITest extends TychoPlexusTestCase {
             }
 
         };
-        subject.getArtifact(brokenSink, null);
+        assertThrows(ArtifactSinkException.class, () -> subject.getArtifact(brokenSink, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetArtifactToClosedSink() throws Exception {
-        subject.getArtifact(new NonStartableArtifactSink(), null);
+        assertThrows(IllegalArgumentException.class, () -> subject.getArtifact(new NonStartableArtifactSink(), null));
     }
 
     @SuppressWarnings("deprecation")
@@ -414,9 +422,9 @@ public class LocalArtifactRepositoryP2APITest extends TychoPlexusTestCase {
         assertThat(status, is(errorStatus()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetRawArtifactToClosedSink() throws Exception {
-        subject.getRawArtifact(new NonStartableArtifactSink(), null);
+        assertThrows(IllegalArgumentException.class, () -> subject.getRawArtifact(new NonStartableArtifactSink(), null));
     }
 
     @SuppressWarnings("deprecation")

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactRepositoryTest.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayOutputStream;
@@ -23,6 +23,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -45,14 +49,17 @@ import org.eclipse.tycho.p2.repository.TychoRepositoryIndex;
 import org.eclipse.tycho.test.util.MockMavenContext;
 import org.eclipse.tycho.test.util.NoopFileLockService;
 import org.eclipse.tycho.test.util.TemporaryLocalMavenRepository;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
-public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class LocalArtifactRepositoryTest {
 
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @RegisterExtension
     public TemporaryLocalMavenRepository mvnRepo = new TemporaryLocalMavenRepository();
 
     private void deleteDir(File dir) {
@@ -76,7 +83,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
     @Test
     public void testOutdatedIndex() throws ComponentLookupException {
         //create Repo with single artifact
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
         ArtifactDescriptor desc = newBundleArtifactDescriptor(false);
         repo.addDescriptor(desc);
@@ -84,13 +91,13 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
         // check: the artifact is in the index
         TychoRepositoryIndex artifactIndex = createArtifactsIndex(mvnRepo.getLocalRepositoryRoot());
-        Assert.assertFalse(artifactIndex.getProjectGAVs().isEmpty());
+        Assertions.assertFalse(artifactIndex.getProjectGAVs().isEmpty());
 
         // delete artifact content from file system
         deleteDir(new File(mvnRepo.getLocalRepositoryRoot(), "p2"));
 
         // create a new repo and check that the reference was gracefully removed from the index
-        repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class), mvnRepo.getLocalRepositoryIndex());
+        repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class), mvnRepo.getLocalRepositoryIndex());
         repo.save();
         artifactIndex = createArtifactsIndex(mvnRepo.getLocalRepositoryRoot());
         assertTrue(artifactIndex.getProjectGAVs().isEmpty());
@@ -98,7 +105,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void getP2Location() throws ComponentLookupException {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
 
         ArtifactDescriptor desc = newBundleArtifactDescriptor(false);
@@ -130,7 +137,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void getMavenLocation() throws ComponentLookupException {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
 
         ArtifactDescriptor desc = newBundleArtifactDescriptor(true);
@@ -143,7 +150,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void getMavenLocationWithClassifierAndExtension() throws ComponentLookupException {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
 
         ArtifactDescriptor desc = newBundleArtifactDescriptor(true);
@@ -172,7 +179,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void addP2Artifact() throws Exception {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
 
         ArtifactDescriptor desc = newBundleArtifactDescriptor(false);
@@ -199,7 +206,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void addMavenArtifact() throws Exception {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
 
         ArtifactDescriptor desc = newBundleArtifactDescriptor(true);
@@ -214,7 +221,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void reload() throws Exception {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
         ArtifactDescriptor mavenArtifact = newBundleArtifactDescriptor(true);
         ArtifactDescriptor p2Artifact = newBundleArtifactDescriptor(false);
@@ -224,14 +231,14 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
         repo.save();
 
-        repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class), mvnRepo.getLocalRepositoryIndex());
+        repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class), mvnRepo.getLocalRepositoryIndex());
         assertTrue(repo.contains(mavenArtifact.getArtifactKey()));
         assertTrue(repo.contains(p2Artifact.getArtifactKey()));
     }
 
     @Test
     public void testGetArtifactsNoRequests() throws ComponentLookupException {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
         IStatus status = repo.getArtifacts(new IArtifactRequest[0], new NullProgressMonitor());
         assertTrue(status.isOK());
@@ -239,7 +246,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testGetArtifactsErrorRequest() throws ComponentLookupException {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
         IArtifactRequest errorRequest = new IArtifactRequest() {
             @Override
@@ -262,7 +269,7 @@ public class LocalArtifactRepositoryTest extends TychoPlexusTestCase {
 
     @Test
     public void testGetRawArtifactDummy() throws ProvisionException, IOException, ComponentLookupException {
-        LocalArtifactRepository repo = new LocalArtifactRepository(lookup(IProvisioningAgent.class),
+        LocalArtifactRepository repo = new LocalArtifactRepository(container.lookup(IProvisioningAgent.class),
                 mvnRepo.getLocalRepositoryIndex());
         ArtifactDescriptor p2Artifact = newBundleArtifactDescriptor(false);
         byte[] content = new byte[] { 111, 112 };

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MavenServiceStubbingTestBase.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MavenServiceStubbingTestBase.java
@@ -12,10 +12,19 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.io.IOException;
+import java.io.File;
 import java.util.Collection;
 
+import javax.inject.Inject;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.sisu.equinox.EquinoxServiceFactory;
 import org.eclipse.tycho.FileLockService;
@@ -23,25 +32,31 @@ import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
 import org.eclipse.tycho.test.util.NoopFileLockService;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test base class that provides a stub registration of those services which are normally provided
  * from outside the OSGi runtime.
  */
-public class MavenServiceStubbingTestBase extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class MavenServiceStubbingTestBase {
 
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @TempDir
+    Path temporaryFolder;
+
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
 
     private IProvisioningAgent provisioningAgent;
 
-    @Before
+    @BeforeEach
     public void initServiceInstances() throws Exception {
         //trigger loading of the embedded OSGi framework
-        Collection<EquinoxServiceFactory> serviceFactories = lookupList(EquinoxServiceFactory.class);
+        Collection<EquinoxServiceFactory> serviceFactories = container.lookupList(EquinoxServiceFactory.class);
         for (EquinoxServiceFactory factory : serviceFactories) {
             try {
                 factory.getService(IProvisioningAgent.class);
@@ -49,13 +64,13 @@ public class MavenServiceStubbingTestBase extends TychoPlexusTestCase {
 
             }
         }
-        provisioningAgent = lookup(IProvisioningAgent.class);
+        provisioningAgent = container.lookup(IProvisioningAgent.class);
         provisioningAgent.getService(Object.class);
         assertNotNull(provisioningAgent);
     }
 
     protected MavenContext createMavenContext() throws Exception {
-        MavenContext mavenContext = new MockMavenContext(temporaryFolder.newFolder("target"), logVerifier.getLogger()) {
+        MavenContext mavenContext = new MockMavenContext(newFolder("target"), logVerifier.getLogger()) {
 
             @Override
             public String getExtension(String artifactType) {
@@ -74,4 +89,8 @@ public class MavenServiceStubbingTestBase extends TychoPlexusTestCase {
         return provisioningAgent;
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(temporaryFolder.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MirroringArtifactProviderErrorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MirroringArtifactProviderErrorTest.java
@@ -14,10 +14,14 @@ package org.eclipse.tycho.p2resolver;
 
 import static java.util.Collections.singletonList;
 import static org.eclipse.tycho.test.util.ProbeArtifactSink.newArtifactSinkFor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.tycho.p2.repository.ArtifactTransferPolicies;
@@ -30,18 +34,21 @@ import org.eclipse.tycho.test.util.MockMavenContext;
 import org.eclipse.tycho.test.util.ProbeArtifactSink;
 import org.eclipse.tycho.test.util.TemporaryLocalMavenRepository;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
-public class MirroringArtifactProviderErrorTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class MirroringArtifactProviderErrorTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final IArtifactKey CORRUPT_ARTIFACT = TestRepositoryContent.BUNDLE_A_KEY;
 
-    @Rule
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
-    @Rule
+    @RegisterExtension
     public TemporaryLocalMavenRepository tempLocalMavenRepository = new TemporaryLocalMavenRepository();
 
     private LocalArtifactRepository localRepository;
@@ -49,13 +56,13 @@ public class MirroringArtifactProviderErrorTest extends TychoPlexusTestCase {
 
     MirroringArtifactProvider subject;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         localRepository = tempLocalMavenRepository.getLocalArtifactRepository();
 
         subject = MirroringArtifactProvider.createInstance(localRepository,
                 new RepositoryArtifactProvider(singletonList(TestRepositoryContent.REPO_BUNLDE_AB_PACK_CORRUPT),
-                        ArtifactTransferPolicies.forLocalArtifacts(), lookup(IProvisioningAgent.class)),
+                        ArtifactTransferPolicies.forLocalArtifacts(), container.lookup(IProvisioningAgent.class)),
                 new MockMavenContext(null, logVerifier.getLogger()));
     }
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MirroringArtifactProviderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MirroringArtifactProviderTest.java
@@ -16,11 +16,11 @@ import static org.eclipse.tycho.test.util.ArtifactRepositoryTestUtils.ANY_ARTIFA
 import static org.eclipse.tycho.test.util.ArtifactRepositoryTestUtils.canonicalDescriptorFor;
 import static org.eclipse.tycho.test.util.ProbeArtifactSink.newArtifactSinkFor;
 import static org.eclipse.tycho.test.util.ProbeRawArtifactSink.newRawArtifactSinkFor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -28,6 +28,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
@@ -47,13 +51,16 @@ import org.eclipse.tycho.test.util.ProbeArtifactSink;
 import org.eclipse.tycho.test.util.ProbeRawArtifactSink;
 import org.eclipse.tycho.test.util.TemporaryLocalMavenRepository;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
-public class MirroringArtifactProviderTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class MirroringArtifactProviderTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     // remote bundles
     private static final IArtifactKey BUNDLE_A_KEY = TestRepositoryContent.BUNDLE_A_KEY;
@@ -70,10 +77,10 @@ public class MirroringArtifactProviderTest extends TychoPlexusTestCase {
     // not available bundle
     private static final IArtifactKey OTHER_KEY = TestRepositoryContent.NOT_CONTAINED_ARTIFACT_KEY;
 
-    @Rule
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
 
-    @Rule
+    @RegisterExtension
     public TemporaryLocalMavenRepository localRepositoryManager = new TemporaryLocalMavenRepository();
     private File localRepositoryRoot;
     private LocalArtifactRepository localRepository;
@@ -84,11 +91,11 @@ public class MirroringArtifactProviderTest extends TychoPlexusTestCase {
     private MirroringArtifactProvider subject;
     private IStatus status;
 
-    @Before
+    @BeforeEach
     public void initSubject() throws Exception {
         RepositoryArtifactProvider remoteProvider = new RepositoryArtifactProvider(
                 Collections.singletonList(TestRepositoryContent.REPO_BUNDLE_AB),
-                ArtifactTransferPolicies.forLocalArtifacts(), lookup(IProvisioningAgent.class));
+                ArtifactTransferPolicies.forLocalArtifacts(), container.lookup(IProvisioningAgent.class));
 
         // initialize local repository content (see BUNDLE_L_KEY)
         localRepositoryRoot = localRepositoryManager.getLocalRepositoryRoot();
@@ -99,12 +106,12 @@ public class MirroringArtifactProviderTest extends TychoPlexusTestCase {
                 new MockMavenContext(null, logVerifier.getLogger()));
     }
 
-    @Before
+    @BeforeEach
     public void expectNoWarningsInLog() throws Exception {
         logVerifier.expectNoWarnings();
     }
 
-    @After
+    @AfterEach
     public void checkStatusAndSinkConsistency() {
         if (testSink != null) {
             testSink.checkConsistencyWithStatus(status);

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2DependencyGeneratorImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2DependencyGeneratorImplTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,9 +35,9 @@ import org.eclipse.tycho.test.util.ArtifactMock;
 import org.eclipse.tycho.test.util.BuildPropertiesParserForTesting;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
 public class P2DependencyGeneratorImplTest {
     private static final String DEFAULT_VERSION = "1.0.0-SNAPSHOT";
@@ -46,10 +46,10 @@ public class P2DependencyGeneratorImplTest {
     private P2GeneratorImpl subject;
     private List<IInstallableUnit> units;
     private List<IArtifactDescriptor> artifacts;
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
-    @Before
+    @BeforeEach
     public void resetTestSubjectAndResultFields() {
         subject = new P2GeneratorImpl(true);
         subject.setMavenContext(new MockMavenContext(null, logVerifier.getLogger()));

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2GeneratorImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2GeneratorImplTest.java
@@ -14,10 +14,10 @@ package org.eclipse.tycho.p2resolver;
 
 import static org.eclipse.tycho.test.util.InstallableUnitMatchers.hasGAV;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -44,12 +44,12 @@ import org.eclipse.tycho.test.util.ArtifactMock;
 import org.eclipse.tycho.test.util.BuildPropertiesParserForTesting;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
 public class P2GeneratorImplTest {
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     @Test
@@ -119,7 +119,7 @@ public class P2GeneratorImplTest {
         List<IRequirement> requirements = new ArrayList<>(iu.getRequirements());
         IRequiredCapability requirement = getReqCap(requirements, PublisherHelper.CAPABILITY_NS_JAVA_PACKAGE,
                 "org.osgi.framework");
-        assertNotNull("org.osgi.framework", requirement);
+        assertNotNull(requirement, "org.osgi.framework");
         assertTrue(requirement.isGreedy());
         assertEquals(1, requirement.getMin());
         assertEquals(1, requirement.getMax());

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataGeneratorImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2MetadataGeneratorImplTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -30,13 +30,13 @@ import org.eclipse.tycho.test.util.ArtifactMock;
 import org.eclipse.tycho.test.util.BuildPropertiesParserForTesting;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
 public class P2MetadataGeneratorImplTest {
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     @Test
@@ -56,21 +56,21 @@ public class P2MetadataGeneratorImplTest {
         List<IInstallableUnit> units = new ArrayList<>(metadata.getInstallableUnits());
         List<IArtifactDescriptor> artifacts = new ArrayList<>(metadata.getArtifactDescriptors());
 
-        Assert.assertEquals(1, units.size());
+        Assertions.assertEquals(1, units.size());
         IInstallableUnit unit = units.iterator().next();
 
-        Assert.assertEquals("org.eclipse.tycho.p2.impl.test.bundle", unit.getId());
-        Assert.assertEquals("1.0.0.qualifier", unit.getVersion().toString());
-        Assert.assertEquals(4, unit.getRequirements().size());
+        Assertions.assertEquals("org.eclipse.tycho.p2.impl.test.bundle", unit.getId());
+        Assertions.assertEquals("1.0.0.qualifier", unit.getVersion().toString());
+        Assertions.assertEquals(4, unit.getRequirements().size());
 
-        Assert.assertEquals(1, artifacts.size());
+        Assertions.assertEquals(1, artifacts.size());
         IArtifactDescriptor ad = artifacts.iterator().next();
-        Assert.assertEquals("org.eclipse.tycho.p2.impl.test.bundle", ad.getArtifactKey().getId());
-        Assert.assertEquals("1.0.0.qualifier", ad.getArtifactKey().getVersion().toString());
+        Assertions.assertEquals("org.eclipse.tycho.p2.impl.test.bundle", ad.getArtifactKey().getId());
+        Assertions.assertEquals("1.0.0.qualifier", ad.getArtifactKey().getVersion().toString());
 
-        Assert.assertEquals(groupId, ad.getProperties().get(TychoConstants.PROP_GROUP_ID));
-        Assert.assertEquals(artifactId, ad.getProperties().get(TychoConstants.PROP_ARTIFACT_ID));
-        Assert.assertEquals(version, ad.getProperties().get(TychoConstants.PROP_VERSION));
+        Assertions.assertEquals(groupId, ad.getProperties().get(TychoConstants.PROP_GROUP_ID));
+        Assertions.assertEquals(artifactId, ad.getProperties().get(TychoConstants.PROP_ARTIFACT_ID));
+        Assertions.assertEquals(version, ad.getProperties().get(TychoConstants.PROP_VERSION));
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverAdditionalRequirementsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverAdditionalRequirementsTest.java
@@ -25,10 +25,10 @@ import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
 public class P2ResolverAdditionalRequirementsTest {
 
@@ -38,12 +38,12 @@ public class P2ResolverAdditionalRequirementsTest {
     private static final String IU_TYPE = ArtifactType.TYPE_INSTALLABLE_UNIT;
     private static final String TARGET_UNIT_ID = "testbundleName";
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private P2ResolverImpl impl;
 
-    @Before
+    @BeforeEach
     public void initBlankResolver() {
         impl = new P2ResolverImpl(null, null, logVerifier.getMavenLogger(),
                 Collections.singletonList(TargetEnvironment.getRunningEnvironment()));
@@ -73,13 +73,13 @@ public class P2ResolverAdditionalRequirementsTest {
 
     private static void assertIUMatchesRequirements(IInstallableUnit unit, List<IRequirement> requirements) {
         for (IRequirement requirement : requirements) {
-            Assert.assertTrue("IU " + unit + " must match requirement " + requirement, requirement.isMatch(unit));
+            Assertions.assertTrue(requirement.isMatch(unit), "IU " + unit + " must match requirement " + requirement);
         }
     }
 
     private static void assertIUDoesNotMatchRequirements(IInstallableUnit unit, List<IRequirement> requirements) {
         for (IRequirement requirement : requirements) {
-            Assert.assertFalse("IU " + unit + " must not match requirement " + requirement, requirement.isMatch(unit));
+            Assertions.assertFalse(requirement.isMatch(unit), "IU " + unit + " must not match requirement " + requirement);
         }
     }
 
@@ -95,10 +95,8 @@ public class P2ResolverAdditionalRequirementsTest {
 
         IInstallableUnit iu = createIU(arbitraryVersion);
 
-        Assert.assertTrue("Requires version 0.0.0; should be satisfied by any version",
-                additionalRequirements.get(0).isMatch(iu));
-        Assert.assertTrue("Requires version 0.0.0; should be satisfied by any version",
-                additionalRequirements.get(1).isMatch(iu));
+        Assertions.assertTrue(additionalRequirements.get(0).isMatch(iu), "Requires version 0.0.0; should be satisfied by any version");
+        Assertions.assertTrue(additionalRequirements.get(1).isMatch(iu), "Requires version 0.0.0; should be satisfied by any version");
     }
 
     @Test
@@ -114,10 +112,8 @@ public class P2ResolverAdditionalRequirementsTest {
 
         IInstallableUnit iu = createIU(arbitraryVersion);
 
-        Assert.assertTrue("Given version was null; should be satisfied by any version",
-                additionalRequirements.get(0).isMatch(iu));
-        Assert.assertTrue("Given version was null; should be satisfied by any version",
-                additionalRequirements.get(1).isMatch(iu));
+        Assertions.assertTrue(additionalRequirements.get(0).isMatch(iu), "Given version was null; should be satisfied by any version");
+        Assertions.assertTrue(additionalRequirements.get(1).isMatch(iu), "Given version was null; should be satisfied by any version");
     }
 
     @Test
@@ -128,10 +124,8 @@ public class P2ResolverAdditionalRequirementsTest {
         List<IRequirement> additionalRequirements = impl.getAdditionalRequirements();
         String matchingVersion = "2.5.8";
         IInstallableUnit iu = createIU(matchingVersion);
-        Assert.assertTrue("version range " + range + " should be satisfied by " + matchingVersion,
-                additionalRequirements.get(0).isMatch(iu));
-        Assert.assertTrue("version range " + range + " should be satisfied by " + matchingVersion,
-                additionalRequirements.get(1).isMatch(iu));
+        Assertions.assertTrue(additionalRequirements.get(0).isMatch(iu), "version range " + range + " should be satisfied by " + matchingVersion);
+        Assertions.assertTrue(additionalRequirements.get(1).isMatch(iu), "version range " + range + " should be satisfied by " + matchingVersion);
     }
 
     private static IInstallableUnit createIU(String version) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.tycho.PackagingType.TYPE_ECLIPSE_FEATURE;
 import static org.eclipse.tycho.PackagingType.TYPE_ECLIPSE_PLUGIN;
 import static org.eclipse.tycho.PackagingType.TYPE_ECLIPSE_REPOSITORY;
 import static org.eclipse.tycho.PackagingType.TYPE_ECLIPSE_TEST_PLUGIN;
+import static org.eclipse.tycho.core.test.utils.ResourceUtil.resourceFile;
 import static org.eclipse.tycho.test.util.ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HANDLER;
 import static org.eclipse.tycho.test.util.ExecutionEnvironmentTestUtils.customEEResolutionHintProvider;
 import static org.eclipse.tycho.test.util.ExecutionEnvironmentTestUtils.standardEEResolutionHintProvider;
@@ -25,11 +26,11 @@ import static org.eclipse.tycho.test.util.InstallableUnitMatchers.unitWithId;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesRegex;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.net.URI;
@@ -62,13 +63,13 @@ import org.eclipse.tycho.test.util.ReactorProjectStub;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
 public class P2ResolverTest extends P2ResolverTestBase {
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private ReactorProject projectToResolve;
@@ -76,7 +77,7 @@ public class P2ResolverTest extends P2ResolverTestBase {
     private static final String LATEST_PLATFORM = "https://download.eclipse.org/eclipse/updates/latest/";
     protected P2Resolver impl;
 
-    @Before
+    @BeforeEach
     public void initDefaultResolver() throws Exception {
 //        org.eclipse.equinox.internal.p2.core.helpers.Tracing.DEBUG_PLANNER_PROJECTOR = true;
         pomDependencies = resolverFactory.newPomDependencyCollector();
@@ -582,7 +583,7 @@ public class P2ResolverTest extends P2ResolverTestBase {
     }
 
     private static void assertContainsUnit(String unitID, Set<?> units) {
-        assertFalse("Unit " + unitID + " not found", getInstallableUnits(unitID, units).isEmpty());
+        assertFalse(getInstallableUnits(unitID, units).isEmpty(), "Unit " + unitID + " not found");
     }
 
     private static List<IInstallableUnit> getInstallableUnits(String unitID, Set<?> units) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverTestBase.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/P2ResolverTestBase.java
@@ -17,6 +17,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.tycho.IDependencyMetadata;
 import org.eclipse.tycho.OptionalResolutionAction;
@@ -32,16 +36,19 @@ import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
 import org.eclipse.tycho.test.util.ReactorProjectStub;
 import org.eclipse.tycho.test.util.TestResolverFactory;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class P2ResolverTestBase extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class P2ResolverTestBase {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final String DEFAULT_VERSION = "1.0.0-SNAPSHOT";
     private static final String DEFAULT_GROUP_ID = "test.groupId";
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private P2GeneratorImpl fullGenerator;
@@ -53,10 +60,10 @@ public class P2ResolverTestBase extends TychoPlexusTestCase {
     protected List<ReactorProject> reactorProjects = new ArrayList<>();
     protected TargetPlatformFactoryImpl tpFactory;
 
-    @Before
+    @BeforeEach
     final public void prepare() throws Exception {
         resolverFactory = new TestResolverFactory(logVerifier.getMavenLogger(), logVerifier.getLogger(),
-                lookup(IProvisioningAgent.class), lookup(MavenTargetLocationFactory.class));
+                container.lookup(IProvisioningAgent.class), container.lookup(MavenTargetLocationFactory.class));
         MockMavenContext mavenContext = new MockMavenContext(null, logVerifier.getLogger());
         fullGenerator = new P2GeneratorImpl(true);
         fullGenerator.setMavenContext(mavenContext);

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PomDependencyCollectorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PomDependencyCollectorTest.java
@@ -17,12 +17,19 @@ package org.eclipse.tycho.p2resolver;
 import static org.eclipse.tycho.test.util.InstallableUnitMatchers.unitWithId;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.tycho.PackagingType;
@@ -30,28 +37,31 @@ import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
 import org.eclipse.tycho.test.util.ArtifactMock;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.ReactorProjectStub;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class PomDependencyCollectorTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class PomDependencyCollectorTest {
 
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
 
     private PomDependencyCollector subject;
 
     private ArtifactMock artifact;
 
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
-    @Before
+    @BeforeEach
     public void setUpSubject() throws Exception {
         subject = new PomDependencyCollectorImpl(logVerifier.getLogger(),
-                new ReactorProjectStub(tempManager.newFolder(), "test"), lookup(IProvisioningAgent.class));
+                new ReactorProjectStub(newFolder("temp"), "test"), container.lookup(IProvisioningAgent.class));
     }
 
     @Test
@@ -101,4 +111,8 @@ public class PomDependencyCollectorTest extends TychoPlexusTestCase {
                 "artifactId", "1", PackagingType.TYPE_ECLIPSE_PLUGIN, "p2metadata");
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishProductToolTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishProductToolTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
+import static org.eclipse.tycho.core.test.utils.ResourceUtil.resourceFile;
 import static org.eclipse.tycho.test.util.InstallableUnitMatchers.configureTouchpointInstructionThat;
 import static org.eclipse.tycho.test.util.InstallableUnitMatchers.hasSelfCapability;
 import static org.eclipse.tycho.test.util.InstallableUnitMatchers.productUnit;
@@ -27,14 +28,17 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,6 +48,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.query.QueryUtil;
@@ -60,32 +68,35 @@ import org.eclipse.tycho.p2.tools.publisher.facade.PublishProductTool;
 import org.eclipse.tycho.targetplatform.P2TargetPlatform;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.ReactorProjectIdentitiesStub;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class PublishProductToolTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class PublishProductToolTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final String QUALIFIER = "20150109";
     private static final String FLAVOR = "tooling";
     private static final List<TargetEnvironment> ENVIRONMENTS = Collections
             .singletonList(new TargetEnvironment("testos", "testws", "testarch"));
 
-    @Rule
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
-    @Rule
-    public TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
     private Interpolator interpolatorMock;
 
     private PublishingRepository outputRepository;
     private PublishProductTool subject;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
-        File projectDirectory = tempManager.newFolder("projectDir");
-        outputRepository = new PublishingRepositoryImpl(lookup(IProvisioningAgent.class),
+        File projectDirectory = newFolder("projectDir");
+        outputRepository = new PublishingRepositoryImpl(container.lookup(IProvisioningAgent.class),
                 new ReactorProjectIdentitiesStub(projectDirectory));
 
         interpolatorMock = mock(Interpolator.class);
@@ -304,4 +315,8 @@ public class PublishProductToolTest extends TychoPlexusTestCase {
         return results.getMetadataRepository().query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet();
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublisherServiceFactoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublisherServiceFactoryTest.java
@@ -13,13 +13,13 @@
 package org.eclipse.tycho.p2resolver;
 
 import org.eclipse.tycho.p2.tools.publisher.facade.PublisherServiceFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PublisherServiceFactoryTest extends MavenServiceStubbingTestBase {
 
     @Test
     public void testThatRequiredServicesAreAvailable() throws Exception {
-        lookup(PublisherServiceFactory.class);
+        container.lookup(PublisherServiceFactory.class);
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublisherServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublisherServiceTest.java
@@ -12,12 +12,16 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.eclipse.tycho.core.test.utils.ResourceUtil.resourceFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,6 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IProvidedCapability;
@@ -44,35 +52,38 @@ import org.eclipse.tycho.p2.tools.publisher.facade.PublisherService;
 import org.eclipse.tycho.test.util.InstallableUnitUtil;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.ReactorProjectIdentitiesStub;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class PublisherServiceTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class PublisherServiceTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final String DEFAULT_QUALIFIER = "1.2.3.testqual";
     private static final List<TargetEnvironment> DEFAULT_ENVIRONMENTS = Collections
             .singletonList(new TargetEnvironment("testos", "testws", "testarch"));
 
-    @Rule
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
-    @Rule
-    public TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
     private PublishingRepository outputRepository;
     private PublisherService subject;
 
-    @Before
+    @BeforeEach
     public void initSubject() throws Exception {
-        File projectDirectory = tempManager.newFolder("projectDir");
+        File projectDirectory = newFolder("projectDir");
 
         LinkedHashSet<IInstallableUnit> installableUnits = new LinkedHashSet<>();
         installableUnits.add(InstallableUnitUtil.createFeatureIU("org.eclipse.example.original_feature", "1.0.0"));
         IMetadataRepository context = new ImmutableInMemoryMetadataRepository(installableUnits, true);
 
         // TODO these publishers don't produce artifacts, so we could run without file system
-        outputRepository = new PublishingRepositoryImpl(lookup(IProvisioningAgent.class),
+        outputRepository = new PublishingRepositoryImpl(container.lookup(IProvisioningAgent.class),
                 new ReactorProjectIdentitiesStub(projectDirectory));
         PublisherActionRunner publisherRunner = new PublisherActionRunner(context, DEFAULT_ENVIRONMENTS,
                 logVerifier.getLogger());
@@ -112,8 +123,7 @@ public class PublisherServiceTest extends TychoPlexusTestCase {
                 }
             }
         }
-        assertTrue("did not find capability for package javax.activation with custom version " + version_1_1_1,
-                customJavaxActivationVersionFound);
+        assertTrue(customJavaxActivationVersionFound, "did not find capability for package javax.activation with custom version " + version_1_1_1);
         assertTrue(unitsById(seeds).keySet().contains("config.a.jre.virgo"));
     }
 
@@ -136,4 +146,8 @@ public class PublisherServiceTest extends TychoPlexusTestCase {
         return result;
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ReactorRepositoryManagerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ReactorRepositoryManagerTest.java
@@ -13,42 +13,51 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertNotNull;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
 import org.eclipse.tycho.repository.registry.facade.ReactorRepositoryManager;
 import org.eclipse.tycho.test.util.ReactorProjectStub;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ReactorRepositoryManagerTest extends MavenServiceStubbingTestBase {
 
     private ReactorRepositoryManager subject;
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
     private PomDependencyCollector pomDependencyCollector;
 
-    @Before
+    @BeforeEach
     public void setUpContext() throws Exception {
         pomDependencyCollector = new PomDependencyCollectorImpl(logVerifier.getLogger(),
-                new ReactorProjectStub(tempManager.newFolder(), "test"), getProvisioningAgent());
+                new ReactorProjectStub(newFolder("temp"), "test"), getProvisioningAgent());
     }
 
     @Test
     public void testReactorRepositoryManagerServiceAvailability() throws Exception {
-        subject = lookup(ReactorRepositoryManager.class);
+        subject = container.lookup(ReactorRepositoryManager.class);
 
         assertNotNull(subject);
     }
 
     @Test
     public void testReactorRepositoryManagerFacadeServiceAvailability() throws Exception {
-        subject = lookup(ReactorRepositoryManager.class);
+        subject = container.lookup(ReactorRepositoryManager.class);
 
         assertNotNull(subject);
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentCompositeLoadingTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentCompositeLoadingTest.java
@@ -12,36 +12,46 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class RemoteAgentCompositeLoadingTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class RemoteAgentCompositeLoadingTest {
 
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @TempDir
+    Path tempManager;
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private IProvisioningAgent subject;
 
-    @Before
+    @BeforeEach
     public void initSubject() throws Exception {
-        tempManager.newFolder("localRepo");
-        subject = lookup(IProvisioningAgent.class);
+        newFolder("localRepo");
+        subject = container.lookup(IProvisioningAgent.class);
     }
 
     @Test
@@ -57,4 +67,8 @@ public class RemoteAgentCompositeLoadingTest extends TychoPlexusTestCase {
         assertEquals(ProvisionException.REPOSITORY_FAILED_READ, e.getStatus().getCode());
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentDisableP2MirrorsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentDisableP2MirrorsTest.java
@@ -12,11 +12,19 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.repository.IRepository;
@@ -24,26 +32,29 @@ import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class RemoteAgentDisableP2MirrorsTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class RemoteAgentDisableP2MirrorsTest {
 
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @TempDir
+    Path tempManager;
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 
     @Test
-    @Ignore("can't be tested that way!")
+    @Disabled("can't be tested that way!")
     public void testDisableP2Mirrors() throws Exception {
         IProvisioningAgent agent = createRemoteAgent(true);
         IArtifactRepository repo = loadRepository(agent, ResourceUtil.resourceFile("p2-mirrors-disable").toURI());
@@ -60,7 +71,7 @@ public class RemoteAgentDisableP2MirrorsTest extends TychoPlexusTestCase {
     }
 
     private IProvisioningAgent createRemoteAgent(boolean disableMirrors) throws Exception {
-        return lookup(IProvisioningAgent.class);
+        return container.lookup(IProvisioningAgent.class);
     }
 
     private static IArtifactRepository loadRepository(IProvisioningAgent agent, URI location)

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentMavenMirrorsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentMavenMirrorsTest.java
@@ -12,12 +12,19 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
@@ -29,26 +36,29 @@ import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2maven.repository.DefaultMavenRepositorySettings;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class RemoteAgentMavenMirrorsTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class RemoteAgentMavenMirrorsTest {
 
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @TempDir
+    Path tempManager;
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
-    @Rule
+    @RegisterExtension
     public HttpServer localServer = new HttpServer();
 
     private IProvisioningAgent subject;
 
-    @Before
+    @BeforeEach
     public void initSubject() throws Exception {
-        subject = lookup(IProvisioningAgent.class);
+        subject = container.lookup(IProvisioningAgent.class);
     }
 
     @Test
@@ -86,7 +96,7 @@ public class RemoteAgentMavenMirrorsTest extends TychoPlexusTestCase {
         URI mirroredUrl = URI
                 .create(localServer.addServlet("mirrored", ResourceUtil.resourceFile("repositories/e342")));
         String repositoryFallbackId = originalUrl.toString();
-        assertFalse("self-test: fallback ID shall be URL without trailing slash", repositoryFallbackId.endsWith("/"));
+        assertFalse(repositoryFallbackId.endsWith("/"), "self-test: fallback ID shall be URL without trailing slash");
         try {
             prepareMavenMirrorConfiguration(repositoryFallbackId, mirroredUrl);
 
@@ -107,7 +117,7 @@ public class RemoteAgentMavenMirrorsTest extends TychoPlexusTestCase {
     }
 
     private File noContent() throws Exception {
-        return tempManager.newFolder("empty");
+        return newFolder("empty");
     }
 
     private Repositories loadRepositories(String id, URI specifiedUrl) throws Exception {
@@ -139,5 +149,9 @@ public class RemoteAgentMavenMirrorsTest extends TychoPlexusTestCase {
         public IArtifactRepository getArtifactRepository() {
             return artifactRepository;
         }
+    }
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentMetadataRepositoryCacheTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentMetadataRepositoryCacheTest.java
@@ -12,50 +12,61 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for verifying the caching behavior of the RemoteAgent's metadata repository manager.
  */
-public class RemoteAgentMetadataRepositoryCacheTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class RemoteAgentMetadataRepositoryCacheTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final String HTTP_REPO_PATH = "e342";
 
-    @Rule
-    public TemporaryFolder tempManager = new TemporaryFolder();
-    @Rule
+    @TempDir
+    Path tempManager;
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
 
-    @Rule
+    @RegisterExtension
     public final HttpServer localServer = new HttpServer();
     private URI localHttpRepo;
 
-    @Before
+    @BeforeEach
     public void startHttpServer() throws Exception {
         localHttpRepo = URI
                 .create(localServer.addServlet(HTTP_REPO_PATH, new File("src/test/resources/repositories/e342")));
     }
 
-    @Before
+    @BeforeEach
     public void initLocalMavenRepository() throws Exception {
-        tempManager.newFolder("m2-repo");
+        newFolder("m2-repo");
     }
 
     @Test
@@ -93,13 +104,13 @@ public class RemoteAgentMetadataRepositoryCacheTest extends TychoPlexusTestCase 
         assertNotNull(repo);
     }
 
-    @Test(expected = ProvisionException.class)
+    @Test
     public void testOnlineLoadingFailsFastIfNoSourceAvailable() throws Exception {
         // server unavailable and no cache entry
         localServer.stop();
 
         IProvisioningAgent onlineAgent = newOnlineAgent();
-        loadHttpRepository(onlineAgent);
+        assertThrows(ProvisionException.class, () -> loadHttpRepository(onlineAgent));
     }
 
     @Test
@@ -117,11 +128,11 @@ public class RemoteAgentMetadataRepositoryCacheTest extends TychoPlexusTestCase 
     }
 
     private IProvisioningAgent newOnlineAgent() throws Exception {
-        return lookup(IProvisioningAgent.class);
+        return container.lookup(IProvisioningAgent.class);
     }
 
     private IProvisioningAgent newOfflineAgent() throws Exception {
-        return lookup(IProvisioningAgent.class);
+        return container.lookup(IProvisioningAgent.class);
     }
 
     private IMetadataRepository loadHttpRepository(IProvisioningAgent onlineAgent) throws ProvisionException {
@@ -130,4 +141,8 @@ public class RemoteAgentMetadataRepositoryCacheTest extends TychoPlexusTestCase 
         return repo;
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentMetadataRepositoryOfflineCache.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RemoteAgentMetadataRepositoryOfflineCache.java
@@ -12,49 +12,60 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for verifying the caching behavior of the RemoteAgent's metadata repository manager.
  */
-public class RemoteAgentMetadataRepositoryOfflineCache extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class RemoteAgentMetadataRepositoryOfflineCache implements TychoPlexusExtension.MavenSessionCustomizer {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final String HTTP_REPO_PATH = "e342";
 
-    @Rule
-    public TemporaryFolder tempManager = new TemporaryFolder();
-    @Rule
+    @TempDir
+    Path tempManager;
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
 
-    @Rule
+    @RegisterExtension
     public final HttpServer localServer = new HttpServer();
     private URI localHttpRepo;
 
-    @Before
+    @BeforeEach
     public void initLocalMavenRepository() throws Exception {
         localHttpRepo = URI
                 .create(localServer.addServlet(HTTP_REPO_PATH, new File("src/test/resources/repositories/e342")));
-        tempManager.newFolder("m2-repo");
+        newFolder("m2-repo");
     }
 
     @Override
-    protected void modifySession(MavenSession mavenSession) {
+    public void customizeSession(MavenSession mavenSession) {
         mavenSession.getRequest().setOffline(true);
     }
 
@@ -65,7 +76,7 @@ public class RemoteAgentMetadataRepositoryOfflineCache extends TychoPlexusTestCa
     }
 
     private IProvisioningAgent newOfflineAgent() throws Exception {
-        return lookup(IProvisioningAgent.class);
+        return container.lookup(IProvisioningAgent.class);
     }
 
     private IMetadataRepository loadHttpRepository(IProvisioningAgent offlineAgent) throws ProvisionException {
@@ -75,4 +86,8 @@ public class RemoteAgentMetadataRepositoryOfflineCache extends TychoPlexusTestCa
         return repo;
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverExecutionEnvironmentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverExecutionEnvironmentTest.java
@@ -21,11 +21,18 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
@@ -42,23 +49,26 @@ import org.eclipse.tycho.targetplatform.TargetDefinition;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Repository;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TargetDefinitionResolverExecutionEnvironmentTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class TargetDefinitionResolverExecutionEnvironmentTest {
 
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private TargetDefinitionResolver subject;
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
     private TargetDefinitionResolver targetResolverForEE(String executionEnvironmentName, String... systemPackages)
             throws ProvisionException, IOException {
-        MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
+        MavenContext mavenCtx = new MockMavenContext(newFolder("localRepo"), logVerifier.getLogger());
         return new TargetDefinitionResolver(defaultEnvironments(),
                 new StandardEEResolutionHints(new ExecutionEnvironmentStub(executionEnvironmentName, systemPackages)),
                 IncludeSourceMode.honor, ReferencedRepositoryMode.ignore, mavenCtx, null,
@@ -70,7 +80,7 @@ public class TargetDefinitionResolverExecutionEnvironmentTest extends TychoPlexu
         subject = targetResolverForEE("CDC-1.0/Foundation-1.0");
 
         TargetDefinition definition = definitionWith(new AlternatePackageProviderLocationStub());
-        Collection<IInstallableUnit> units = subject.resolveContent(definition, lookup(IProvisioningAgent.class))
+        Collection<IInstallableUnit> units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class))
                 .query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet();
 
         // expect that resolver included a bundle providing org.w3c.dom (here javax.xml)...
@@ -84,7 +94,7 @@ public class TargetDefinitionResolverExecutionEnvironmentTest extends TychoPlexu
         subject = targetResolverForEE("JavaSE-1.7", "org.w3c.dom");
 
         TargetDefinition definition = definitionWith(new AlternatePackageProviderLocationStub());
-        Collection<IInstallableUnit> units = subject.resolveContent(definition, lookup(IProvisioningAgent.class))
+        Collection<IInstallableUnit> units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class))
                 .query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet();
 
         // expect that resolver did not included a bundle providing org.w3c.dom...
@@ -113,4 +123,8 @@ public class TargetDefinitionResolverExecutionEnvironmentTest extends TychoPlexu
 
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeModeTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeModeTest.java
@@ -13,6 +13,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.MAIN_BUNDLE;
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.OPTIONAL_BUNDLE;
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.REFERENCED_BUNDLE_V1;
@@ -27,6 +33,10 @@ import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
@@ -41,24 +51,27 @@ import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TargetDefinitionResolverIncludeModeTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class TargetDefinitionResolverIncludeModeTest {
 
-    @Rule
+    @Inject
+    protected PlexusContainer container;
+
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private TargetDefinitionResolver subject;
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
-    @Before
+    @BeforeEach
     public void initSubject() throws Exception {
-        MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
+        MavenContext mavenCtx = new MockMavenContext(newFolder("localRepo"), logVerifier.getLogger());
         subject = new TargetDefinitionResolver(defaultEnvironments(),
                 ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
                 ReferencedRepositoryMode.ignore, mavenCtx, null,
@@ -69,36 +82,36 @@ public class TargetDefinitionResolverIncludeModeTest extends TychoPlexusTestCase
     public void testResolveWithPlanner() throws Exception {
         TargetDefinition definition = definitionWith(
                 new PlannerLocationStub(TestRepositories.V1_AND_V2, TARGET_FEATURE));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units),
                 bagEquals(versionedIdList(TARGET_FEATURE, MAIN_BUNDLE, REFERENCED_BUNDLE_V1, OPTIONAL_BUNDLE)));
     }
 
-    @Test(expected = ResolverException.class)
+    @Test
     public void testUnsatisfiedDependencyWithPlannerFails() throws Exception {
         // ignore logged errors
         logVerifier.expectError(any(String.class));
 
         TargetDefinition definition = definitionWith(
                 new PlannerLocationStub(TestRepositories.UNSATISFIED, MAIN_BUNDLE));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        assertThrows(ResolverException.class, () -> subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class)));
     }
 
-    @Test(expected = ResolverException.class)
+    @Test
     public void testUnsatisfiedInclusionWithPlannerFails() throws Exception {
         // ignore logged errors
         logVerifier.expectError(any(String.class));
 
         TargetDefinition definition = definitionWith(
                 new PlannerLocationStub(TestRepositories.UNSATISFIED, TARGET_FEATURE));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        assertThrows(ResolverException.class, () -> subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class)));
     }
 
     @Test
     public void testResolveWithSlicer() throws Exception {
         TargetDefinition definition = definitionWith(
                 new SlicerLocationStub(TestRepositories.V1_AND_V2, TARGET_FEATURE));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units),
                 bagEquals(versionedIdList(TARGET_FEATURE, MAIN_BUNDLE, REFERENCED_BUNDLE_V1)));
     }
@@ -111,7 +124,7 @@ public class TargetDefinitionResolverIncludeModeTest extends TychoPlexusTestCase
         // expectWarningMissingDependency(MAIN_BUNDLE, REFERENCED_BUNDLE_V1);
         expectNoErrors();
         TargetDefinition definition = definitionWith(new SlicerLocationStub(TestRepositories.UNSATISFIED, MAIN_BUNDLE));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(MAIN_BUNDLE)));
     }
 
@@ -121,14 +134,14 @@ public class TargetDefinitionResolverIncludeModeTest extends TychoPlexusTestCase
         expectNoErrors();
         TargetDefinition definition = definitionWith(
                 new SlicerLocationStub(TestRepositories.UNSATISFIED, TARGET_FEATURE));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class));
     }
 
-    @Test(expected = TargetDefinitionResolutionException.class)
+    @Test
     public void testResolveConflictingIncludeMode() throws Exception {
         TargetDefinition definition = definitionWith(new SlicerLocationStub(TestRepositories.V1, MAIN_BUNDLE),
                 new PlannerLocationStub(TestRepositories.V2));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        assertThrows(TargetDefinitionResolutionException.class, () -> subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class)));
     }
 
     private void expectWarningMissingDependency(IVersionedId from, IVersionedId to) {
@@ -163,5 +176,9 @@ public class TargetDefinitionResolverIncludeModeTest extends TychoPlexusTestCase
         public IncludeMode getIncludeMode() {
             return IncludeMode.SLICER;
         }
+    }
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeSourceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverIncludeSourceTest.java
@@ -19,11 +19,20 @@ import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.versione
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
@@ -40,41 +49,44 @@ import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class TargetDefinitionResolverIncludeSourceTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final IVersionedId BUNDLE_WITH_SOURCES = new VersionedId("simple.bundle", "1.0.0.201407081200");
     private static final IVersionedId SOURCE_BUNDLE = new VersionedId("simple.bundle.source", "1.0.0.201407081200");
     private static final IVersionedId NOSOURCE_BUNDLE = new VersionedId("nosource.bundle", "1.0.0");
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
     private TargetDefinitionResolver subject;
 
-    @Before
+    @BeforeEach
     public void initSubject() throws Exception {
-        MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
+        MavenContext mavenCtx = new MockMavenContext(newFolder("localRepo"), logVerifier.getLogger());
         subject = new TargetDefinitionResolver(defaultEnvironments(),
                 ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
                 ReferencedRepositoryMode.ignore, mavenCtx, null,
                 new DefaultTargetDefinitionVariableResolver(mavenCtx, logVerifier.getLogger()));
     }
 
-    @Test(expected = TargetDefinitionResolutionException.class)
+    @Test
     public void testConflictingIncludeSourceLocations() throws Exception {
         TargetDefinition definition = definitionWith(
                 new WithSourceLocationStub(null, TestRepositories.SOURCES, BUNDLE_WITH_SOURCES),
                 new WithoutSourceLocationStub(null, TestRepositories.SOURCES));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        assertThrows(TargetDefinitionResolutionException.class, () -> subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class)));
     }
 
     @Test
@@ -83,7 +95,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
                 new WithSourceLocationStub(IncludeMode.SLICER, TestRepositories.SOURCES, BUNDLE_WITH_SOURCES));
 
         TargetDefinitionContent content = subject.resolveContentWithExceptions(definition,
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
@@ -96,7 +108,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
                 new WithSourceLocationStub(IncludeMode.PLANNER, TestRepositories.SOURCES, BUNDLE_WITH_SOURCES));
 
         TargetDefinitionContent content = subject.resolveContentWithExceptions(definition,
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
@@ -114,7 +126,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
                 new WithoutSourceLocationStub(IncludeMode.SLICER, TestRepositories.SOURCES, BUNDLE_WITH_SOURCES));
 
         TargetDefinitionContent content = subject.resolveContentWithExceptions(definition,
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(content), not(hasItem(SOURCE_BUNDLE)));
         assertEquals(1, getResultSet(content).size());
@@ -126,7 +138,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
                 new WithoutSourceLocationStub(IncludeMode.PLANNER, TestRepositories.SOURCES, BUNDLE_WITH_SOURCES));
 
         TargetDefinitionContent content = subject.resolveContentWithExceptions(definition,
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(content), not(hasItem(SOURCE_BUNDLE)));
         assertEquals(1, getResultSet(content).size());
@@ -138,7 +150,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
                 TestRepositories.SOURCES, BUNDLE_WITH_SOURCES, NOSOURCE_BUNDLE));
 
         TargetDefinitionContent content = subject.resolveContentWithExceptions(definition,
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(content), hasItem(NOSOURCE_BUNDLE));
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
@@ -152,7 +164,7 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
                 TestRepositories.SOURCES, BUNDLE_WITH_SOURCES, NOSOURCE_BUNDLE));
 
         TargetDefinitionContent content = subject.resolveContentWithExceptions(definition,
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(content), hasItem(NOSOURCE_BUNDLE));
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
@@ -199,5 +211,9 @@ public class TargetDefinitionResolverIncludeSourceTest extends TychoPlexusTestCa
         public IncludeMode getIncludeMode() {
             return this.includeMode;
         }
+    }
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverTest.java
@@ -15,12 +15,16 @@ package org.eclipse.tycho.p2resolver;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -28,6 +32,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
@@ -52,16 +60,19 @@ import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 import org.eclipse.tycho.targetplatform.TargetDefinitionSyntaxException;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class TargetDefinitionResolverTest {
+
+    @Inject
+    protected PlexusContainer container;
     /** Feature including MAIN_BUNDLE and REFERENCED_BUNDLE_V1 */
     static final IVersionedId TARGET_FEATURE = new VersionedId("trt.targetFeature.feature.group", "1.0.0.201108051343");
 
@@ -81,17 +92,17 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
     private static final VersionedId REFERENCED_BUNDLE_INVALID_VERSION = new VersionedId("trt.bundle.referenced",
             INVALID_VERSION_MARKER);
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
     private TargetDefinitionResolver subject;
 
-    @Before
+    @BeforeEach
     public void initContext() throws Exception {
-        MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
+        MavenContext mavenCtx = new MockMavenContext(newFolder("localRepo"), logVerifier.getLogger());
         subject = new TargetDefinitionResolver(defaultEnvironments(),
                 ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
                 ReferencedRepositoryMode.ignore, mavenCtx, null,
@@ -107,7 +118,7 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
         String uri = TargetDefinitionResolver
                 .convertRawToUri("file:C:\\ws\\target-testcase\\tycho\\target.references\\target.refs/base.target");
         //check that it has the missing / infront of the protocol
-        assertTrue(uri + " does not start with file:/", uri.startsWith("file:/"));
+        assertTrue(uri.startsWith("file:/"), uri + " does not start with file:/");
         //check that this could be parsed as an URI afterwards
         URI parsed = new URI(uri);
         parsed.toURL();
@@ -117,14 +128,14 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
     @Test
     public void testResolveNoLocations() throws Exception {
         TargetDefinition definition = definitionWith();
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList()));
     }
 
     @Test
     public void testResolveOtherLocationYieldsWarning() throws Exception {
         TargetDefinition definition = definitionWith(new OtherLocationStub(), new LocationStub(TARGET_FEATURE));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), hasItem(MAIN_BUNDLE));
         logVerifier.expectWarning("Target location type 'OtherLocation' is not supported");
     }
@@ -132,7 +143,7 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
     @Test
     public void testResolveMultipleUnits() throws Exception {
         TargetDefinition definition = definitionWith(new LocationStub(OPTIONAL_BUNDLE, REFERENCED_BUNDLE_V1));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(REFERENCED_BUNDLE_V1, OPTIONAL_BUNDLE)));
     }
 
@@ -140,7 +151,7 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
     public void testResolveMultipleLocations() throws Exception {
         TargetDefinition definition = definitionWith(new LocationStub(OPTIONAL_BUNDLE),
                 new LocationStub(REFERENCED_BUNDLE_V1));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(REFERENCED_BUNDLE_V1, OPTIONAL_BUNDLE)));
     }
 
@@ -148,21 +159,21 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
     public void testResolveMultipleRepositories() throws Exception {
         TargetDefinition definition = definitionWith(
                 new LocationStub(TestRepositories.V1_AND_V2, OPTIONAL_BUNDLE, REFERENCED_BUNDLE_V2));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(REFERENCED_BUNDLE_V2, OPTIONAL_BUNDLE)));
     }
 
     @Test
     public void testResolveNoRepositories() throws Exception {
         TargetDefinition definition = definitionWith(new LocationStub(TestRepositories.NONE));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList()));
     }
 
     @Test
     public void testResolveIncludesDependencies() throws Exception {
         TargetDefinition definition = definitionWith(new LocationStub(TestRepositories.V1_AND_V2, TARGET_FEATURE));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), hasItem(MAIN_BUNDLE));
         assertThat(versionedIdsOf(units), hasItem(REFERENCED_BUNDLE_V1));
     }
@@ -174,29 +185,29 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
         // logVerifier.expectNoWarnings();
         TargetDefinition definition = definitionWith(new LocationStub(TestRepositories.UNSATISFIED, TARGET_FEATURE),
                 new LocationStub(TestRepositories.V1_AND_V2, MAIN_BUNDLE, REFERENCED_BUNDLE_V1));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), hasItem(MAIN_BUNDLE));
         assertThat(versionedIdsOf(units), hasItem(REFERENCED_BUNDLE_V1));
     }
 
-    @Test(expected = TargetDefinitionResolutionException.class)
+    @Test
     public void testMissingUnit() throws Exception {
         TargetDefinition definition = definitionWith(new LocationStub(TestRepositories.V2, MAIN_BUNDLE));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        assertThrows(TargetDefinitionResolutionException.class, () -> subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class)));
     }
 
-    @Test(expected = TargetDefinitionResolutionException.class)
+    @Test
     public void testUnitOnlyLookedUpInLocation() throws Exception {
         TargetDefinition definition = definitionWith(new LocationStub(TestRepositories.V2, MAIN_BUNDLE),
                 new LocationStub(TestRepositories.V1));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        assertThrows(TargetDefinitionResolutionException.class, () -> subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class)));
     }
 
     @Test
     public void testUnitWithWildcardVersion() throws ProvisionException, ComponentLookupException {
         TargetDefinition definition = definitionWith(
                 new LocationStub(TestRepositories.V1_AND_V2, REFERENCED_BUNDLE_WILDCARD_VERSION));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(REFERENCED_BUNDLE_V2)));
     }
 
@@ -204,7 +215,7 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
     public void testUnitWithExactVersion() throws ProvisionException, ComponentLookupException {
         TargetDefinition definition = definitionWith(
                 new LocationStub(TestRepositories.V1_AND_V2, REFERENCED_BUNDLE_V1));
-        TargetDefinitionContent units = subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(REFERENCED_BUNDLE_V1)));
     }
 
@@ -212,24 +223,24 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
      * Ideally, the interface should return strongly typed versions. Since this is not possible in
      * the facade, syntax errors in the version attribute can only be detected by the resolver.
      */
-    @Test(expected = TargetDefinitionSyntaxException.class)
+    @Test
     public void testUnitWithWrongVersionYieldsSyntaxException() throws Exception {
         TargetDefinition definition = definitionWith(
                 new LocationStub(TestRepositories.V1_AND_V2, REFERENCED_BUNDLE_INVALID_VERSION));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        assertThrows(TargetDefinitionSyntaxException.class, () -> subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class)));
     }
 
-    @Test(expected = TargetDefinitionResolutionException.class)
+    @Test
     public void testInvalidRepository() throws Exception {
         TargetDefinition definition = definitionWith(new LocationStub(TestRepositories.INVALID, TARGET_FEATURE));
-        subject.resolveContentWithExceptions(definition, lookup(IProvisioningAgent.class));
+        assertThrows(TargetDefinitionResolutionException.class, () -> subject.resolveContentWithExceptions(definition, container.lookup(IProvisioningAgent.class)));
     }
 
     @Test
     public void testResolveWithBundleInclusionListYieldsWarning() throws ProvisionException, ComponentLookupException {
         List<Location> noLocations = Collections.emptyList();
         TargetDefinition definition = new TargetDefinitionStub(noLocations, true);
-        subject.resolveContent(definition, lookup(IProvisioningAgent.class));
+        subject.resolveContent(definition, container.lookup(IProvisioningAgent.class));
 
         // this was bug 373776: the includeBundles tag (which is the selection on the Content tab) was silently ignored
         logVerifier.expectWarning("De-selecting bundles in a target definition file is not supported");
@@ -440,4 +451,8 @@ public class TargetDefinitionResolverTest extends TychoPlexusTestCase {
 
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverWithPlatformSpecificUnitsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetDefinitionResolverWithPlatformSpecificUnitsTest.java
@@ -13,17 +13,25 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.bagEquals;
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.definitionWith;
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.versionedIdList;
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.versionedIdsOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
@@ -42,12 +50,15 @@ import org.eclipse.tycho.targetplatform.TargetDefinitionContent;
 import org.eclipse.tycho.targetplatform.TargetDefinitionResolutionException;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.MockMavenContext;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class TargetDefinitionResolverWithPlatformSpecificUnitsTest {
+
+    @Inject
+    protected PlexusContainer container;
     private static final IVersionedId LAUNCHER_FEATURE = new VersionedId("org.eclipse.equinox.executable.feature.group",
             "3.3.101.R34x_v20081125-7H-ELfE8hXnkE15Wh9Tnyu");
     private static final IVersionedId LAUNCHER_FEATURE_JAR = new VersionedId(
@@ -63,9 +74,9 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
 
     private static TargetDefinition targetDefinition;
 
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
-    @Rule
+    @TempDir
+    Path tempManager;
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private TargetDefinitionResolver subject;
@@ -75,7 +86,7 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
         targetDefinition = definitionWith(new FilterRepoLocationStubWithLauncherUnit(IncludeMode.PLANNER));
         subject = createResolver(Collections.singletonList(new TargetEnvironment(null, null, null)));
 
-        TargetDefinitionContent units = subject.resolveContent(targetDefinition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(targetDefinition, container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(units),
                 bagEquals(versionedIdList(LAUNCHER_FEATURE, LAUNCHER_FEATURE_JAR, LAUNCHER_BUNDLE)));
@@ -87,7 +98,7 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
         targetDefinition = definitionWith(new FilterRepoLocationStubWithLauncherUnit(IncludeMode.PLANNER));
         subject = createResolver(Collections.singletonList(environment));
 
-        TargetDefinitionContent units = subject.resolveContent(targetDefinition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(targetDefinition, container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(units), bagEquals(
                 versionedIdList(LAUNCHER_FEATURE, LAUNCHER_FEATURE_JAR, LAUNCHER_BUNDLE, LAUNCHER_BUNDLE_LINUX)));
@@ -100,7 +111,7 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
         targetDefinition = definitionWith(new FilterRepoLocationStubWithLauncherUnit(IncludeMode.PLANNER));
         subject = createResolver(environments);
 
-        TargetDefinitionContent units = subject.resolveContent(targetDefinition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(targetDefinition, container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(LAUNCHER_FEATURE, LAUNCHER_FEATURE_JAR,
                 LAUNCHER_BUNDLE, LAUNCHER_BUNDLE_LINUX, LAUNCHER_BUNDLE_WINDOWS, LAUNCHER_BUNDLE_MAC)));
@@ -112,7 +123,7 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
         targetDefinition = definitionWith(new FilterRepoLocationStubWithLauncherUnit(IncludeMode.SLICER));
         subject = createResolver(Collections.singletonList(environment));
 
-        TargetDefinitionContent units = subject.resolveContent(targetDefinition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(targetDefinition, container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(units), bagEquals(
                 versionedIdList(LAUNCHER_FEATURE, LAUNCHER_FEATURE_JAR, LAUNCHER_BUNDLE, LAUNCHER_BUNDLE_LINUX)));
@@ -125,7 +136,7 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
         targetDefinition = definitionWith(new FilterRepoLocationStubWithLauncherUnit(IncludeMode.SLICER));
         subject = createResolver(environments);
 
-        TargetDefinitionContent units = subject.resolveContent(targetDefinition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(targetDefinition, container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(LAUNCHER_FEATURE, LAUNCHER_FEATURE_JAR,
                 LAUNCHER_BUNDLE, LAUNCHER_BUNDLE_WINDOWS, LAUNCHER_BUNDLE_MAC)));
@@ -137,24 +148,24 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
         targetDefinition = definitionWith(new FilterRepoLocationStubWithLauncherUnit(IncludeMode.SLICER, true));
         subject = createResolver(Collections.singletonList(environment));
 
-        TargetDefinitionContent units = subject.resolveContent(targetDefinition, lookup(IProvisioningAgent.class));
+        TargetDefinitionContent units = subject.resolveContent(targetDefinition, container.lookup(IProvisioningAgent.class));
 
         assertThat(versionedIdsOf(units), bagEquals(versionedIdList(LAUNCHER_FEATURE, LAUNCHER_FEATURE_JAR,
                 LAUNCHER_BUNDLE, LAUNCHER_BUNDLE_LINUX, LAUNCHER_BUNDLE_WINDOWS, LAUNCHER_BUNDLE_MAC)));
     }
 
-    @Test(expected = TargetDefinitionResolutionException.class)
+    @Test
     public void testConflictingIncludeAllEnvironments() throws Exception {
         targetDefinition = definitionWith(new FilterRepoLocationStubWithLauncherUnit(IncludeMode.SLICER, true),
                 new FilterRepoLocationStubWithLauncherUnit(IncludeMode.SLICER, false));
         subject = createResolver(Collections.singletonList(new TargetEnvironment(null, null, null)));
 
-        subject.resolveContentWithExceptions(targetDefinition, lookup(IProvisioningAgent.class));
+        assertThrows(TargetDefinitionResolutionException.class, () -> subject.resolveContentWithExceptions(targetDefinition, container.lookup(IProvisioningAgent.class)));
     }
 
     private TargetDefinitionResolver createResolver(List<TargetEnvironment> environments)
             throws ProvisionException, IOException {
-        MavenContext mavenCtx = new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger());
+        MavenContext mavenCtx = new MockMavenContext(newFolder("localRepo"), logVerifier.getLogger());
         return new TargetDefinitionResolver(environments, ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS,
                 IncludeSourceMode.honor, ReferencedRepositoryMode.ignore, mavenCtx, null,
                 new DefaultTargetDefinitionVariableResolver(mavenCtx, logVerifier.getLogger()));
@@ -210,4 +221,8 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest extends Tycho
         }
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetPlatformFactoryTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
+import static org.eclipse.tycho.core.test.utils.ResourceUtil.resourceFile;
 import static org.eclipse.tycho.p2resolver.ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HANDLER;
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.MAIN_BUNDLE;
 import static org.eclipse.tycho.p2resolver.TargetDefinitionResolverTest.REFERENCED_BUNDLE_V1;
@@ -23,11 +24,14 @@ import static org.eclipse.tycho.test.util.InstallableUnitMatchers.unitWithIdAndV
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +43,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
@@ -72,25 +80,28 @@ import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.ReactorProjectIdentitiesStub;
 import org.eclipse.tycho.test.util.ReactorProjectStub;
 import org.eclipse.tycho.test.util.TestResolverFactory;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TargetPlatformFactoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class TargetPlatformFactoryTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final ReactorProjectIdentities DUMMY_PROJECT = new ReactorProjectIdentitiesStub("dummy-artifact");
 
     // the joint artifact provider is tested in integration
     private static final List<IRawArtifactFileProvider> REACTOR_ARTIFACTS = Collections.emptyList();
 
-    @Rule
+    @RegisterExtension
     public LogVerifier logVerifier = new LogVerifier();
 
-    @Rule
-    public final TemporaryFolder tempManager = new TemporaryFolder();
+    @TempDir
+    Path tempManager;
 
     private TargetPlatformConfigurationStub tpConfig;
 
@@ -100,17 +111,17 @@ public class TargetPlatformFactoryTest extends TychoPlexusTestCase {
 
     private Path localM2Repo;
 
-    @Before
+    @BeforeEach
     public void setUpSubjectAndContext() throws Exception {
         TestResolverFactory testResolverFactory = new TestResolverFactory(logVerifier.getMavenLogger(),
-                logVerifier.getLogger(), lookup(IProvisioningAgent.class), lookup(MavenTargetLocationFactory.class));
+                logVerifier.getLogger(), container.lookup(IProvisioningAgent.class), container.lookup(MavenTargetLocationFactory.class));
         subject = testResolverFactory.getTargetPlatformFactoryImpl();
         localM2Repo = testResolverFactory.mavenContext.getLocalRepositoryRoot().getAbsoluteFile().toPath();
 
         tpConfig = new TargetPlatformConfigurationStub();
         tpConfig.setEnvironments(Collections.singletonList(new TargetEnvironment(null, null, null))); // dummy value for target file resolution
         pomDependencyCollector = new PomDependencyCollectorImpl(logVerifier.getLogger(),
-                new ReactorProjectStub(tempManager.newFolder(), "test"), lookup(IProvisioningAgent.class));
+                new ReactorProjectStub(newFolder("temp"), "test"), container.lookup(IProvisioningAgent.class));
     }
 
     @Test
@@ -259,7 +270,7 @@ public class TargetPlatformFactoryTest extends TychoPlexusTestCase {
     @Test
     public void testIncludeLocalMavenRepo() throws Exception {
         TestResolverFactory factory = new TestResolverFactory(logVerifier.getMavenLogger(), logVerifier.getLogger(),
-                lookup(IProvisioningAgent.class), lookup(MavenTargetLocationFactory.class));
+                container.lookup(IProvisioningAgent.class), container.lookup(MavenTargetLocationFactory.class));
         LocalMetadataRepository localMetadataRepo = factory.getLocalMetadataRepository();
         // add one IU to local repo
         localMetadataRepo.addInstallableUnit(InstallableUnitUtil.createIU("locallyInstalledIU", "1.0.0"),
@@ -287,16 +298,16 @@ public class TargetPlatformFactoryTest extends TychoPlexusTestCase {
         assertThat(tp.getInstallableUnits(), hasItem(unitWithIdAndVersion(REFERENCED_BUNDLE_V2)));
     }
 
-    @Test(expected = DuplicateReactorIUsException.class)
+    @Test
     public void testDuplicateReactorUnits() throws Exception {
         List<ReactorProject> reactorProjects = new ArrayList<>();
         reactorProjects.add(createReactorProject("project1", "unit.a", "unit.b"));
         reactorProjects.add(createReactorProject("project2", "unit.b", null));
-        subject.createTargetPlatform(tpConfig, NOOP_EE_RESOLUTION_HANDLER, reactorProjects);
+        assertThrows(DuplicateReactorIUsException.class, () -> subject.createTargetPlatform(tpConfig, NOOP_EE_RESOLUTION_HANDLER, reactorProjects));
     }
 
     @Test
-    @Ignore("This test don't work because maven provides a 'not real' local repo to the test")
+    @Disabled("This test don't work because maven provides a 'not real' local repo to the test")
     public void testMavenArtifactsInTargetDefinitionResolveToMavenPath() throws Exception {
         File targetDefinition = resourceFile("targetresolver/mavenDep.target");
         tpConfig.addTargetDefinition(TargetDefinitionFile.read(targetDefinition));
@@ -362,4 +373,8 @@ public class TargetPlatformFactoryTest extends TychoPlexusTestCase {
         }
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempManager.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetPlatformFilterEvaluatorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/TargetPlatformFilterEvaluatorTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2resolver;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.eclipse.tycho.targetplatform.TargetPlatformFilter.removeAllFilter;
 import static org.eclipse.tycho.targetplatform.TargetPlatformFilter.restrictionFilter;
 import static org.eclipse.tycho.targetplatform.TargetPlatformFilter.CapabilityPattern.patternWithVersion;
@@ -30,6 +31,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.query.QueryUtil;
@@ -42,20 +47,23 @@ import org.eclipse.tycho.targetplatform.TargetPlatformFilterSyntaxException;
 import org.eclipse.tycho.targetplatform.TargetPlatformFilter.CapabilityPattern;
 import org.eclipse.tycho.targetplatform.TargetPlatformFilter.CapabilityType;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
-public class TargetPlatformFilterEvaluatorTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class TargetPlatformFilterEvaluatorTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final CapabilityPattern ALL_MULTIVERSION_BUNDLES = patternWithVersion(CapabilityType.OSGI_BUNDLE,
             "trf.bundle.multiversion", null);
 
-    @Rule
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private static Set<IInstallableUnit> baselineUnits;
@@ -63,14 +71,14 @@ public class TargetPlatformFilterEvaluatorTest extends TychoPlexusTestCase {
 
     private TargetPlatformFilterEvaluator subject;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         baselineUnits = loadTestUnits();
         workUnits = new LinkedHashSet<>(baselineUnits);
     }
 
     private Set<IInstallableUnit> loadTestUnits() throws Exception {
-        IMetadataRepositoryManager metadataManager = lookup(IProvisioningAgent.class)
+        IMetadataRepositoryManager metadataManager = container.lookup(IProvisioningAgent.class)
                 .getService(IMetadataRepositoryManager.class);
         File testDataFile = ResourceUtil.resourceFile("targetfiltering/content.xml");
         IMetadataRepository testDataRepository = metadataManager.loadRepository(testDataFile.getParentFile().toURI(),
@@ -199,22 +207,22 @@ public class TargetPlatformFilterEvaluatorTest extends TychoPlexusTestCase {
                 .expectWarning(allOf(containsString("Removed all units"), containsString("trf.bundle.multiversion")));
     }
 
-    @Test(expected = TargetPlatformFilterSyntaxException.class)
+    @Test
     public void testNonParsableVersion() throws Exception {
         TargetPlatformFilter invalidFilter = restrictionFilter(ALL_MULTIVERSION_BUNDLES,
                 patternWithVersion(null, null, "1.a"));
         subject = newEvaluator(invalidFilter);
 
-        subject.filterUnits(workUnits);
+        assertThrows(TargetPlatformFilterSyntaxException.class, () -> subject.filterUnits(workUnits));
     }
 
-    @Test(expected = TargetPlatformFilterSyntaxException.class)
+    @Test
     public void testNonParsableVersionRange() throws Exception {
         TargetPlatformFilter invalidFilter = restrictionFilter(ALL_MULTIVERSION_BUNDLES,
                 patternWithVersionRange(null, null, "[1.0.0,")); // "[1.0.0," is invalid; "1.0.0" is the range from 1 to infinity
         subject = newEvaluator(invalidFilter);
 
-        subject.filterUnits(workUnits);
+        assertThrows(TargetPlatformFilterSyntaxException.class, () -> subject.filterUnits(workUnits));
     }
 
     private Collection<String> removedUnits() {

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorApplicationServiceTest.java
@@ -14,9 +14,13 @@ package org.eclipse.tycho.p2tools;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.io.IOException;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,6 +32,10 @@ import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IRequirement;
@@ -46,16 +54,19 @@ import org.eclipse.tycho.p2.tools.RepositoryReferences;
 import org.eclipse.tycho.p2.tools.publisher.DependencySeedUtil;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.ReactorProjectIdentitiesStub;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class MirrorApplicationServiceTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     // feature containing org.eclipse.core.runtime 3.4
     private static final String SIMPLE_FEATURE = "org.eclipse.example.original_feature";
@@ -75,18 +86,18 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
 
     private MirrorApplicationServiceImpl subject;
 
-    @Rule
-    public final TemporaryFolder tempFolder = new TemporaryFolder();
-    @Rule
+    @TempDir
+    Path tempFolder;
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
-    @Before
+    @BeforeEach
     public void initTestContext() throws Exception {
-        IProvisioningAgent agent = lookup(IProvisioningAgent.class);
+        IProvisioningAgent agent = container.lookup(IProvisioningAgent.class);
         agent.getService(IArtifactRepositoryManager.class);
-        destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest"), DEFAULT_NAME);
+        destinationRepo = new DestinationRepositoryDescriptor(newFolder("dest"), DEFAULT_NAME);
 
-        File projectFolder = tempFolder.getRoot();
+        File projectFolder = tempFolder.toFile();
         ReactorProjectIdentities currentProject = new ReactorProjectIdentitiesStub(projectFolder);
         context = new BuildContext(currentProject, DEFAULT_QUALIFIER, DEFAULT_ENVIRONMENTS);
 
@@ -95,13 +106,12 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         subject.setLogger(logVerifier.getLogger());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMirrorNothing() throws Exception {
         // make sure that this unsupported case is detected; the mirror application would just mirror everything
         Collection<DependencySeed> noSeeds = Collections.emptyList();
 
-        subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, noSeeds, context, false, false, false,
-                false, false, false, null);
+        assertThrows(IllegalArgumentException.class, () -> subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, noSeeds, context, false, false, false, false, false, false, null));
     }
 
     @Test
@@ -120,7 +130,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         extraArtifactRepositoryProperties.put("p2.statsURI", "http://some.where");
         extraArtifactRepositoryProperties.put("p2.mirrorsURL", "http://some.where.else");
         extraArtifactRepositoryProperties.put("foo", "bar");
-        destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest2"), DEFAULT_NAME, false, false,
+        destinationRepo = new DestinationRepositoryDescriptor(newFolder("dest2"), DEFAULT_NAME, false, false,
                 false, false, true, extraArtifactRepositoryProperties, Collections.emptyList(),
                 Collections.emptyList());
         subject.mirrorReactor(sourceRepos("patch", "e342"), destinationRepo, seedFor(SIMPLE_FEATURE_IU), context, false,
@@ -140,8 +150,7 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
                 extraArtifactRepositoryProperties.remove(propertyName);
             }
         }
-        assertEquals("Artifact repository is missing extra properties", Collections.emptyMap(),
-                extraArtifactRepositoryProperties);
+        assertEquals(Collections.emptyMap(), extraArtifactRepositoryProperties, "Artifact repository is missing extra properties");
     }
 
     @Test
@@ -228,4 +237,8 @@ public class MirrorApplicationServiceTest extends TychoPlexusTestCase {
         return new File(repo.getLocation(), path);
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempFolder.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorStandaloneParentCategoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorStandaloneParentCategoryTest.java
@@ -13,15 +13,23 @@
 package org.eclipse.tycho.p2tools;
 
 import static org.eclipse.tycho.p2tools.MirrorApplicationServiceTest.sourceRepos;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.query.IQueryResult;
@@ -34,13 +42,16 @@ import org.eclipse.tycho.BuildOutputDirectory;
 import org.eclipse.tycho.p2.tools.DestinationRepositoryDescriptor;
 import org.eclipse.tycho.p2.tools.mirroring.facade.MirrorOptions;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class MirrorStandaloneParentCategoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class MirrorStandaloneParentCategoryTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final String DEFAULT_NAME = "dummy";
     private static final String PARENT_CATEGORY_NAME = "Parent Category";
@@ -49,22 +60,22 @@ public class MirrorStandaloneParentCategoryTest extends TychoPlexusTestCase {
     private DestinationRepositoryDescriptor destinationRepo;
     private MirrorApplicationServiceImpl subject;
 
-    @Rule
-    public final TemporaryFolder tempFolder = new TemporaryFolder();
-    @Rule
+    @TempDir
+    Path tempFolder;
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private BuildDirectory targetFolder;
 
-    @Before
+    @BeforeEach
     public void initTestContext() throws Exception {
-        IProvisioningAgent agent = lookup(IProvisioningAgent.class);
+        IProvisioningAgent agent = container.lookup(IProvisioningAgent.class);
         agent.getService(IArtifactRepositoryManager.class);
-        destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest"), DEFAULT_NAME);
+        destinationRepo = new DestinationRepositoryDescriptor(newFolder("dest"), DEFAULT_NAME);
         subject = new MirrorApplicationServiceImpl();
         subject.setAgent(agent);
         subject.setLogger(logVerifier.getLogger());
-        targetFolder = new BuildOutputDirectory(tempFolder.getRoot());
+        targetFolder = new BuildOutputDirectory(tempFolder.toFile());
     }
 
     @Test
@@ -76,7 +87,7 @@ public class MirrorStandaloneParentCategoryTest extends TychoPlexusTestCase {
                 targetFolder);
 
         IInstallableUnit parent = findParentUnit();
-        assertNotNull("Parent category IU was not injected into the destination repository", parent);
+        assertNotNull(parent, "Parent category IU was not injected into the destination repository");
         assertEquals(PARENT_CATEGORY_ID, parent.getId());
         assertEquals(PARENT_CATEGORY_NAME, parent.getProperty(IInstallableUnit.PROP_NAME));
         assertEquals(Boolean.TRUE.toString(), parent.getProperty(QueryUtil.PROP_TYPE_CATEGORY));
@@ -96,11 +107,9 @@ public class MirrorStandaloneParentCategoryTest extends TychoPlexusTestCase {
         Set<String> requiredIds = parent.getRequirements().stream()
                 .map(r -> r.getMatches().getParameters()[0].toString()).collect(Collectors.toSet());
 
-        assertTrue("Parent should require test.category.alpha",
-                requiredIds.contains("org.eclipse.example.category.alpha"));
-        assertTrue("Parent should require test.category.beta",
-                requiredIds.contains("org.eclipse.example.category.beta"));
-        assertEquals("Parent should require exactly the two source categories", 2, requiredIds.size());
+        assertTrue(requiredIds.contains("org.eclipse.example.category.alpha"), "Parent should require test.category.alpha");
+        assertTrue(requiredIds.contains("org.eclipse.example.category.beta"), "Parent should require test.category.beta");
+        assertEquals(2, requiredIds.size(), "Parent should require exactly the two source categories");
     }
 
     @Test
@@ -109,7 +118,7 @@ public class MirrorStandaloneParentCategoryTest extends TychoPlexusTestCase {
                 new MirrorOptions(), targetFolder);
 
         IInstallableUnit parent = findParentUnit();
-        assertTrue("No parent IU should be present when categoryName is not set", parent == null);
+        assertTrue(parent == null, "No parent IU should be present when categoryName is not set");
     }
 
     @Test
@@ -126,7 +135,7 @@ public class MirrorStandaloneParentCategoryTest extends TychoPlexusTestCase {
         IQueryResult<IInstallableUnit> result = openDestinationRepo().query(QueryUtil.createIUQuery(PARENT_CATEGORY_ID),
                 null);
         long count = StreamSupport.stream(result.spliterator(), false).count();
-        assertEquals("Parent category IU must appear exactly once after two mirror runs", 1, count);
+        assertEquals(1, count, "Parent category IU must appear exactly once after two mirror runs");
     }
 
     // --- helpers ---
@@ -138,9 +147,13 @@ public class MirrorStandaloneParentCategoryTest extends TychoPlexusTestCase {
     }
 
     private IMetadataRepository openDestinationRepo() throws Exception {
-        IProvisioningAgent agent = lookup(IProvisioningAgent.class);
+        IProvisioningAgent agent = container.lookup(IProvisioningAgent.class);
         IMetadataRepositoryManager mgr = agent.getService(IMetadataRepositoryManager.class);
         return mgr.loadRepository(destinationRepo.getLocation().toURI(), null);
     }
 
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempFolder.resolve(path)).toFile();
+    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorStandaloneTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2tools/MirrorStandaloneTest.java
@@ -15,13 +15,21 @@ package org.eclipse.tycho.p2tools;
 
 import static org.eclipse.tycho.p2tools.MirrorApplicationServiceTest.repoFile;
 import static org.eclipse.tycho.p2tools.MirrorApplicationServiceTest.sourceRepos;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.tycho.BuildDirectory;
@@ -32,35 +40,38 @@ import org.eclipse.tycho.p2.tools.RepositoryReferences;
 import org.eclipse.tycho.p2.tools.mirroring.facade.IUDescription;
 import org.eclipse.tycho.p2.tools.mirroring.facade.MirrorOptions;
 import org.eclipse.tycho.test.util.LogVerifier;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class MirrorStandaloneTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class MirrorStandaloneTest {
+
+    @Inject
+    protected PlexusContainer container;
     private static final String DEFAULT_NAME = "dummy";
 
     private DestinationRepositoryDescriptor destinationRepo;
 
     private MirrorApplicationServiceImpl subject;
 
-    @Rule
-    public final TemporaryFolder tempFolder = new TemporaryFolder();
-    @Rule
+    @TempDir
+    Path tempFolder;
+    @RegisterExtension
     public final LogVerifier logVerifier = new LogVerifier();
 
     private BuildDirectory targetFolder;
 
-    @Before
+    @BeforeEach
     public void initTestContext() throws Exception {
-        IProvisioningAgent agent = lookup(IProvisioningAgent.class);
+        IProvisioningAgent agent = container.lookup(IProvisioningAgent.class);
         agent.getService(IArtifactRepositoryManager.class);
-        destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest"), DEFAULT_NAME);
+        destinationRepo = new DestinationRepositoryDescriptor(newFolder("dest"), DEFAULT_NAME);
         subject = new MirrorApplicationServiceImpl();
         subject.setAgent(agent);
         subject.setLogger(logVerifier.getLogger());
-        targetFolder = new BuildOutputDirectory(tempFolder.getRoot());
+        targetFolder = new BuildOutputDirectory(tempFolder.toFile());
     }
 
     @Test
@@ -120,11 +131,9 @@ public class MirrorStandaloneTest extends TychoPlexusTestCase {
         assertEquals(1, runtimeBundles.length);
     }
 
-    @Test(expected = FacadeException.class)
+    @Test
     public void testMirrorNotExisting() throws Exception {
-        subject.mirrorStandalone(e342PlusFragmentsRepo(), destinationRepo,
-                Collections.singletonList(new IUDescription("org.eclipse.core.runtime", "10.0.0")), new MirrorOptions(),
-                targetFolder);
+        assertThrows(FacadeException.class, () -> subject.mirrorStandalone(e342PlusFragmentsRepo(), destinationRepo, Collections.singletonList(new IUDescription("org.eclipse.core.runtime", "10.0.0")), new MirrorOptions(), targetFolder));
     }
 
     @Test
@@ -137,11 +146,9 @@ public class MirrorStandaloneTest extends TychoPlexusTestCase {
 
     }
 
-    @Test(expected = FacadeException.class)
+    @Test
     public void testNotIgnoringErrorsShouldThrowException() throws FacadeException {
-        subject.mirrorStandalone(sourceRepos("invalid/wrong_checksum"), destinationRepo,
-                Collections.singletonList(new IUDescription("jarsigning", "0.0.1.201109191414")), new MirrorOptions(),
-                targetFolder);
+        assertThrows(FacadeException.class, () -> subject.mirrorStandalone(sourceRepos("invalid/wrong_checksum"), destinationRepo, Collections.singletonList(new IUDescription("jarsigning", "0.0.1.201109191414")), new MirrorOptions(), targetFolder));
     }
 
     @Test
@@ -155,5 +162,9 @@ public class MirrorStandaloneTest extends TychoPlexusTestCase {
 
     private RepositoryReferences e342PlusFragmentsRepo() {
         return sourceRepos("e342", "fragments");
+    }
+
+    private File newFolder(String path) throws IOException {
+        return Files.createDirectories(tempFolder.resolve(path)).toFile();
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/HttpServer.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/HttpServer.java
@@ -26,9 +26,11 @@ import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class HttpServer extends ExternalResource {
+public class HttpServer implements BeforeEachCallback, AfterEachCallback {
     static final int BIND_ATTEMPTS = 20;
     static final Random rnd = new Random();
 
@@ -50,12 +52,12 @@ public class HttpServer extends ExternalResource {
     }
 
     @Override
-    protected void before() throws Throwable {
+    public void beforeEach(ExtensionContext context) throws Exception {
         runningServer = startServer();
     }
 
     @Override
-    protected void after() {
+    public void afterEach(ExtensionContext context) {
         try {
             stop();
         } catch (Exception e) {
@@ -142,7 +144,7 @@ public class HttpServer extends ExternalResource {
 
     private void checkRunning() {
         if (runningServer == null) {
-            throw new IllegalStateException("HttpServer instance is not running. Did you forget the @Rule annotation?");
+            throw new IllegalStateException("HttpServer instance is not running. Did you forget the @RegisterExtension annotation?");
         }
     }
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/LogVerifier.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/LogVerifier.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.util;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,16 +25,16 @@ import org.eclipse.tycho.core.shared.MavenLogger;
 import org.eclipse.tycho.osgi.adapters.MavenLoggerAdapter;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
-import org.junit.Rule;
-import org.junit.rules.Verifier;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
- * Verifier to be used with JUnit's {@link Rule} annotation which provides a {@link MavenLogger}
+ * Extension to be registered with {@code @RegisterExtension} which provides a {@link MavenLogger}
  * instance and performs assertions on the log entries written to that logger. By default, it is
  * expected that no errors are logged. The expectations can be modified (per test) by calling the
  * <code>expect</code> methods on this instance.
  */
-public class LogVerifier extends Verifier {
+public class LogVerifier implements AfterEachCallback {
 
     private static boolean WRITE_TO_CONSOLE = false;
 
@@ -304,11 +304,17 @@ public class LogVerifier extends Verifier {
     }
 
     @Override
-    protected void verify() throws Throwable {
+    public void afterEach(ExtensionContext context) {
         TestRunContext contextAfterTest = currentContext;
 
         // reset configuration and errors/warnings
         currentContext = null;
+
+        // JUnit 4's Verifier only verified when the test itself passed; without this a failing
+        // test would additionally report unexpected log output and hide the real failure
+        if (context.getExecutionException().isPresent()) {
+            return;
+        }
 
         if (contextAfterTest != null) {
             contextAfterTest.checkLoggedErrors();

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/MatchingItemFinder.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/MatchingItemFinder.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.util;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/NonStartableArtifactSink.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/NonStartableArtifactSink.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.util;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.OutputStream;
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/ProbeArtifactSink.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/ProbeArtifactSink.java
@@ -18,9 +18,9 @@ import static org.eclipse.tycho.test.util.StatusMatchers.warningStatus;
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/TemporaryLocalMavenRepository.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/TemporaryLocalMavenRepository.java
@@ -14,36 +14,51 @@ package org.eclipse.tycho.test.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
 
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils;
 import org.eclipse.tycho.p2.repository.LocalArtifactRepository;
 import org.eclipse.tycho.p2.repository.LocalRepositoryP2Indices;
 import org.eclipse.tycho.p2resolver.LocalRepositoryP2IndicesImpl;
-import org.junit.Rule;
-import org.junit.rules.ExternalResource;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
- * JUnit {@link Rule} that can provide a {@link LocalArtifactRepository} for a temporary local Maven
+ * Extension that can provide a {@link LocalArtifactRepository} for a temporary local Maven
  * repository directory, or other objects needed for testing an {@link LocalArtifactRepository}
  * instance.
  */
-public class TemporaryLocalMavenRepository extends ExternalResource {
+public class TemporaryLocalMavenRepository implements BeforeEachCallback, AfterEachCallback {
 
+    // not registered as an extension, only used to hand a Logger to the MockMavenContext below
     public LogVerifier logVerifier = new LogVerifier();
-    private final TemporaryFolder tempManager = new TemporaryFolder();
+    private Path tempRoot;
     private File repoRoot;
     private LocalRepositoryP2IndicesImpl repoIndex;
     private LocalArtifactRepository repo;
 
     @Override
-    protected void before() throws Throwable {
-        tempManager.create();
+    public void beforeEach(ExtensionContext context) throws Exception {
+        tempRoot = Files.createTempDirectory("tycho-local-maven-repo");
     }
 
     @Override
-    protected void after() {
-        tempManager.delete();
+    public void afterEach(ExtensionContext context) throws Exception {
+        repo = null;
+        repoIndex = null;
+        repoRoot = null;
+        if (tempRoot != null) {
+            try (Stream<Path> paths = Files.walk(tempRoot)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(path -> path.toFile().delete());
+            } finally {
+                tempRoot = null;
+            }
+        }
     }
 
     public void initContentFromResourceFolder(File resourceFolder) throws IOException {
@@ -53,9 +68,9 @@ public class TemporaryLocalMavenRepository extends ExternalResource {
     public File getLocalRepositoryRoot() {
         if (repoRoot == null) {
             try {
-                repoRoot = tempManager.newFolder("repository");
+                repoRoot = Files.createDirectories(tempRoot.resolve("repository")).toFile();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedIOException(e);
             }
         }
         return repoRoot;

--- a/tycho-core/src/test/java/org/eclipse/tycho/test/util/TychoPlexusExtension.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/test/util/TychoPlexusExtension.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Aleksandar Kurtakov and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Aleksandar Kurtakov - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.util;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.plugin.testing.stubs.StubArtifactRepository;
+import org.apache.maven.session.scope.internal.SessionScope;
+import org.apache.maven.settings.Settings;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.testing.PlexusExtension;
+import org.eclipse.sisu.equinox.EquinoxServiceFactory;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * A {@link PlexusExtension} that additionally enters the Maven {@link SessionScope} and seeds a
+ * {@link MavenSession} into it.
+ * <p>
+ * Plain {@code @PlexusTest} is enough for components that are not session scoped. Tycho components
+ * such as {@code DefaultMavenBundleResolver} inject session scoped ones, and looking those up
+ * without a scope fails with "Cannot access session scope outside of a scoping block", so use
+ * {@code @ExtendWith(TychoPlexusExtension.class)} for tests that touch them.
+ */
+public class TychoPlexusExtension extends PlexusExtension {
+
+    @Override
+    protected void customizeContainerConfiguration(ContainerConfiguration configuration) {
+        configuration.setAutoWiring(true);
+        configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+    }
+
+    /**
+     * Implemented by tests that need to change the {@link MavenSession} before any component reads
+     * it. Values such as the offline flag are cached on first access, so setting them from a
+     * {@code @BeforeEach} of the test itself would come too late.
+     */
+    public interface MavenSessionCustomizer {
+        void customizeSession(MavenSession session);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void beforeEach(ExtensionContext context) throws Exception {
+        super.beforeEach(context);
+        PlexusContainer container = getContainer(context);
+        MavenSession mavenSession = new MavenSession(container, new Settings(),
+                new StubArtifactRepository(getBasedir()), null, null, List.of(), getBasedir(),
+                System.getProperties(), System.getProperties(), new Date());
+        mavenSession.setProjects(List.of());
+        if (context.getRequiredTestInstance() instanceof MavenSessionCustomizer customizer) {
+            customizer.customizeSession(mavenSession);
+        }
+        SessionScope sessionScope = container.lookup(SessionScope.class);
+        sessionScope.enter();
+        sessionScope.seed(MavenSession.class, mavenSession);
+        container.lookup(LegacySupport.class).setSession(mavenSession);
+        // if possible, init the service factory and loading of services
+        Collection<EquinoxServiceFactory> coreFactory = container.lookupList(EquinoxServiceFactory.class);
+        for (EquinoxServiceFactory factory : coreFactory) {
+            try {
+                factory.getService(Object.class);
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        try {
+            getContainer(context).lookup(SessionScope.class).exit();
+        } finally {
+            super.afterEach(context);
+        }
+    }
+
+}


### PR DESCRIPTION
LogVerifier, HttpServer and TemporaryLocalMavenRepository become extensions registered with @RegisterExtension. The LogVerifier only verifies when the test itself passed, as the JUnit 4 Verifier did.

Tests no longer extend TychoPlexusTestCase but use TychoPlexusExtension, which adds a MavenSession to what PlexusExtension does.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])