### PR TITLE
Run more tycho-core tests on JUnit Jupiter

### DIFF
--- a/tycho-core/src/test/java/org/eclipse/m2e/pde/target/shared/MavenBundleWrapperTest.java
+++ b/tycho-core/src/test/java/org/eclipse/m2e/pde/target/shared/MavenBundleWrapperTest.java
@@ -12,43 +12,44 @@
  *******************************************************************************/
 package org.eclipse.m2e.pde.target.shared;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for {@link MavenBundleWrapper} functionality.
  */
 public class MavenBundleWrapperTest {
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    Path temporaryFolder;
 
     @Test
     public void testGetEclipseSourceBundle_createsNewBundle() throws Exception {
         // Create a source JAR file
-        File sourceFile = temporaryFolder.newFile("test-source.jar");
+        File sourceFile = newFile("test-source.jar");
         createSourceJar(sourceFile);
 
         Manifest manifest = new Manifest();
         File result = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest, "com.example.bundle", "1.0.0");
 
         assertNotNull(result);
-        assertTrue("Eclipse source bundle should exist", result.exists());
+        assertTrue(result.exists(), "Eclipse source bundle should exist");
         assertEquals("com.example.bundle.source_1.0.0.jar", result.getName());
         assertEquals(sourceFile.getParentFile(), result.getParentFile());
 
@@ -66,7 +67,7 @@ public class MavenBundleWrapperTest {
     @Test
     public void testGetEclipseSourceBundle_returnsCache() throws Exception {
         // Create a source JAR file
-        File sourceFile = temporaryFolder.newFile("cached-source.jar");
+        File sourceFile = newFile("cached-source.jar");
         createSourceJar(sourceFile);
 
         Manifest manifest1 = new Manifest();
@@ -83,14 +84,14 @@ public class MavenBundleWrapperTest {
         File result2 = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest2, "com.example.bundle", "1.0.0");
 
         assertEquals(result1.getAbsolutePath(), result2.getAbsolutePath());
-        assertEquals("Cache should be reused, modification time should be unchanged", firstModTime,
-                result2.lastModified());
+        assertEquals(firstModTime, result2.lastModified(),
+                "Cache should be reused, modification time should be unchanged");
     }
 
     @Test
     public void testGetEclipseSourceBundle_regeneratesWhenSourceChanged() throws Exception {
         // Create a source JAR file
-        File sourceFile = temporaryFolder.newFile("changing-source.jar");
+        File sourceFile = newFile("changing-source.jar");
         createSourceJar(sourceFile);
 
         Manifest manifest1 = new Manifest();
@@ -109,13 +110,13 @@ public class MavenBundleWrapperTest {
 
         assertEquals(result1.getAbsolutePath(), result2.getAbsolutePath());
         // The file should be regenerated (different size due to different content)
-        assertTrue("Regenerated bundle should have different size", result2.length() != firstSize);
+        assertTrue(result2.length() != firstSize, "Regenerated bundle should have different size");
     }
 
     @Test
     public void testGetEclipseSourceBundle_differentBSNCreatesSeparateCache() throws Exception {
         // Create a source JAR file
-        File sourceFile = temporaryFolder.newFile("artifact-source.jar");
+        File sourceFile = newFile("artifact-source.jar");
         createSourceJar(sourceFile);
 
         // Wrap the same source with different BSN/version
@@ -126,8 +127,8 @@ public class MavenBundleWrapperTest {
         File result2 = MavenBundleWrapper.getEclipseSourceBundle(sourceFile, manifest2, "com.other.bundle", "2.0.0");
 
         // Should be different files
-        assertFalse("Different BSN/version should produce different cache files",
-                result1.getAbsolutePath().equals(result2.getAbsolutePath()));
+        assertFalse(result1.getAbsolutePath().equals(result2.getAbsolutePath()),
+                "Different BSN/version should produce different cache files");
         assertEquals("com.example.bundle.source_1.0.0.jar", result1.getName());
         assertEquals("com.other.bundle.source_2.0.0.jar", result2.getName());
 
@@ -146,37 +147,41 @@ public class MavenBundleWrapperTest {
 
     @Test
     public void testIsOutdated_returnsTrueForMissingCache() throws Exception {
-        File sourceFile = temporaryFolder.newFile("source.jar");
-        File cacheFile = new File(temporaryFolder.getRoot(), "cache.jar");
+        File sourceFile = newFile("source.jar");
+        File cacheFile = new File(temporaryFolder.toFile(), "cache.jar");
 
-        assertTrue("Missing cache file should be outdated",
-                MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()));
+        assertTrue(MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()),
+                "Missing cache file should be outdated");
     }
 
     @Test
     public void testIsOutdated_returnsFalseForUpToDateCache() throws Exception {
-        File sourceFile = temporaryFolder.newFile("source.jar");
-        File cacheFile = temporaryFolder.newFile("cache.jar");
+        File sourceFile = newFile("source.jar");
+        File cacheFile = newFile("cache.jar");
 
         // Set cache to be same timestamp as source
         cacheFile.setLastModified(sourceFile.lastModified());
 
-        assertFalse("Cache with same timestamp should not be outdated",
-                MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()));
+        assertFalse(MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()),
+                "Cache with same timestamp should not be outdated");
     }
 
     @Test
     public void testIsOutdated_returnsTrueWhenSourceNewer() throws Exception {
-        File sourceFile = temporaryFolder.newFile("source.jar");
-        File cacheFile = temporaryFolder.newFile("cache.jar");
+        File sourceFile = newFile("source.jar");
+        File cacheFile = newFile("cache.jar");
 
         // Set source to be newer than cache
         Thread.sleep(100);
         sourceFile.setLastModified(System.currentTimeMillis());
         cacheFile.setLastModified(sourceFile.lastModified() - 1000);
 
-        assertTrue("Cache should be outdated when source is newer",
-                MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()));
+        assertTrue(MavenBundleWrapper.isOutdated(cacheFile.toPath(), sourceFile.toPath()),
+                "Cache should be outdated when source is newer");
+    }
+
+    private File newFile(String name) throws IOException {
+        return Files.createFile(temporaryFolder.resolve(name)).toFile();
     }
 
     private void createSourceJar(File file) throws IOException {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/ee/CustomExecutionEnvironmentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/ee/CustomExecutionEnvironmentTest.java
@@ -16,9 +16,9 @@ import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +28,7 @@ import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
 import org.eclipse.tycho.SystemCapability;
 import org.eclipse.tycho.SystemCapability.Type;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Constants;
 
 @SuppressWarnings("deprecation")

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationTest.java
@@ -12,9 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.ee;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,8 +25,8 @@ import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.eclipse.tycho.BuildFailureException;
 import org.eclipse.tycho.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.SystemCapability;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ExecutionEnvironmentConfigurationTest {
 
@@ -40,7 +41,7 @@ public class ExecutionEnvironmentConfigurationTest {
 
     ExecutionEnvironmentConfiguration subject;
 
-    @Before
+    @BeforeEach
     public void initSubject() {
         subject = new ExecutionEnvironmentConfigurationImpl(logger, false, null, null);
     }
@@ -92,46 +93,50 @@ public class ExecutionEnvironmentConfigurationTest {
         assertEquals(CUSTOM_PROFILE, subject.getFullSpecification().getProfileName());
     }
 
-    @Test(expected = BuildFailureException.class)
+    @Test
     public void testMustNotIgnoreEEWhenUsingCustomProfile() {
         subject = new ExecutionEnvironmentConfigurationImpl(logger, true, null, null);
         subject.setProfileConfiguration(CUSTOM_PROFILE, DUMMY_ORIGIN);
 
-        subject.isCustomProfile();
+        assertThrows(BuildFailureException.class, () -> subject.isCustomProfile());
     }
 
     // BEGIN fail fast if methods are called in unexpected order
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void disallowSetProfileConfigurationAfterGetters() {
         subject.setProfileConfiguration(STANDARD_PROFILE, DUMMY_ORIGIN);
         subject.getFullSpecification();
-        subject.setProfileConfiguration(OTHER_STANDARD_PROFILE, DUMMY_ORIGIN);
+        assertThrows(IllegalStateException.class,
+                () -> subject.setProfileConfiguration(OTHER_STANDARD_PROFILE, DUMMY_ORIGIN));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void disallowOverrideProfileConfigurationAfterGetters() {
         subject.setProfileConfiguration(STANDARD_PROFILE, DUMMY_ORIGIN);
         subject.getFullSpecification();
-        subject.overrideProfileConfiguration(OTHER_STANDARD_PROFILE, DUMMY_ORIGIN);
+        assertThrows(IllegalStateException.class,
+                () -> subject.overrideProfileConfiguration(OTHER_STANDARD_PROFILE, DUMMY_ORIGIN));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void disallowSetCustomProfileSpecificationForStandardProfiles() throws Exception {
         subject.setProfileConfiguration(STANDARD_PROFILE, DUMMY_ORIGIN);
-        subject.setFullSpecificationForCustomProfile(DUMMY_CUSTOM_PROFILE_SPEC);
+        assertThrows(IllegalStateException.class,
+                () -> subject.setFullSpecificationForCustomProfile(DUMMY_CUSTOM_PROFILE_SPEC));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void disallowMultipleSetCustomProfileSpecification() throws Exception {
         subject.setProfileConfiguration(CUSTOM_PROFILE, DUMMY_ORIGIN);
         subject.setFullSpecificationForCustomProfile(DUMMY_CUSTOM_PROFILE_SPEC);
-        subject.setFullSpecificationForCustomProfile(DUMMY_CUSTOM_PROFILE_SPEC);
+        assertThrows(IllegalStateException.class,
+                () -> subject.setFullSpecificationForCustomProfile(DUMMY_CUSTOM_PROFILE_SPEC));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testGetMissingFullSpecificationForCustomProfile() {
         subject.setProfileConfiguration(CUSTOM_PROFILE, DUMMY_ORIGIN);
-        subject.getFullSpecification();
+        assertThrows(IllegalStateException.class, () -> subject.getFullSpecification());
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/ee/StandardExecutionEnvironmentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/ee/StandardExecutionEnvironmentTest.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.ee;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -24,8 +24,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.plugin.testing.SilentLog;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class StandardExecutionEnvironmentTest {
 
@@ -48,7 +48,7 @@ public class StandardExecutionEnvironmentTest {
     private StandardExecutionEnvironment javaSECompact2Environment;
     private StandardExecutionEnvironment javaSECompact3Environment;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         javaSECompact1Environment = ExecutionEnvironmentUtils.getExecutionEnvironment("JavaSE/compact1-1.8", null, null,
                 new SilentLog());

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/locking/FileLockServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/locking/FileLockServiceTest.java
@@ -13,10 +13,10 @@
 
 package org.eclipse.tycho.core.locking;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,18 +29,17 @@ import java.nio.file.StandardOpenOption;
 import java.util.Random;
 
 import org.eclipse.tycho.LockTimeoutException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class FileLockServiceTest {
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+    @TempDir
+    Path tempFolder;
     private FileLockServiceImpl subject;
 
-    @Before
+    @BeforeEach
     public void setup() {
         subject = new FileLockServiceImpl();
     }
@@ -61,7 +60,7 @@ public class FileLockServiceTest {
 
     @Test
     public void testLockDirectory() throws IOException {
-        File testDir = tempFolder.newFolder("test");
+        File testDir = Files.createDirectory(tempFolder.resolve("test")).toFile();
         Path lockFile = getLockMarkerFile(testDir);
         try (var locked = subject.lock(testDir)) {
             assertTrue(isLocked(testDir));
@@ -87,11 +86,10 @@ public class FileLockServiceTest {
     @Test
     public void testLockReentranceDifferentLocker() throws IOException {
         final File testFile = newTestFile();
-        assertThrows("lock already held by same VM but could be acquired a second time", LockTimeoutException.class,
-                () -> {
-                    subject.lock(testFile);
-                    subject.lock(testFile, 0L);
-                });
+        assertThrows(LockTimeoutException.class, () -> {
+            subject.lock(testFile);
+            subject.lock(testFile, 0L);
+        }, "lock already held by same VM but could be acquired a second time");
     }
 
     @Test
@@ -99,8 +97,8 @@ public class FileLockServiceTest {
         File testFile = newTestFile();
         LockProcess lockProcess = new LockProcess(testFile, 200L);
         lockProcess.lockFileInForkedProcess();
-        assertThrows("lock already held by other VM but could be acquired a second time", LockTimeoutException.class,
-                () -> subject.lock(testFile, 0L));
+        assertThrows(LockTimeoutException.class, () -> subject.lock(testFile, 0L),
+                "lock already held by other VM but could be acquired a second time");
         lockProcess.cleanup();
     }
 
@@ -131,7 +129,7 @@ public class FileLockServiceTest {
 
     @Test
     public void testURLEncoding() throws IOException {
-        File testFile = new File(tempFolder.getRoot(), "file with spaces" + new Random().nextInt());
+        File testFile = new File(tempFolder.toFile(), "file with spaces" + new Random().nextInt());
         File markerFile = new File(testFile.getAbsolutePath() + ".tycholock");
         assertFalse(markerFile.isFile());
         try (var locked = subject.lock(testFile)) {
@@ -140,8 +138,7 @@ public class FileLockServiceTest {
     }
 
     private File newTestFile() throws IOException {
-        File testFile = tempFolder.newFile("testfile-" + new Random().nextInt());
-        return testFile;
+        return Files.createFile(tempFolder.resolve("testfile-" + new Random().nextInt())).toFile();
     }
 
     private Path getLockMarkerFile(File file) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/maven/MavenDependenciesResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/maven/MavenDependenciesResolverTest.java
@@ -9,11 +9,15 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.maven;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.List;
+
+import javax.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -25,9 +29,9 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequestPopulationException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.LegacySupport;
-import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -36,9 +40,14 @@ import org.eclipse.tycho.MavenArtifactRepositoryReference;
 import org.eclipse.tycho.core.DependencyResolutionException;
 import org.eclipse.tycho.core.MavenDependenciesResolver;
 import org.eclipse.tycho.osgi.configuration.MavenDependenciesResolverConfigurer;
-import org.junit.Test;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.junit.jupiter.api.Test;
 
-public class MavenDependenciesResolverTest extends AbstractMojoTestCase {
+@PlexusTest
+public class MavenDependenciesResolverTest {
+
+    @Inject
+    private PlexusContainer container;
 
     @Test
     public void testResolveCommonsIO() throws DependencyResolutionException, PlexusContainerException,
@@ -49,7 +58,7 @@ public class MavenDependenciesResolverTest extends AbstractMojoTestCase {
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setLocalRepositoryPath(localRepo);
         
-        DefaultMavenExecutionRequestPopulator populator = getContainer()
+        DefaultMavenExecutionRequestPopulator populator = container
                 .lookup(DefaultMavenExecutionRequestPopulator.class);
         populator.populateDefaults(request);
         
@@ -59,12 +68,12 @@ public class MavenDependenciesResolverTest extends AbstractMojoTestCase {
         RepositorySystemSession repositorySession = LegacyLocalRepositoryManager.overlay(localRepository, baseSession, null);
         
         // Create session with proper repository system session
-        MavenSession session = new MavenSession(getContainer(), repositorySession, request, 
+        MavenSession session = new MavenSession(container, repositorySession, request, 
                 new DefaultMavenExecutionResult());
         session.setCurrentProject(new MavenProject());
         
-        getContainer().lookup(LegacySupport.class).setSession(session);
-        MavenDependenciesResolverConfigurer resolver = (MavenDependenciesResolverConfigurer) getContainer()
+        container.lookup(LegacySupport.class).setSession(session);
+        MavenDependenciesResolverConfigurer resolver = (MavenDependenciesResolverConfigurer) container
                 .lookup(MavenDependenciesResolver.class);
         
         // Get the remote repositories from the request
@@ -86,7 +95,7 @@ public class MavenDependenciesResolverTest extends AbstractMojoTestCase {
                         }).map(MavenArtifactRepositoryReference.class::cast)
                         .toList(),
                 session);
-        assertEquals(deps.toString(), 1, deps.size());
+        assertEquals(1, deps.size(), deps.toString());
         FileUtils.deleteDirectory(localRepo);
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/maven/TychoInterpolatorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/maven/TychoInterpolatorTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.maven;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,8 +22,8 @@ import java.util.Properties;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TychoInterpolatorTest {
 
@@ -31,7 +31,7 @@ public class TychoInterpolatorTest {
     private TychoInterpolator interpolator;
     private MavenProject project;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MavenSession session = mock(MavenSession.class);
         project = mock(MavenProject.class);

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipantTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipantTest.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.maven;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Arrays;
 
 import org.apache.maven.MavenExecutionException;
@@ -19,7 +21,7 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.testing.SilentLog;
 import org.apache.maven.project.MavenProject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TychoMavenLifecycleParticipantTest {
 
@@ -43,17 +45,18 @@ public class TychoMavenLifecycleParticipantTest {
         tycho.validateConsistentTychoVersion(Arrays.asList(project));
     }
 
-    @Test(expected = MavenExecutionException.class)
+    @Test
     public void validateConsistentTychoVersionWithDifferentVersionsInSameProject() throws MavenExecutionException {
         TychoMavenLifecycleParticipant tycho = new TychoMavenLifecycleParticipant(new SilentLog());
         MavenProject project = createProject();
         addTychoPlugin(project, "tycho-packaging-plugin", "0.22.0");
         addTychoPlugin(project, "tycho-versions-plugin", "0.23.0");
 
-        tycho.validateConsistentTychoVersion(Arrays.asList(project));
+        assertThrows(MavenExecutionException.class,
+                () -> tycho.validateConsistentTychoVersion(Arrays.asList(project)));
     }
 
-    @Test(expected = MavenExecutionException.class)
+    @Test
     public void validateConsistentTychoVersionWithDifferentVersionsInDifferentProjects() throws MavenExecutionException {
         TychoMavenLifecycleParticipant tycho = new TychoMavenLifecycleParticipant(new SilentLog());
         MavenProject project1 = createProject();
@@ -61,7 +64,8 @@ public class TychoMavenLifecycleParticipantTest {
         MavenProject project2 = createProject();
         addTychoPlugin(project2, "tycho-versions-plugin", "0.23.0");
 
-        tycho.validateConsistentTychoVersion(Arrays.asList(project1, project2));
+        assertThrows(MavenExecutionException.class,
+                () -> tycho.validateConsistentTychoVersion(Arrays.asList(project1, project2)));
     }
 
     private MavenProject createProject() {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/BuildPropertiesParserImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/BuildPropertiesParserImplTest.java
@@ -24,9 +24,9 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.tycho.testing.TestUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BuildPropertiesParserImplTest {
 
@@ -36,7 +36,7 @@ public class BuildPropertiesParserImplTest {
     private MavenProject project1;
     private MavenProject project2;
 
-    @Before
+    @BeforeEach
     public void setup() throws IllegalArgumentException, IllegalAccessException {
         legacySupport = mock(LegacySupport.class);
         mavenSession = mock(MavenSession.class);
@@ -56,13 +56,13 @@ public class BuildPropertiesParserImplTest {
     public void testReadPropertiesFileWithExistingFile() throws IOException {
         File baseDir = TestUtil.getBasedir("buildproperties");
         Properties properties = BuildPropertiesParserImpl.readProperties(new File(baseDir, "build.properties"), null);
-        Assert.assertEquals(3, properties.size());
+        Assertions.assertEquals(3, properties.size());
     }
 
     @Test
     public void testReadPropertiesWithNonExistingFile() {
         Properties properties = BuildPropertiesParserImpl.readProperties(new File("MISSING_FILE"), null);
-        Assert.assertEquals(0, properties.size());
+        Assertions.assertEquals(0, properties.size());
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/OsgiManifestTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/OsgiManifestTest.java
@@ -2,14 +2,14 @@ package org.eclipse.tycho.core.osgitools;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InputStream;
 import java.net.URISyntaxException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OsgiManifestTest {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/p2tools/DirectorApplicationCommandTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/p2tools/DirectorApplicationCommandTest.java
@@ -25,8 +25,8 @@ import java.util.List;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.p2.tools.director.shared.AbstractDirectorApplicationCommand;
 import org.eclipse.tycho.p2.tools.director.shared.DirectorCommandException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DirectorApplicationCommandTest {
 
@@ -46,7 +46,7 @@ public class DirectorApplicationCommandTest {
 
     private AbstractDirectorApplicationCommandForTesting subject;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         subject = new AbstractDirectorApplicationCommandForTesting();
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/OverridePreconditionCheckerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/OverridePreconditionCheckerTest.java
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -23,7 +24,7 @@ import java.util.Properties;
 import org.eclipse.tycho.IArtifactFacade;
 import org.eclipse.tycho.targetplatform.TargetDefinition.MavenDependency;
 import org.eclipse.tycho.targetplatform.TargetDefinition.MavenGAVLocation.DependencyDepth;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OverridePreconditionCheckerTest {
 
@@ -129,9 +130,10 @@ public class OverridePreconditionCheckerTest {
         assertNull(result);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullInstructionsMapThrows() {
-        OverridePreconditionChecker.checkOverridePreconditions(ORIGINAL, null, DependencyDepth.NONE, ROOTS);
+        assertThrows(NullPointerException.class, () -> OverridePreconditionChecker
+                .checkOverridePreconditions(ORIGINAL, null, DependencyDepth.NONE, ROOTS));
     }
 
     private static Map<String, Properties> singleInstruction(String symbolicName) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/TychoMirrorSelectorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/resolver/TychoMirrorSelectorTest.java
@@ -27,15 +27,15 @@ import org.eclipse.aether.repository.MirrorSelector;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.tycho.p2maven.repository.DefaultMavenRepositorySettings;
 import org.eclipse.tycho.p2maven.repository.P2ArtifactRepositoryLayout;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TychoMirrorSelectorTest {
 
     private DefaultMavenRepositorySettings selector;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MirrorSelector ms = mock(MirrorSelector.class);
         RepositorySystemSession repo = mock(RepositorySystemSession.class);
@@ -58,7 +58,7 @@ public class TychoMirrorSelectorTest {
                 "https://download.eclipse.org/eclipse/update/4.6");
         Mirror mirrorWithMatchingMirrorOfIds = createMirror("myId", "http://foo.bar", "neon-repo-with-id");
         Mirror selectedMirror = selector.getTychoMirror(repository, Arrays.asList(mirrorWithMatchingMirrorOfIds));
-        Assert.assertEquals(mirrorWithMatchingMirrorOfIds.getId(), selectedMirror.getId());
+        Assertions.assertEquals(mirrorWithMatchingMirrorOfIds.getId(), selectedMirror.getId());
     }
 
     @Test
@@ -69,8 +69,8 @@ public class TychoMirrorSelectorTest {
         Mirror prefixMatchingMirror2 = createMirror("myId2", "http://foo1.bar1", "http://abc.vxz");
         Mirror selectedMirror = selector.getTychoMirror(repository,
                 Arrays.asList(prefixMatchingMirror1, prefixMatchingMirror2));
-        Assert.assertNotNull(selectedMirror);
-        Assert.assertEquals("http://foo.bar/eclipse/update/4.6", selectedMirror.getUrl());
+        Assertions.assertNotNull(selectedMirror);
+        Assertions.assertEquals("http://foo.bar/eclipse/update/4.6", selectedMirror.getUrl());
     }
 
     private ArtifactRepository createArtifactRepository(String id, String url) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/shared/BuildPropertiesImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/shared/BuildPropertiesImplTest.java
@@ -13,9 +13,9 @@
 
 package org.eclipse.tycho.core.shared;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -31,7 +31,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.eclipse.tycho.core.BuildPropertiesImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BuildPropertiesImplTest {
 
@@ -110,7 +110,7 @@ public class BuildPropertiesImplTest {
         BuildPropertiesImpl buildProperties2 = new BuildPropertiesImpl(reverseSortedProperties);
         List<String> sourceFolderKeys1 = new ArrayList<>(buildProperties1.getJarToSourceFolderMap().keySet());
         List<String> sourceFolderKeys2 = new ArrayList<>(buildProperties2.getJarToSourceFolderMap().keySet());
-        assertEquals("keyset iteration order must be stable.", sourceFolderKeys1, sourceFolderKeys2);
+        assertEquals(sourceFolderKeys1, sourceFolderKeys2, "keyset iteration order must be stable.");
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/shared/LRUCacheTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/shared/LRUCacheTest.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.tycho.core.shared;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
 import org.eclipse.tycho.core.LRUCache;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LRUCacheTest {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/shared/RepositoryBlackboardKeyTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/shared/RepositoryBlackboardKeyTest.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.shared;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import org.eclipse.tycho.p2.repository.RepositoryBlackboardKey;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RepositoryBlackboardKeyTest {
 
@@ -34,9 +34,9 @@ public class RepositoryBlackboardKeyTest {
 
         // then
         assertNotNull(key);
-        assertNotNull("should have a valid URI", key.toURI());
-        assertTrue("should contain encoded pathname",
-                key.toURI().getPath().indexOf(URLEncoder.encode(pathname, StandardCharsets.UTF_8)) > -1);
+        assertNotNull(key.toURI(), "should have a valid URI");
+        assertTrue(key.toURI().getPath().indexOf(URLEncoder.encode(pathname, StandardCharsets.UTF_8)) > -1,
+                "should contain encoded pathname");
     }
 
     @Test
@@ -46,7 +46,7 @@ public class RepositoryBlackboardKeyTest {
 
         // then
         assertNotNull(key);
-        assertNotNull("should have a valid URI", key.toURI());
-        assertTrue("should contain null pathname", key.toURI().getPath().indexOf("null") > -1);
+        assertNotNull(key.toURI(), "should have a valid URI");
+        assertTrue(key.toURI().getPath().indexOf("null") > -1, "should contain null pathname");
     }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/shared/TargetEnvironmentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/shared/TargetEnvironmentTest.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.shared;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Map;
 
 import org.eclipse.tycho.TargetEnvironment;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TargetEnvironmentTest {
     private static final String OS = "macosx";
@@ -28,7 +28,7 @@ public class TargetEnvironmentTest {
 
     private TargetEnvironment subject;
 
-    @Before
+    @BeforeEach
     public void initSubject() {
         subject = new TargetEnvironment(OS, WS, ARCH);
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/test/DefaultBundleReaderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/test/DefaultBundleReaderTest.java
@@ -12,40 +12,45 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.codehaus.plexus.testing.PlexusExtension.getBasedir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+
+import javax.inject.Inject;
 
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.tycho.core.osgitools.BundleReader;
 import org.eclipse.tycho.core.osgitools.DefaultBundleReader;
 import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.core.osgitools.OsgiManifestParserException;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class DefaultBundleReaderTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class DefaultBundleReaderTest {
+
+    @Inject
+    private BundleReader bundleReader;
 
     private File cacheDir;
 
-    private DefaultBundleReader bundleReader;
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         cacheDir = File.createTempFile("cache", "");
         cacheDir.delete();
         cacheDir.mkdirs();
-        bundleReader = (DefaultBundleReader) lookup(BundleReader.class);
-        bundleReader.setCacheLocation(cacheDir);
+        ((DefaultBundleReader) bundleReader).setCacheLocation(cacheDir);
     }
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         FileUtils.deleteDirectory(cacheDir);
     }
@@ -54,7 +59,7 @@ public class DefaultBundleReaderTest extends TychoPlexusTestCase {
     public void testExtractDirClasspathEntries() throws Exception {
         File bundleWithNestedDirClasspath = getTestJar();
         File libDirectory = bundleReader.getEntry(bundleWithNestedDirClasspath, "lib/");
-        assertTrue("directory classpath entry lib/ not extracted", libDirectory.isDirectory());
+        assertTrue(libDirectory.isDirectory(), "directory classpath entry lib/ not extracted");
         assertTrue(new File(libDirectory, "log4j.properties").isFile());
         assertTrue(new File(libDirectory, "subdir/test.txt").isFile());
     }
@@ -63,7 +68,7 @@ public class DefaultBundleReaderTest extends TychoPlexusTestCase {
     public void testEntryMissingTrailingSlash() throws Exception {
         File bundleWithNestedDirClasspath = getTestJar();
         File libDirectory = bundleReader.getEntry(bundleWithNestedDirClasspath, "lib");
-        assertTrue("directory classpath entry lib/ not extracted", libDirectory.isDirectory());
+        assertTrue(libDirectory.isDirectory(), "directory classpath entry lib/ not extracted");
         assertTrue(new File(libDirectory, "log4j.properties").isFile());
         assertTrue(new File(libDirectory, "subdir/test.txt").isFile());
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/test/DefaultDependencyArtifactsTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/test/DefaultDependencyArtifactsTest.java
@@ -27,8 +27,8 @@ import org.eclipse.tycho.DefaultArtifactKey;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.core.osgitools.targetplatform.DefaultDependencyArtifacts;
 import org.eclipse.tycho.core.osgitools.targetplatform.MultiEnvironmentDependencyArtifacts;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DefaultDependencyArtifactsTest {
 
@@ -57,28 +57,28 @@ public class DefaultDependencyArtifactsTest {
         addArtifact(tp, type, id, "5.6.7.zzz");
 
         // 0.0.0 or null match the latest version
-        Assert.assertEquals("5.6.7.zzz", tp.getArtifact(type, id, null).getKey().getVersion());
-        Assert.assertEquals("5.6.7.zzz", tp.getArtifact(type, id, "0.0.0").getKey().getVersion());
+        Assertions.assertEquals("5.6.7.zzz", tp.getArtifact(type, id, null).getKey().getVersion());
+        Assertions.assertEquals("5.6.7.zzz", tp.getArtifact(type, id, "0.0.0").getKey().getVersion());
 
         // 1.2.3 matches the latest qualifier
-        Assert.assertEquals("1.1.0", tp.getArtifact(type, id, "1.1.0").getKey().getVersion());
-        Assert.assertEquals("1.2.3.zzz", tp.getArtifact(type, id, "1.2.3").getKey().getVersion());
+        Assertions.assertEquals("1.1.0", tp.getArtifact(type, id, "1.1.0").getKey().getVersion());
+        Assertions.assertEquals("1.2.3.zzz", tp.getArtifact(type, id, "1.2.3").getKey().getVersion());
 
         // 1.2.3.qualifier matches the latest qualifier
-        Assert.assertEquals("1.1.0", tp.getArtifact(type, id, "1.1.0.qualifier").getKey().getVersion());
-        Assert.assertEquals("1.2.3.zzz", tp.getArtifact(type, id, "1.2.3.qualifier").getKey().getVersion());
+        Assertions.assertEquals("1.1.0", tp.getArtifact(type, id, "1.1.0.qualifier").getKey().getVersion());
+        Assertions.assertEquals("1.2.3.zzz", tp.getArtifact(type, id, "1.2.3.qualifier").getKey().getVersion());
 
         // anything else matches just that exact version
-        Assert.assertEquals("1.2.3.bbb", tp.getArtifact(type, id, "1.2.3.bbb").getKey().getVersion());
+        Assertions.assertEquals("1.2.3.bbb", tp.getArtifact(type, id, "1.2.3.bbb").getKey().getVersion());
 
         // does not match anything
-        Assert.assertNull(tp.getArtifact(type, id, "0.0.0.qualifier"));
-        Assert.assertNull(tp.getArtifact(type, id, "1.0.0"));
-        Assert.assertNull(tp.getArtifact(type, id, "1.0.0.qualifier"));
-        Assert.assertNull(tp.getArtifact(type, id, "1.2.0"));
-        Assert.assertNull(tp.getArtifact(type, id, "1.2.0.qualifier"));
-        Assert.assertNull(tp.getArtifact(type, id, "9.9.9"));
-        Assert.assertNull(tp.getArtifact(type, id, "9.9.9.qualifier"));
+        Assertions.assertNull(tp.getArtifact(type, id, "0.0.0.qualifier"));
+        Assertions.assertNull(tp.getArtifact(type, id, "1.0.0"));
+        Assertions.assertNull(tp.getArtifact(type, id, "1.0.0.qualifier"));
+        Assertions.assertNull(tp.getArtifact(type, id, "1.2.0"));
+        Assertions.assertNull(tp.getArtifact(type, id, "1.2.0.qualifier"));
+        Assertions.assertNull(tp.getArtifact(type, id, "9.9.9"));
+        Assertions.assertNull(tp.getArtifact(type, id, "9.9.9.qualifier"));
     }
 
     private void addArtifact(DefaultDependencyArtifacts tp, String type, String id, String version) {
@@ -96,7 +96,7 @@ public class DefaultDependencyArtifactsTest {
         tp.addArtifactFile(key, location, Set.of(unit("a")));
         tp.addArtifactFile(key, location, Set.of(unit("a")));
 
-        Assert.assertEquals(1, tp.getArtifacts().size());
+        Assertions.assertEquals(1, tp.getArtifacts().size());
     }
 
     @Test
@@ -132,12 +132,12 @@ public class DefaultDependencyArtifactsTest {
 
         List<ArtifactDescriptor> artifacts = tp.getArtifacts();
 
-        Assert.assertEquals(1, artifacts.size());
+        Assertions.assertEquals(1, artifacts.size());
 
         Collection<IInstallableUnit> units = artifacts.get(0).getInstallableUnits();
-        Assert.assertEquals(2, units.size());
-        Assert.assertTrue(units.contains(unit("a")));
-        Assert.assertTrue(units.contains(unit("b")));
+        Assertions.assertEquals(2, units.size());
+        Assertions.assertTrue(units.contains(unit("a")));
+        Assertions.assertTrue(units.contains(unit("b")));
     }
 
     @Test
@@ -150,7 +150,7 @@ public class DefaultDependencyArtifactsTest {
         tp.addArtifactFile(key, location, Set.of(unit("a")));
         tp.addNonReactorUnits(Set.of(unit("b")));
 
-        Assert.assertEquals(Set.of(unit("a"), unit("b")), tp.getInstallableUnits());
+        Assertions.assertEquals(Set.of(unit("a"), unit("b")), tp.getInstallableUnits());
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/utils/TychoVersionTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/utils/TychoVersionTest.java
@@ -13,14 +13,14 @@
 
 package org.eclipse.tycho.core.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
 import org.eclipse.tycho.version.TychoVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TychoVersionTest {
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CompositeArtifactProviderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CompositeArtifactProviderTest.java
@@ -45,7 +45,7 @@ public class CompositeArtifactProviderTest extends CompositeArtifactProviderTest
         IRawArtifactFileProvider[] components = new IRawArtifactFileProvider[repositoryURLs.length];
         for (int ix = 0; ix < repositoryURLs.length; ix++) {
             components[ix] = new FileRepositoryArtifactProvider(Collections.singletonList(repositoryURLs[ix]),
-                    TRANSFER_POLICY, lookup(IProvisioningAgent.class));
+                    TRANSFER_POLICY, container.lookup(IProvisioningAgent.class));
         }
         return components;
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CompositeArtifactProviderTestBase.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/CompositeArtifactProviderTestBase.java
@@ -44,6 +44,9 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.p2.core.ProvisionException;
@@ -60,12 +63,17 @@ import org.eclipse.tycho.test.util.ProbeArtifactSink;
 import org.eclipse.tycho.test.util.ProbeOutputStream;
 import org.eclipse.tycho.test.util.ProbeRawArtifactSink;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactProvider> extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactProvider> {
+
+    @Inject
+    protected PlexusContainer container;
 
     protected ProbeArtifactSink testSink;
     protected ProbeRawArtifactSink rawTestSink;

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootfileArtifactRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FeatureRootfileArtifactRepositoryTest.java
@@ -35,12 +35,15 @@ import org.eclipse.tycho.core.publisher.FeatureRootfileArtifactRepository;
 import org.eclipse.tycho.p2.metadata.IP2Artifact;
 import org.eclipse.tycho.p2.publisher.rootfiles.FeatureRootAdvice;
 import org.eclipse.tycho.p2maven.advices.MavenPropertiesAdvice;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
-public class FeatureRootfileArtifactRepositoryTest extends TychoPlexusTestCase {
+// the extension starts the embedded framework, without which PublisherHelper finds no extension registry
+@ExtendWith(TychoPlexusExtension.class)
+public class FeatureRootfileArtifactRepositoryTest {
     @TempDir
     Path tempFolder;
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FileRepositoryArtifactProviderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/FileRepositoryArtifactProviderTest.java
@@ -24,6 +24,9 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
@@ -33,11 +36,16 @@ import org.eclipse.tycho.p2.repository.ArtifactTransferPolicies;
 import org.eclipse.tycho.p2.repository.ArtifactTransferPolicy;
 import org.eclipse.tycho.p2.repository.FileRepositoryArtifactProvider;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class FileRepositoryArtifactProviderTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class FileRepositoryArtifactProviderTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final ArtifactTransferPolicy TRANSFER_POLICY = ArtifactTransferPolicies.forLocalArtifacts();
 
@@ -47,7 +55,7 @@ public class FileRepositoryArtifactProviderTest extends TychoPlexusTestCase {
     public void initContextAndSubject() throws Exception {
         subject = new FileRepositoryArtifactProvider(
                 Arrays.asList(TestRepositoryContent.REPO2_BUNDLE_A, REPO_BUNDLE_AB), TRANSFER_POLICY,
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactTransferPolicyTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalArtifactTransferPolicyTest.java
@@ -20,6 +20,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
@@ -31,10 +34,15 @@ import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2.repository.ArtifactTransferPolicy;
 import org.eclipse.tycho.p2.repository.LocalArtifactTransferPolicy;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class LocalArtifactTransferPolicyTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class LocalArtifactTransferPolicyTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     static final IArtifactKey DEFAULT_KEY = new ArtifactKey("osgi.bundle", "org.eclipse.osgi",
             Version.parseVersion("3.4.3.R34x_v20081215-1030"));
@@ -44,7 +52,7 @@ public class LocalArtifactTransferPolicyTest extends TychoPlexusTestCase {
     @Test
     public void testPreferredOrder() throws Exception {
         IArtifactDescriptor[] descriptors = loadDescriptorsFromRepository("packedCanonicalAndOther",
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
 
         List<IArtifactDescriptor> result = subject.sortFormatsByPreference(descriptors);
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalMetadataRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/LocalMetadataRepositoryTest.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -41,11 +44,17 @@ import org.eclipse.tycho.p2.repository.RepositoryLayoutHelper;
 import org.eclipse.tycho.p2.repository.TychoRepositoryIndex;
 import org.eclipse.tycho.test.util.MockMavenContext;
 import org.eclipse.tycho.test.util.NoopFileLockService;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class LocalMetadataRepositoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class LocalMetadataRepositoryTest {
+
+    @Inject
+    protected PlexusContainer container;
+
     private IProgressMonitor monitor = new NullProgressMonitor();
 
     @Test
@@ -58,7 +67,7 @@ public class LocalMetadataRepositoryTest extends TychoPlexusTestCase {
     }
 
     protected IMetadataRepository loadRepository(File location) throws ProvisionException, ComponentLookupException {
-        return new LocalMetadataRepository(lookup(IProvisioningAgent.class), location.toURI(),
+        return new LocalMetadataRepository(container.lookup(IProvisioningAgent.class), location.toURI(),
                 createMetadataIndex(location),
                 new LocalRepositoryReader(new MockMavenContext(location, mock(MavenLogger.class))));
     }
@@ -75,7 +84,8 @@ public class LocalMetadataRepositoryTest extends TychoPlexusTestCase {
         metadataFile.delete();
         metadataFile.getParentFile().mkdirs();
         TychoRepositoryIndex metadataIndex = createMetadataIndex(location);
-        return new LocalMetadataRepository(lookup(IProvisioningAgent.class), location.toURI(), metadataIndex, null);
+        return new LocalMetadataRepository(container.lookup(IProvisioningAgent.class), location.toURI(),
+                metadataIndex, null);
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MetadataSerializableImplTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/MetadataSerializableImplTest.java
@@ -24,6 +24,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
@@ -33,17 +36,22 @@ import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.p2tools.MetadataSerializableImpl;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class MetadataSerializableImplTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class MetadataSerializableImplTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private IProvisioningAgent agent;
 
     @BeforeEach
     public void setUp() throws Exception {
-        agent = lookup(IProvisioningAgent.class);
+        agent = container.lookup(IProvisioningAgent.class);
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleArtifactRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleArtifactRepositoryTest.java
@@ -30,6 +30,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
@@ -44,12 +47,17 @@ import org.eclipse.tycho.IArtifactSink;
 import org.eclipse.tycho.WriteSessionContext;
 import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2.repository.module.ModuleArtifactRepository;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
-public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class ModuleArtifactRepositoryTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final IArtifactKey BUNDLE_ARTIFACT_KEY = new ArtifactKey("osgi.bundle", "bundle",
             Version.parseVersion("1.2.3.201011101425"));
@@ -215,7 +223,7 @@ public class ModuleArtifactRepositoryTest extends TychoPlexusTestCase {
 
     private IArtifactRepository loadRepositoryViaAgent(File location)
             throws ProvisionException, ComponentLookupException {
-        IArtifactRepositoryManager repoManager = lookup(IProvisioningAgent.class)
+        IArtifactRepositoryManager repoManager = container.lookup(IProvisioningAgent.class)
                 .getService(IArtifactRepositoryManager.class);
         return repoManager.loadRepository(location.toURI(), null);
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleMetadataRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ModuleMetadataRepositoryTest.java
@@ -24,6 +24,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
@@ -38,12 +41,17 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.core.test.utils.ResourceUtil;
 import org.eclipse.tycho.p2.repository.module.ModuleMetadataRepository;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
-public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class ModuleMetadataRepositoryTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     private static final IVersionedId BUNDLE_UNIT = new VersionedId("bundle", "1.2.3.201011101425");
     private static final IVersionedId SOURCE_UNIT = new VersionedId("bundle.source", "1.2.3.TAGNAME");
@@ -140,7 +148,7 @@ public class ModuleMetadataRepositoryTest extends TychoPlexusTestCase {
 
     private IMetadataRepository loadRepositoryViaAgent(File location)
             throws ProvisionException, ComponentLookupException {
-        IMetadataRepositoryManager repoManager = lookup(IProvisioningAgent.class)
+        IMetadataRepositoryManager repoManager = container.lookup(IProvisioningAgent.class)
                 .getService(IMetadataRepositoryManager.class);
         return repoManager.loadRepository(location.toURI(), null);
     }

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ProviderOnlyArtifactRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/ProviderOnlyArtifactRepositoryTest.java
@@ -25,6 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.tycho.IRawArtifactFileProvider;
@@ -33,11 +36,16 @@ import org.eclipse.tycho.p2.repository.FileRepositoryArtifactProvider;
 import org.eclipse.tycho.p2.repository.ProviderOnlyArtifactRepository;
 import org.eclipse.tycho.test.util.ProbeOutputStream;
 import org.eclipse.tycho.test.util.TestRepositoryContent;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class ProviderOnlyArtifactRepositoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class ProviderOnlyArtifactRepositoryTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     // test (legacy) methods of IArtifactRepository that are not in IRawArtifactProvider
 
@@ -86,7 +94,7 @@ public class ProviderOnlyArtifactRepositoryTest extends TychoPlexusTestCase {
 
     private ProviderOnlyArtifactRepository createProviderOnlyArtifactRepositoryDelegatingTo(URI... delegatedContent)
             throws Exception {
-        IProvisioningAgent p2Agent = lookup(IProvisioningAgent.class);
+        IProvisioningAgent p2Agent = container.lookup(IProvisioningAgent.class);
         IRawArtifactFileProvider artifactProvider = new FileRepositoryArtifactProvider(asList(delegatedContent),
                 ArtifactTransferPolicies.forLocalArtifacts(), p2Agent);
 

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishingRepositoryTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/PublishingRepositoryTest.java
@@ -28,6 +28,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
+import javax.inject.Inject;
+
+import org.codehaus.plexus.PlexusContainer;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
@@ -41,12 +44,17 @@ import org.eclipse.tycho.WriteSessionContext.ClassifierAndExtension;
 import org.eclipse.tycho.p2.repository.PublishingRepository;
 import org.eclipse.tycho.p2.repository.module.PublishingRepositoryImpl;
 import org.eclipse.tycho.test.util.ReactorProjectIdentitiesStub;
-import org.eclipse.tycho.testing.TychoPlexusTestCase;
+import org.eclipse.tycho.test.util.TychoPlexusExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
-public class PublishingRepositoryTest extends TychoPlexusTestCase {
+@ExtendWith(TychoPlexusExtension.class)
+public class PublishingRepositoryTest {
+
+    @Inject
+    protected PlexusContainer container;
 
     @TempDir
     Path tempManager;
@@ -60,7 +68,7 @@ public class PublishingRepositoryTest extends TychoPlexusTestCase {
     public void initSubject() throws Exception {
         project = new ReactorProjectIdentitiesStub(newFolder("projectDir"));
 
-        subject = new PublishingRepositoryImpl(lookup(IProvisioningAgent.class), project);
+        subject = new PublishingRepositoryImpl(container.lookup(IProvisioningAgent.class), project);
     }
 
     @Test

--- a/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RepositoryArtifactProviderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/p2resolver/RepositoryArtifactProviderTest.java
@@ -61,7 +61,7 @@ public class RepositoryArtifactProviderTest extends CompositeArtifactProviderTes
     @Override
     protected IRawArtifactProvider createCompositeArtifactProvider(URI... repositoryURLs) throws Exception {
         return new RepositoryArtifactProvider(Arrays.asList(repositoryURLs), TRANSFER_POLICY,
-                lookup(IProvisioningAgent.class));
+                container.lookup(IProvisioningAgent.class));
     }
 
     @Test


### PR DESCRIPTION
Run tycho-core apart from org.eclipse.m2e.pde.target.tests as Jupiter tests.

TychoPlexusTestCase has JUnit 4 @Before and @After, so under Jupiter its
setup never ran and the tests worked off a container nobody tore down.
MavenDependenciesResolverTest ran twice once it had a Jupiter @Test,
because AbstractMojoTestCase also made it a JUnit 3 test class.