### PR TITLE
Run the tycho-its tests on JUnit Jupiter

### DIFF
--- a/tycho-its/src/test/java/org/eclipse/tycho/test/AbstractTychoIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/AbstractTychoIntegrationTest.java
@@ -12,14 +12,15 @@
  *******************************************************************************/
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,19 +43,23 @@ import org.apache.maven.it.Verifier;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.tycho.test.util.EnvironmentUtil;
-import org.junit.Rule;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 public abstract class AbstractTychoIntegrationTest {
 
-	@Rule
-	public TestName name = new TestName();
+	private String testName;
+
+	@BeforeEach
+	final void rememberTestName(TestInfo testInfo) {
+		testName = testInfo.getTestMethod().map(Method::getName).orElseGet(testInfo::getDisplayName);
+	}
 
 	protected File getBasedir(String test) throws IOException {
 		File baseDir = getTychoIntegrationTestsFolder();
 		File src = new File(new File(baseDir, "projects"), test).getAbsoluteFile();
 		File dst = new File(new File(baseDir, "target/projects"),
-				getClass().getSimpleName() + "/" + name.getMethodName() + "/" + test.replace("../", "./"))
+				getClass().getSimpleName() + "/" + testName + "/" + test.replace("../", "./"))
 				.getAbsoluteFile();
 
 		if (dst.isDirectory()) {
@@ -300,29 +305,25 @@ public abstract class AbstractTychoIntegrationTest {
 		DirectoryScanner ds = scan(baseDir, pattern);
 		File[] includedFiles = Arrays.stream(ds.getIncludedFiles()).map(file -> new File(baseDir, file))
 				.toArray(File[]::new);
-		assertEquals(
-				baseDir.getAbsolutePath() + "/" + pattern + System.lineSeparator() + Arrays.stream(includedFiles)
-						.map(f -> f.getName()).collect(Collectors.joining(System.lineSeparator())),
-				1, includedFiles.length);
-		assertTrue(baseDir.getAbsolutePath() + "/" + pattern, includedFiles[0].canRead());
+		assertEquals(1, includedFiles.length, baseDir.getAbsolutePath() + "/" + pattern + System.lineSeparator() + Arrays.stream(includedFiles) .map(f -> f.getName()).collect(Collectors.joining(System.lineSeparator())));
+		assertTrue(includedFiles[0].canRead(), baseDir.getAbsolutePath() + "/" + pattern);
 		return includedFiles;
 	}
 
 	protected void assertDirectoryExists(File targetdir, String pattern) {
 		DirectoryScanner ds = scan(targetdir, pattern);
-		assertEquals(targetdir.getAbsolutePath() + "/" + pattern, 1, ds.getIncludedDirectories().length);
-		assertTrue(targetdir.getAbsolutePath() + "/" + pattern,
-				new File(targetdir, ds.getIncludedDirectories()[0]).exists());
+		assertEquals(1, ds.getIncludedDirectories().length, targetdir.getAbsolutePath() + "/" + pattern);
+		assertTrue(new File(targetdir, ds.getIncludedDirectories()[0]).exists(), targetdir.getAbsolutePath() + "/" + pattern);
 	}
 
 	protected void assertFileDoesNotExist(File targetdir, String pattern) {
 		DirectoryScanner ds = scan(targetdir, pattern);
-		assertEquals(targetdir.getAbsolutePath() + "/" + pattern, 0, ds.getIncludedFiles().length);
+		assertEquals(0, ds.getIncludedFiles().length, targetdir.getAbsolutePath() + "/" + pattern);
 	}
 
 	protected void assertDirectoryDoesNotExist(File baseDir, String pattern) {
 		DirectoryScanner ds = scan(baseDir, pattern);
-		assertEquals(baseDir.getAbsolutePath() + "/" + pattern, 0, ds.getIncludedDirectories().length);
+		assertEquals(0, ds.getIncludedDirectories().length, baseDir.getAbsolutePath() + "/" + pattern);
 	}
 
 	private static DirectoryScanner scan(File targetdir, String pattern) {
@@ -385,7 +386,7 @@ public abstract class AbstractTychoIntegrationTest {
 		for (int i = 0; i < lines.size(); i++) {
 			if (lines.get(i).equals("-vm")) {
 				String vm = lines.get(i + 1);
-				assertTrue("VM (" + vm + ") is not JustJ!", vm.contains("plugins/org.eclipse.justj.openjdk."));
+				assertTrue(vm.contains("plugins/org.eclipse.justj.openjdk."), "VM (" + vm + ") is not JustJ!");
 				return;
 			}
 		}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/BaselinePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/BaselinePluginTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -21,8 +21,8 @@ import java.util.List;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for the tycho-baseline-plugin with features containing source features.
@@ -31,7 +31,7 @@ public class BaselinePluginTest extends AbstractTychoIntegrationTest {
 
 	private static File baselineRepo = null;
 
-	@Before
+	@BeforeEach
 	public void buildBaselineRepository() throws Exception {
 		if (baselineRepo == null) {
 			File repoLocation = buildBaseRepo();
@@ -129,11 +129,11 @@ public class BaselinePluginTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File repoBase = new File(verifier.getBasedir(), "base-repo/site/target/repository");
-		assertTrue("base repository was not created at " + repoBase.getAbsolutePath(), repoBase.isDirectory());
-		assertTrue("content.jar was not created at " + repoBase.getAbsolutePath(),
-				new File(repoBase, "content.jar").isFile());
-		assertTrue("artifacts.jar was not created at " + repoBase.getAbsolutePath(),
-				new File(repoBase, "artifacts.jar").isFile());
+		assertTrue(repoBase.isDirectory(), "base repository was not created at " + repoBase.getAbsolutePath());
+		assertTrue(new File(repoBase, "content.jar").isFile(),
+				"content.jar was not created at " + repoBase.getAbsolutePath());
+		assertTrue(new File(repoBase, "artifacts.jar").isFile(),
+				"artifacts.jar was not created at " + repoBase.getAbsolutePath());
 		return repoBase;
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/CategoryP2MetadataPathWithSpacesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/CategoryP2MetadataPathWithSpacesTest.java
@@ -14,8 +14,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -36,10 +36,10 @@ public class CategoryP2MetadataPathWithSpacesTest extends AbstractTychoIntegrati
 		verifier.verifyErrorFreeLog();
 
 		File site = new File(verifier.getBasedir(), "target/site with space");
-		Assert.assertTrue(site.getAbsolutePath() + " is not a directory!", site.isDirectory());
+		Assertions.assertTrue(site.isDirectory(), site.getAbsolutePath() + " is not a directory!");
 
 		File content = new File(site, "content.jar");
-		Assert.assertTrue(content.getAbsolutePath() + " is not a file!", content.isFile());
+		Assertions.assertTrue(content.isFile(), content.getAbsolutePath() + " is not a file!");
 
 		boolean found = false;
 		Document document;
@@ -58,7 +58,7 @@ public class CategoryP2MetadataPathWithSpacesTest extends AbstractTychoIntegrati
 			}
 		}
 
-		Assert.assertTrue("Custom category is missing: " + content.getAbsolutePath(), found);
+		Assertions.assertTrue(found, "Custom category is missing: " + content.getAbsolutePath());
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/CompilerPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/CompilerPluginTest.java
@@ -13,7 +13,7 @@
 package org.eclipse.tycho.test;
 
 import org.apache.maven.it.Verifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for the tycho-compiler-plugin

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/CustomBundlePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/CustomBundlePluginTest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CustomBundlePluginTest extends AbstractTychoIntegrationTest {
 
@@ -28,7 +28,7 @@ public class CustomBundlePluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		File attached = new File(verifier.getBasedir(),
 				"custom.bundle.feature/target/site/plugins/custom.bundle.attached_1.0.0.123abc.jar");
-		assertTrue("Missing expected file " + attached, attached.canRead());
+		assertTrue(attached.canRead(), "Missing expected file " + attached);
 	}
 
 	@Test
@@ -38,6 +38,6 @@ public class CustomBundlePluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		File attached = new File(verifier.getBasedir(),
 				"target/unresolvable-custom-bundle-1.0.0-SNAPSHOT-attached.jar");
-		assertTrue("Missing expected file " + attached, attached.canRead());
+		assertTrue(attached.canRead(), "Missing expected file " + attached);
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/DemoTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/DemoTest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -31,8 +31,8 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
 import org.eclipse.osgi.service.resolver.BundleDescription;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * This integration test builds and tests the demo projects we provide in the
@@ -47,20 +47,20 @@ public class DemoTest extends AbstractTychoIntegrationTest {
 		// Check the product only contains our "modified" launcher
 		Path exe = basedir.resolve("target/products/launchericons/win32/win32/x86_64/eclipse.exe");
 		Path console = basedir.resolve("target/products/launchericons/win32/win32/x86_64/eclipsec.exe");
-		assertTrue(exe + " does not exits", Files.isRegularFile(exe));
-		assertFalse(exe + " should not exits", Files.isRegularFile(console));
+		assertTrue(Files.isRegularFile(exe), exe + " does not exits");
+		assertFalse(Files.isRegularFile(console), exe + " should not exits");
 		// Check the repository only contains our "modified" launcher
 		try (JarFile jarFile = new JarFile(basedir
 				.resolve("target/repository/binary/launchericons.executable.win32.win32.x86_64_1.0.0").toFile())) {
-			assertNotNull("eclipse.exe does not exits in repository", jarFile.getEntry("eclipse.exe"));
-			assertNull("eclipsec.exe does not exits in repository", jarFile.getEntry("eclipsec.exe"));
+			assertNotNull(jarFile.getEntry("eclipse.exe"), "eclipse.exe does not exits in repository");
+			assertNull(jarFile.getEntry("eclipsec.exe"), "eclipsec.exe does not exits in repository");
 		}
 		// Check the cache only contains our "modified" launcher
 		try (JarFile jarFile = new JarFile(basedir.resolve(
 				"target/products/launchericons/win32/win32/x86_64/p2/org.eclipse.equinox.p2.core/cache/binary/launchericons.executable.win32.win32.x86_64_1.0.0")
 				.toFile())) {
-			assertNotNull("eclipse.exe does not exits in repository", jarFile.getEntry("eclipse.exe"));
-			assertNull("eclipsec.exe does not exits in repository", jarFile.getEntry("eclipsec.exe"));
+			assertNotNull(jarFile.getEntry("eclipse.exe"), "eclipse.exe does not exits in repository");
+			assertNull(jarFile.getEntry("eclipsec.exe"), "eclipsec.exe does not exits in repository");
 		}
 	}
 
@@ -70,13 +70,13 @@ public class DemoTest extends AbstractTychoIntegrationTest {
 		BundleDescription description = BundlesAction.createBundleDescription(Path
 				.of(verifier.getBasedir(), "tycho.demo.service.impl/target/tycho.demo.service.impl-1.0.0-SNAPSHOT.jar")
 				.toFile());
-		assertNotNull("demo bundle was not packed", description);
+		assertNotNull(description, "demo bundle was not packed");
 		@SuppressWarnings("unchecked")
 		Dictionary<String, String> manifest = (Dictionary<String, String>) description.getUserObject();
-		assertEquals("Service component not found", "OSGI-INF/tycho.demo.service.impl.InverterServiceImpl.xml",
-				manifest.get("Service-Component"));
-		assertTrue("tycho.demo.service.api package not imported", Arrays.stream(description.getImportPackages())
-				.anyMatch(pkg -> "tycho.demo.service.api".equals(pkg.getName())));
+		assertEquals("OSGI-INF/tycho.demo.service.impl.InverterServiceImpl.xml", manifest.get("Service-Component"),
+				"Service component not found");
+		assertTrue(Arrays.stream(description.getImportPackages())
+				.anyMatch(pkg -> "tycho.demo.service.api".equals(pkg.getName())), "tycho.demo.service.api package not imported");
 	}
 
 	@Test
@@ -101,7 +101,7 @@ public class DemoTest extends AbstractTychoIntegrationTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testTychoBndDemo() throws Exception {
 		runDemo("testing/bnd/", "-f", "osgi-test");
 		// TODO add a TCK test demo, e.g. when h2 complies to the jdbc spec we can use
@@ -128,8 +128,7 @@ public class DemoTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = runDemo("bnd-workspace");
 		String expectedLocation = "tycho.demo.impl/target/executable/tycho.demo.app.jar";
 		File exportedJar = Path.of(verifier.getBasedir(), expectedLocation).toFile();
-		assertTrue("Did not find exported executable jar at expected location: " + expectedLocation,
-				exportedJar.exists());
+		assertTrue(exportedJar.exists(), "Did not find exported executable jar at expected location: " + expectedLocation);
 	}
 
 	@Test
@@ -157,8 +156,8 @@ public class DemoTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = runDemo("promote-p2");
 		String expectedLocation = "promotion/target/updatesite/updates/index.html";
 		Path indexHtml = Path.of(verifier.getBasedir(), expectedLocation);
-		assertTrue("Did not find HTML page for update site at expected location: " + expectedLocation,
-				Files.exists(indexHtml));
+		assertTrue(Files.exists(indexHtml),
+				"Did not find HTML page for update site at expected location: " + expectedLocation);
 	}
 
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/DependencyToolsPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/DependencyToolsPluginTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.version.TychoVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DependencyToolsPluginTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/DocumentBundlePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/DocumentBundlePluginTest.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.nio.file.Files;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DocumentBundlePluginTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/EclipsePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/EclipsePluginTest.java
@@ -1,7 +1,7 @@
 package org.eclipse.tycho.test;
 
 import org.apache.maven.it.Verifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EclipsePluginTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/MNGECLIPSE949jarDirectoryBundles/JarDirectoryBundlesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/MNGECLIPSE949jarDirectoryBundles/JarDirectoryBundlesTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.MNGECLIPSE949jarDirectoryBundles;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -21,7 +21,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.core.osgitools.DefaultBundleReader;
 import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JarDirectoryBundlesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/ManifestAssertions.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/ManifestAssertions.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -156,12 +156,12 @@ public class ManifestAssertions {
 	 */
 	public ManifestAssertions assertPackageLowerBound(String packageName, String expectedLower, String message) {
 		VersionRange range = importPackageRanges.get(packageName);
-		assertNotNull(message + " - Import-Package '" + packageName + "' should have a version range in " + bundleName,
-				range);
+		assertNotNull(range,
+				message + " - Import-Package '" + packageName + "' should have a version range in " + bundleName);
 		Version expected = Version.parseVersion(expectedLower);
 		Version left = range.getLeft();
-		assertTrue(message + " [Import-Package " + packageName + "] - expected lower bound " + expected
-				+ " but was " + left, left.compareTo(expected) == 0);
+		assertTrue(left.compareTo(expected) == 0,
+				message + " [Import-Package " + packageName + "] - expected lower bound " + expected + " but was " + left);
 		return this;
 	}
 
@@ -177,13 +177,13 @@ public class ManifestAssertions {
 	 */
 	public ManifestAssertions assertPackageUpperBound(String packageName, String expectedUpper, String message) {
 		VersionRange range = importPackageRanges.get(packageName);
-		assertNotNull(message + " - Import-Package '" + packageName + "' should have a version range in " + bundleName,
-				range);
+		assertNotNull(range,
+				message + " - Import-Package '" + packageName + "' should have a version range in " + bundleName);
 		Version expected = Version.parseVersion(expectedUpper);
 		Version right = range.getRight();
-		assertNotNull(message + " [Import-Package " + packageName + "] - upper bound should exist: " + range, right);
-		assertTrue(message + " [Import-Package " + packageName + "] - expected upper bound " + expected
-				+ " but was " + right, right.compareTo(expected) == 0);
+		assertNotNull(right, message + " [Import-Package " + packageName + "] - upper bound should exist: " + range);
+		assertTrue(right.compareTo(expected) == 0,
+				message + " [Import-Package " + packageName + "] - expected upper bound " + expected + " but was " + right);
 		return this;
 	}
 
@@ -199,12 +199,11 @@ public class ManifestAssertions {
 	 */
 	public ManifestAssertions assertBundleLowerBound(String bundleId, String expectedLower, String message) {
 		VersionRange range = requireBundleRanges.get(bundleId);
-		assertNotNull(message + " - Require-Bundle '" + bundleId + "' should have a version range in " + bundleName,
-				range);
+		assertNotNull(range, message + " - Require-Bundle '" + bundleId + "' should have a version range in " + bundleName);
 		Version expected = Version.parseVersion(expectedLower);
 		Version left = range.getLeft();
-		assertTrue(message + " [Require-Bundle " + bundleId + "] - expected lower bound " + expected
-				+ " but was " + left, left.compareTo(expected) == 0);
+		assertTrue(left.compareTo(expected) == 0,
+				message + " [Require-Bundle " + bundleId + "] - expected lower bound " + expected + " but was " + left);
 		return this;
 	}
 
@@ -220,13 +219,12 @@ public class ManifestAssertions {
 	 */
 	public ManifestAssertions assertBundleUpperBound(String bundleId, String expectedUpper, String message) {
 		VersionRange range = requireBundleRanges.get(bundleId);
-		assertNotNull(message + " - Require-Bundle '" + bundleId + "' should have a version range in " + bundleName,
-				range);
+		assertNotNull(range, message + " - Require-Bundle '" + bundleId + "' should have a version range in " + bundleName);
 		Version expected = Version.parseVersion(expectedUpper);
 		Version right = range.getRight();
-		assertNotNull(message + " [Require-Bundle " + bundleId + "] - upper bound should exist: " + range, right);
-		assertTrue(message + " [Require-Bundle " + bundleId + "] - expected upper bound " + expected
-				+ " but was " + right, right.compareTo(expected) == 0);
+		assertNotNull(right, message + " [Require-Bundle " + bundleId + "] - upper bound should exist: " + range);
+		assertTrue(right.compareTo(expected) == 0,
+				message + " [Require-Bundle " + bundleId + "] - expected upper bound " + expected + " but was " + right);
 		return this;
 	}
 
@@ -245,8 +243,7 @@ public class ManifestAssertions {
 		String rawVersion = requireBundleRawVersions.get(bundleId);
 		assertNotNull(message + " - Require-Bundle '" + bundleId + "' should have a version in " + bundleName,
 				rawVersion);
-		assertTrue(message + " [Require-Bundle " + bundleId + "] - expected raw version '" + expectedRawVersion
-				+ "' but was '" + rawVersion + "'", expectedRawVersion.equals(rawVersion));
+		assertTrue(expectedRawVersion.equals(rawVersion), message + " [Require-Bundle " + bundleId + "] - expected raw version '" + expectedRawVersion + "' but was '" + rawVersion + "'");
 		return this;
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/P2DirectorPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/P2DirectorPluginTest.java
@@ -1,8 +1,8 @@
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -12,7 +12,7 @@ import java.util.List;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.TargetEnvironment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class P2DirectorPluginTest extends AbstractTychoIntegrationTest {
 
@@ -110,16 +110,16 @@ public class P2DirectorPluginTest extends AbstractTychoIntegrationTest {
 			Path productDir = basedir.toPath().resolve(productDirRelative);
 
 			// Verify product was created
-			assertTrue("Product directory should exist: " + productDir, Files.exists(productDir));
+			assertTrue(Files.exists(productDir), "Product directory should exist: " + productDir);
 
 			// Verify p2 cache directory was deleted
 			Path cacheDir = productDir.resolve("p2/org.eclipse.equinox.p2.core/cache");
-			assertFalse("P2 cache directory should not exist when deleteP2Cache=true", Files.exists(cacheDir));
+			assertFalse(Files.exists(cacheDir), "P2 cache directory should not exist when deleteP2Cache=true");
 
 			// Verify that p2 directory itself still exists (just not the cache
 			// subdirectory)
 			Path p2Dir = productDir.resolve("p2");
-			assertTrue("P2 directory should still exist: " + p2Dir, Files.exists(p2Dir));
+			assertTrue(Files.exists(p2Dir), "P2 directory should still exist: " + p2Dir);
 		}
 	}
 
@@ -135,12 +135,12 @@ public class P2DirectorPluginTest extends AbstractTychoIntegrationTest {
 			Path productDir = basedir.toPath().resolve(productDirRelative);
 
 			// Verify product was created
-			assertTrue("Product directory should exist: " + productDir, Files.exists(productDir));
+			assertTrue(Files.exists(productDir), "Product directory should exist: " + productDir);
 
 			// Verify p2 cache directory exists (default behavior - cache should be kept)
 			Path cacheDir = productDir.resolve("p2/org.eclipse.equinox.p2.core/cache");
-			assertTrue("P2 cache directory should exist by default (deleteP2Cache not set): " + cacheDir,
-					Files.exists(cacheDir));
+			assertTrue(Files.exists(cacheDir),
+					"P2 cache directory should exist by default (deleteP2Cache not set): " + cacheDir);
 		}
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/P2ExtrasPlugin.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/P2ExtrasPlugin.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -147,9 +147,9 @@ public class P2ExtrasPlugin extends AbstractTychoIntegrationTest {
 
 		Path contentXml = Path.of(verifier.getBasedir()).resolve("target/repository").resolve("content.xml");
 		Element pluginUnitInContentXml = extractUnitFromContentXml(contentXml, pluginId);
-		assertFalse("test plugin should not be marked as zipped", hasChildWithZippedAttribute(pluginUnitInContentXml));
+		assertFalse(hasChildWithZippedAttribute(pluginUnitInContentXml), "test plugin should not be marked as zipped");
 		Element featureUnitInContentXml = extractUnitFromContentXml(contentXml, featureId);
-		assertTrue("test feature should be marked as zipped", hasChildWithZippedAttribute(featureUnitInContentXml));
+		assertTrue(hasChildWithZippedAttribute(featureUnitInContentXml), "test feature should be marked as zipped");
 	}
 
 	private static Element extractUnitFromContentXml(Path contentXml, String unitName) {
@@ -158,8 +158,8 @@ public class P2ExtrasPlugin extends AbstractTychoIntegrationTest {
 		List<Element> units = unitElement.childElements("unit").toList();
 		Optional<Element> extractedUnit = units.stream().filter(element -> unitName.equals(element.attribute("id")))
 				.findFirst();
-		assertTrue(String.format("Unit with name '%s' not found in content.xml with units: %s", unitName, units),
-				extractedUnit.isPresent());
+		assertTrue(extractedUnit.isPresent(),
+				String.format("Unit with name '%s' not found in content.xml with units: %s", unitName, units));
 		return extractedUnit.get();
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0209tychoRepositoryRoundtrip/TychoRepositoryRoundtripTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0209tychoRepositoryRoundtrip/TychoRepositoryRoundtripTest.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO0209tychoRepositoryRoundtrip;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TychoRepositoryRoundtripTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0294ProductP2TargetPlatformResolver/ProductP2TargetPlatformResolverTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0294ProductP2TargetPlatformResolver/ProductP2TargetPlatformResolverTest.java
@@ -16,7 +16,7 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductP2TargetPlatformResolverTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0367localRepositoryCrosstalk/LocalRepositoryCrosstalkTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0367localRepositoryCrosstalk/LocalRepositoryCrosstalkTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.TYCHO0367localRepositoryCrosstalk;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalRepositoryCrosstalkTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0383dotQualifierMatching/DotQualifierMatchingTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0383dotQualifierMatching/DotQualifierMatchingTest.java
@@ -17,7 +17,7 @@ import java.io.File;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DotQualifierMatchingTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0404pomDependencyConsiderExtraClasspath/PomDependencyConsiderExtraClasspathTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0404pomDependencyConsiderExtraClasspath/PomDependencyConsiderExtraClasspathTest.java
@@ -17,7 +17,7 @@ import java.io.File;
 import org.apache.maven.it.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PomDependencyConsiderExtraClasspathTest extends AbstractTychoIntegrationTest {
     @Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0439repositoryCategories/RepositoryCategoriesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0439repositoryCategories/RepositoryCategoriesTest.java
@@ -18,8 +18,8 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -33,10 +33,10 @@ public class RepositoryCategoriesTest extends AbstractTychoIntegrationTest {
 		v01.verifyErrorFreeLog();
 
 		File site = new File(v01.getBasedir(), "target/site");
-		Assert.assertTrue(site.isDirectory());
+		Assertions.assertTrue(site.isDirectory());
 
 		File content = new File(site, "content.jar");
-		Assert.assertTrue(content.getAbsolutePath() + " is not a file!", content.isFile());
+		Assertions.assertTrue(content.isFile(), content.getAbsolutePath() + " is not a file!");
 
 		boolean found = false;
 
@@ -56,7 +56,7 @@ public class RepositoryCategoriesTest extends AbstractTychoIntegrationTest {
 			}
 		}
 
-		Assert.assertTrue("Custom category is missing: " + content.getAbsolutePath(), found);
+		Assertions.assertTrue(found, "Custom category is missing: " + content.getAbsolutePath());
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0453expandReleaseVersion/ExpandReleaseVersionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0453expandReleaseVersion/ExpandReleaseVersionTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO0453expandReleaseVersion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExpandReleaseVersionTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO109product/Tycho109ProductExportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO109product/Tycho109ProductExportTest.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO109product;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho109ProductExportTest extends AbstractTychoIntegrationTest {
 
@@ -34,18 +34,18 @@ public class Tycho109ProductExportTest extends AbstractTychoIntegrationTest {
 		File output = new File(basedir, "HeadlessProduct/target/repository");
 		File outputBinary = new File(output, "binary");
 
-		assertTrue("Exported product folder not found\n" + output.getAbsolutePath(), output.isDirectory());
+		assertTrue(output.isDirectory(), "Exported product folder not found\n" + output.getAbsolutePath());
 		File launcher = new File(outputBinary, "HeadlessProduct.executable.gtk.linux.x86_64_1.0.0");
-		assertTrue("Launcher not found\n" + launcher, launcher.isFile());
+		assertTrue(launcher.isFile(), "Launcher not found\n" + launcher);
 
 		File plugins = new File(output, "plugins");
-		assertTrue("Plugins folder not found", plugins.isDirectory());
+		assertTrue(plugins.isDirectory(), "Plugins folder not found");
 
 		File headlessPlugin = new File(plugins, "HeadlessPlugin_1.0.0.jar");
-		assertTrue("Plugin should be unpacked", headlessPlugin.isFile());
+		assertTrue(headlessPlugin.isFile(), "Plugin should be unpacked");
 
 		File features = new File(output, "features");
-		assertTrue("Features folder not found", features.isDirectory());
+		assertTrue(features.isDirectory(), "Features folder not found");
 	}
 
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO192sourceBundles/Tycho192SourceBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO192sourceBundles/Tycho192SourceBundleTest.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO192sourceBundles;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -31,7 +31,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.XMLTool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Constants;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -54,14 +54,14 @@ public class Tycho192SourceBundleTest extends AbstractTychoIntegrationTest {
 		Document p2ContentDOM = XMLTool.parseXMLDocument(p2Content);
 		Element sourceBundleUnitNode = (Element) XMLTool.getFirstMatchingNode(p2ContentDOM,
 				"/units/unit[@id = 'helloworld.source']");
-		assertNotNull("unit with id 'helloworld.source' not found", sourceBundleUnitNode);
+		assertNotNull(sourceBundleUnitNode, "unit with id 'helloworld.source' not found");
 		assertHasMavenClassifierProperty(sourceBundleUnitNode);
 	}
 
 	private void assertHasMavenClassifierProperty(Element node) throws XPathExpressionException {
 		Element classifierNode = (Element) XMLTool.getFirstMatchingNode(node,
 				"properties/property[@name = 'maven-classifier']");
-		assertNotNull("property node with name 'maven-classifier' not found", classifierNode);
+		assertNotNull(classifierNode, "property node with name 'maven-classifier' not found");
 		assertEquals("sources", classifierNode.getAttribute("value"));
 	}
 
@@ -70,7 +70,7 @@ public class Tycho192SourceBundleTest extends AbstractTychoIntegrationTest {
 		Document p2ArtifactsDOM = XMLTool.parseXMLDocument(p2Artifacts);
 		Element sourceBundleArtifactNode = (Element) XMLTool.getFirstMatchingNode(p2ArtifactsDOM,
 				"/artifacts/artifact[@id = 'helloworld.source']");
-		assertNotNull("artifact with id 'helloworld.source' not found", sourceBundleArtifactNode);
+		assertNotNull(sourceBundleArtifactNode, "artifact with id 'helloworld.source' not found");
 		assertHasMavenClassifierProperty(sourceBundleArtifactNode);
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO240includeLaunchers/IncludeLaunchersTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO240includeLaunchers/IncludeLaunchersTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO240includeLaunchers;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.arch.Processor;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IncludeLaunchersTest extends AbstractTychoIntegrationTest {
 
@@ -50,8 +50,8 @@ public class IncludeLaunchersTest extends AbstractTychoIntegrationTest {
 			executable = "includedLauncher.executable.gtk.linux.x86_64_1.0.0";
 		}
 		File file = new File(binaryDir, executable);
-		assertTrue("Directory " + binaryDir.getAbsolutePath() + " is not a directory", binaryDir.isDirectory());
-		assertTrue("File " + file.getAbsolutePath() + " do not exits, but " + listFiles(binaryDir), file.isFile());
+		assertTrue(binaryDir.isDirectory(), "Directory " + binaryDir.getAbsolutePath() + " is not a directory");
+		assertTrue(file.isFile(), "File " + file.getAbsolutePath() + " do not exits, but " + listFiles(binaryDir));
 
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO246rcpSourceBundles/TYCHO246rcpSourceBundlesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO246rcpSourceBundles/TYCHO246rcpSourceBundlesTest.java
@@ -16,7 +16,7 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TYCHO246rcpSourceBundlesTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO253extraClassPathEntries/ExtraClassPathEntriesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO253extraClassPathEntries/ExtraClassPathEntriesTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.TYCHO253extraClassPathEntries;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExtraClassPathEntriesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO279HttpProxy/ProxySupportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO279HttpProxy/ProxySupportTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO279HttpProxy;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,9 +36,9 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.XMLTool;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.sonatype.jettytestsuite.ProxyServer;
 import org.sonatype.jettytestsuite.proxy.MonitorableProxyServlet;
 import org.w3c.dom.Document;
@@ -64,14 +64,14 @@ public class ProxySupportTest extends AbstractTychoIntegrationTest {
 
 	private File settings;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		baseDir = new File(getVerifier(TEST_BASEDIR).getBasedir());
 		settings = new File(baseDir, "settings.xml");
 		startHttpServer();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		httpServer.stop();
 		httpServer.join();
@@ -89,9 +89,9 @@ public class ProxySupportTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("package");
 		verifier.verifyErrorFreeLog();
 		List<String> accessedUris = proxyServlet.getAccessedUris();
-		assertTrue("proxy was not accessed", accessedUris.size() > 0);
+		assertTrue(accessedUris.size() > 0, "proxy was not accessed");
 		String expectedUri = getP2RepoUrl() + "content.xml";
-		assertTrue("URL " + expectedUri + " was not accessed via proxy", accessedUris.contains(expectedUri));
+		assertTrue(accessedUris.contains(expectedUri), "URL " + expectedUri + " was not accessed via proxy");
 	}
 
 	@Test
@@ -109,9 +109,9 @@ public class ProxySupportTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("package");
 		verifier.verifyErrorFreeLog();
 		List<String> accessedUris = proxyServlet.getAccessedUris();
-		assertTrue("proxy was not accessed", accessedUris.size() > 0);
+		assertTrue(accessedUris.size() > 0, "proxy was not accessed");
 		String expectedUri = getP2RepoUrl() + "content.xml";
-		assertTrue("URL " + expectedUri + " was not accessed via proxy", accessedUris.contains(expectedUri));
+		assertTrue(accessedUris.contains(expectedUri), "URL " + expectedUri + " was not accessed via proxy");
 	}
 
 	@Test
@@ -123,7 +123,7 @@ public class ProxySupportTest extends AbstractTychoIntegrationTest {
 		verifier.getSystemProperties().setProperty("p2.repo", getP2RepoUrl());
 		verifier.executeGoal("package"); // build fails
 		List<String> accessedUris = proxyServlet.getAccessedUris();
-		assertTrue("proxy was accessed although not active. Accessed URIs: " + accessedUris, accessedUris.isEmpty());
+		assertTrue(accessedUris.isEmpty(), "proxy was accessed although not active. Accessed URIs: " + accessedUris);
 	}
 
 	private void startHttpProxyServer(boolean useAuthentication, String user, String password) throws Exception {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO285EclipseSourceBundles/TYCHO285EclipseSourceBundlesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO285EclipseSourceBundles/TYCHO285EclipseSourceBundlesTest.java
@@ -19,8 +19,8 @@ import java.util.jar.Manifest;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TYCHO285EclipseSourceBundlesTest extends AbstractTychoIntegrationTest {
     @Test
@@ -30,16 +30,16 @@ public class TYCHO285EclipseSourceBundlesTest extends AbstractTychoIntegrationTe
         verifier.verifyErrorFreeLog();
 
         File sourceJarFile = new File(verifier.getBasedir(), "target/bundle-1.2.3-SNAPSHOT-sources.jar");
-        Assert.assertTrue(sourceJarFile.exists());
+        Assertions.assertTrue(sourceJarFile.exists());
 
         try (JarFile jar = new JarFile(sourceJarFile)) {
             Manifest manifest = jar.getManifest();
-            Assert.assertNotNull(manifest);
+            Assertions.assertNotNull(manifest);
             Attributes mainAttributes = manifest.getMainAttributes();
 
-            Assert.assertEquals("bundle.source", mainAttributes.getValue("Bundle-SymbolicName"));
-            Assert.assertEquals("1.2.3.TAGNAME", mainAttributes.getValue("Bundle-Version"));
-            Assert.assertEquals("bundle;version=\"1.2.3.TAGNAME\";roots:=\".\"",
+            Assertions.assertEquals("bundle.source", mainAttributes.getValue("Bundle-SymbolicName"));
+            Assertions.assertEquals("1.2.3.TAGNAME", mainAttributes.getValue("Bundle-Version"));
+            Assertions.assertEquals("bundle;version=\"1.2.3.TAGNAME\";roots:=\".\"",
                     mainAttributes.getValue("Eclipse-SourceBundle"));
         }
     }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO300launcherIcons/LauncherIconsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO300launcherIcons/LauncherIconsTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.TYCHO300launcherIcons;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LauncherIconsTest extends AbstractTychoIntegrationTest {
     @Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO308importSystemPackage/ImportSystemPackagesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO308importSystemPackage/ImportSystemPackagesTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.TYCHO308importSystemPackage;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ImportSystemPackagesTest extends AbstractTychoIntegrationTest {
     @Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO309pomDependencyConsider/PomDependencyConsiderTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO309pomDependencyConsider/PomDependencyConsiderTest.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO309pomDependencyConsider;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PomDependencyConsiderTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO321deployableFeature/DeployableFeatureTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO321deployableFeature/DeployableFeatureTest.java
@@ -16,11 +16,11 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Ignore("deployable feature no longer supported")
+@Disabled("deployable feature no longer supported")
 public class DeployableFeatureTest extends AbstractTychoIntegrationTest {
 
 	@Test
@@ -30,13 +30,13 @@ public class DeployableFeatureTest extends AbstractTychoIntegrationTest {
 		v01.verifyErrorFreeLog();
 
 		File site = new File(v01.getBasedir(), "target/site");
-		Assert.assertTrue(site.isDirectory());
+		Assertions.assertTrue(site.isDirectory());
 
-		Assert.assertTrue(new File(site, "features").list().length > 0);
-		Assert.assertTrue(new File(site, "plugins").list().length > 0);
+		Assertions.assertTrue(new File(site, "features").list().length > 0);
+		Assertions.assertTrue(new File(site, "plugins").list().length > 0);
 
-		Assert.assertTrue(new File(site, "artifacts.jar").isFile());
-		Assert.assertTrue(new File(site, "content.jar").isFile());
+		Assertions.assertTrue(new File(site, "artifacts.jar").isFile());
+		Assertions.assertTrue(new File(site, "content.jar").isFile());
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO330validateVersion/ValidateVersionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO330validateVersion/ValidateVersionTest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO330validateVersion;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValidateVersionTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO350ClassCastException/TYCHO350ClassCastExceptionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO350ClassCastException/TYCHO350ClassCastExceptionTest.java
@@ -13,7 +13,7 @@ import static java.util.Arrays.asList;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TYCHO350ClassCastExceptionTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO418pomDependencyConsider/PomDependencyConsiderTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO418pomDependencyConsider/PomDependencyConsiderTest.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO418pomDependencyConsider;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PomDependencyConsiderTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO449SrcIncludesExcludes/Tycho449SrcIncludesExcludesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO449SrcIncludesExcludes/Tycho449SrcIncludesExcludesTest.java
@@ -17,8 +17,8 @@ import java.util.jar.JarFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class Tycho449SrcIncludesExcludesTest extends AbstractTychoIntegrationTest {
 
@@ -29,11 +29,11 @@ public class Tycho449SrcIncludesExcludesTest extends AbstractTychoIntegrationTes
 		verifier.verifyErrorFreeLog();
 		try (JarFile sourceJar = new JarFile(
 				new File(verifier.getBasedir(), "target/TestSourceIncludesExcludes-1.0.0-SNAPSHOT-sources.jar"))) {
-			Assert.assertNull(sourceJar.getEntry("resourceFolder/.hidden/toBeExcluded.txt"));
-			Assert.assertNull(sourceJar.getEntry("resourceFolder/.svn/"));
-			Assert.assertNotNull(sourceJar.getEntry("resourceFolder/test.txt"));
-			Assert.assertNotNull(sourceJar.getEntry("resource.txt"));
-			Assert.assertNotNull(sourceJar.getEntry("additionalResource.txt"));
+			Assertions.assertNull(sourceJar.getEntry("resourceFolder/.hidden/toBeExcluded.txt"));
+			Assertions.assertNull(sourceJar.getEntry("resourceFolder/.svn/"));
+			Assertions.assertNotNull(sourceJar.getEntry("resourceFolder/test.txt"));
+			Assertions.assertNotNull(sourceJar.getEntry("resource.txt"));
+			Assertions.assertNotNull(sourceJar.getEntry("additionalResource.txt"));
 		}
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO502sourceBundleQualifier/Tycho502SourceBundleQualifierTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO502sourceBundleQualifier/Tycho502SourceBundleQualifierTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.TYCHO502sourceBundleQualifier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho502SourceBundleQualifierTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/VersionBumpPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/VersionBumpPluginTest.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -34,7 +34,7 @@ import org.eclipse.tycho.targetplatform.TargetDefinition.MavenGAVLocation;
 import org.eclipse.tycho.targetplatform.TargetDefinition.Unit;
 import org.eclipse.tycho.targetplatform.TargetDefinitionFile;
 import org.eclipse.tycho.version.TychoVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 public class VersionBumpPluginTest extends AbstractTychoIntegrationTest {
@@ -67,18 +67,17 @@ public class VersionBumpPluginTest extends AbstractTychoIntegrationTest {
 					.orElseThrow(() -> new AssertionError("Maven Location not found!"));
 			MavenDependency dependency = dependencies(maven, "javax.annotation", "javax.annotation-api").findFirst()
 					.orElseThrow(() -> new AssertionError("javax.annotation dependency not found"));
-			assertEquals("Maven version was not updated correctly in " + targetFile, "1.3.2", dependency.getVersion());
+			assertEquals("1.3.2", dependency.getVersion(), "Maven version was not updated correctly in " + targetFile);
 			List<MavenDependency> list = dependencies(maven, "jakarta.annotation", "jakarta.annotation-api").toList();
 			assertEquals(2, list.size());
 			VersionScheme scheme = new GenericVersionScheme();
 			// we can not know the exact latest major version, but we know it must be larger
 			// than 3.0
 			Version version3 = scheme.parseVersion("3");
-			assertTrue("Maven version was not updated correctly in " + targetFile + " for jakarta.annotation-api 1.3.5",
-					scheme.parseVersion(list.get(0).getVersion()).compareTo(version3) >= 0);
-			assertTrue(
-					"No Update for Maven version was expected in " + targetFile + " for jakarta.annotation-api 2.0.0",
-					scheme.parseVersion(list.get(1).getVersion()).compareTo(version3) >= 0);
+			assertTrue(scheme.parseVersion(list.get(0).getVersion()).compareTo(version3) >= 0,
+					"Maven version was not updated correctly in " + targetFile + " for jakarta.annotation-api 1.3.5");
+			assertTrue(scheme.parseVersion(list.get(1).getVersion()).compareTo(version3) >= 0,
+					"No Update for Maven version was expected in " + targetFile + " for jakarta.annotation-api 2.0.0");
 		}
 	}
 
@@ -101,12 +100,10 @@ public class VersionBumpPluginTest extends AbstractTychoIntegrationTest {
 					.orElseThrow(() -> new AssertionError("Maven Location not found!"));
 			List<MavenDependency> list = dependencies(maven, "jakarta.annotation", "jakarta.annotation-api").toList();
 			assertEquals(2, list.size());
-			assertEquals(
-					"No Update for Maven version was expected in " + targetFile + " for jakarta.annotation-api 1.3.5",
-					"1.3.5", list.get(0).getVersion());
-			assertEquals(
-					"Maven version was not updated correctly in " + targetFile + " for jakarta.annotation-api 2.0.0",
-					"2.1.1", list.get(1).getVersion());
+			assertEquals("1.3.5", list.get(0).getVersion(),
+					"No Update for Maven version was expected in " + targetFile + " for jakarta.annotation-api 1.3.5");
+			assertEquals("2.1.1", list.get(1).getVersion(),
+					"Maven version was not updated correctly in " + targetFile + " for jakarta.annotation-api 2.0.0");
 
 		}
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/apitools/ApiToolsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/apitools/ApiToolsTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.apitools;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
@@ -25,7 +25,7 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 
@@ -36,7 +36,7 @@ public class ApiToolsTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File descriptionFile = new File(verifier.getBasedir(), "bundle1/target/.api_description");
-		assertTrue(descriptionFile.getAbsoluteFile() + " not found", descriptionFile.isFile());
+		assertTrue(descriptionFile.isFile(), descriptionFile.getAbsoluteFile() + " not found");
 		Document document = Document.of(descriptionFile.toPath());
 		assertEquals("api-bundle-1_0.0.1-SNAPSHOT", document.root().attributeObject("name").value());
 		// TODO enhance project and assert more useful things...

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/baseline/BaselineMojoTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/baseline/BaselineMojoTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.baseline;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,8 +48,8 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.text.edits.MalformedTreeException;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 import org.osgi.framework.Constants;
 
@@ -63,7 +63,7 @@ public class BaselineMojoTest extends AbstractTychoIntegrationTest {
 
 	private static File baselineRepo = null;
 
-	@Before
+	@BeforeEach
 	public void buildBaselineRepository() throws Exception {
 		if (baselineRepo == null) {
 			File repoLocation = buildBaseRepo();
@@ -230,11 +230,11 @@ public class BaselineMojoTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File repoBase = new File(verifier.getBasedir(), "base-repo/site/target/repository");
-		assertTrue("base repository was not created at " + repoBase.getAbsolutePath(), repoBase.isDirectory());
-		assertTrue("content.jar was not created at " + repoBase.getAbsolutePath(),
-				new File(repoBase, "content.jar").isFile());
-		assertTrue("artifacts.jar was not created at " + repoBase.getAbsolutePath(),
-				new File(repoBase, "artifacts.jar").isFile());
+		assertTrue(repoBase.isDirectory(), "base repository was not created at " + repoBase.getAbsolutePath());
+		assertTrue(new File(repoBase, "content.jar").isFile(),
+				"content.jar was not created at " + repoBase.getAbsolutePath());
+		assertTrue(new File(repoBase, "artifacts.jar").isFile(),
+				"artifacts.jar was not created at " + repoBase.getAbsolutePath());
 		return repoBase;
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/brokenp2data/BrokenP2DataTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/brokenp2data/BrokenP2DataTest.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // See #2625
 public class BrokenP2DataTest extends AbstractTychoIntegrationTest {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/CiFriendlyVersionsTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.buildextension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +28,7 @@ import java.util.jar.JarFile;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Constants;
 
 public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
@@ -42,7 +42,7 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		int year = Calendar.getInstance(TimeZone.getTimeZone("UTC")).get(Calendar.YEAR);
 		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0." + year + ".jar");
-		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		assertTrue(file.isFile(), file.getAbsolutePath() + " is not generated!");
 		checkManifestVersion(file, "1.0.0." + year);
 	}
 
@@ -59,7 +59,7 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		String[] jarFiles = targetDir.list((dir, name) -> name.endsWith(".jar"));
 		assertEquals(1, jarFiles.length);
 		File file = new File(targetDir, jarFiles[0]);
-		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		assertTrue(file.isFile(), file.getAbsolutePath() + " is not generated!");
 		String qualifier = jarFiles[0].substring(13, jarFiles[0].lastIndexOf('.'));
 		// if formatter fails to parse it will throw exception and thus fail the test
 		formatter.parse(qualifier);
@@ -74,7 +74,7 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0.abc.jar");
-		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		assertTrue(file.isFile(), file.getAbsolutePath() + " is not generated!");
 		checkManifestVersion(file, "1.0.0.abc");
 	}
 
@@ -85,7 +85,7 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0-SNAPSHOT.jar");
-		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		assertTrue(file.isFile(), file.getAbsolutePath() + " is not generated!");
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0-M1.jar");
-		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		assertTrue(file.isFile(), file.getAbsolutePath() + " is not generated!");
 		checkManifestVersion(file, "1.0.0.zzz");
 	}
 
@@ -110,7 +110,7 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "bundle/target/bundle-1.0.0.jar");
-		assertTrue(file.getAbsolutePath() + " is not generated!", file.isFile());
+		assertTrue(file.isFile(), file.getAbsolutePath() + " is not generated!");
 		checkManifestVersion(file, "1.0.0");
 	}
 
@@ -127,8 +127,8 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 
 		// Pre-build: verify source MANIFEST.MF and feature.xml have 0.0.6.qualifier
 		Path manifest = basedir.resolve("bundles/org.example.bundle/META-INF/MANIFEST.MF");
-		assertTrue("MANIFEST.MF should contain 0.0.6.qualifier",
-				Files.readString(manifest).contains("Bundle-Version: 0.0.6.qualifier"));
+		assertTrue(Files.readString(manifest).contains("Bundle-Version: 0.0.6.qualifier"),
+				"MANIFEST.MF should contain 0.0.6.qualifier");
 		Path featureXml = basedir.resolve("features/org.example.feature/feature.xml");
 		Feature sourceFeature = Feature.read(featureXml.toFile());
 		assertEquals("0.0.6.qualifier", sourceFeature.getVersion());
@@ -138,18 +138,18 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 
 		// Post-build: verify built bundle jar has expanded Bundle-Version
 		Path bundleJar = basedir.resolve("bundles/org.example.bundle/target/org.example.bundle-0.0.6-SNAPSHOT.jar");
-		assertTrue("Bundle jar not found: " + bundleJar, Files.isRegularFile(bundleJar));
+		assertTrue(Files.isRegularFile(bundleJar), "Bundle jar not found: " + bundleJar);
 		try (JarFile jar = new JarFile(bundleJar.toFile())) {
 			String bundleVersion = jar.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-			assertTrue("Bundle-Version should start with 0.0.6: " + bundleVersion, bundleVersion.startsWith("0.0.6."));
+			assertTrue(bundleVersion.startsWith("0.0.6."), "Bundle-Version should start with 0.0.6: " + bundleVersion);
 		}
 
 		// Post-build: verify built feature jar has expanded version
 		Path featureJar = basedir.resolve("features/org.example.feature/target/org.example.feature-0.0.6-SNAPSHOT.jar");
-		assertTrue("Feature jar not found: " + featureJar, Files.isRegularFile(featureJar));
+		assertTrue(Files.isRegularFile(featureJar), "Feature jar not found: " + featureJar);
 		Feature builtFeature = Feature.readJar(featureJar.toFile());
-		assertTrue("Feature version should start with 0.0.6: " + builtFeature.getVersion(),
-				builtFeature.getVersion().startsWith("0.0.6."));
+		assertTrue(builtFeature.getVersion().startsWith("0.0.6."),
+				"Feature version should start with 0.0.6: " + builtFeature.getVersion());
 	}
 
 	@Test
@@ -163,10 +163,10 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 
 		Path basedir = Path.of(verifier.getBasedir());
 		Path featureJar = basedir.resolve("features/org.example.feature/target/org.example.feature-0.0.7-SNAPSHOT.jar");
-		assertTrue("Feature jar not found: " + featureJar, Files.isRegularFile(featureJar));
+		assertTrue(Files.isRegularFile(featureJar), "Feature jar not found: " + featureJar);
 		Feature builtFeature = Feature.readJar(featureJar.toFile());
-		assertTrue("Feature version should start with 0.0.7: " + builtFeature.getVersion(),
-				builtFeature.getVersion().startsWith("0.0.7."));
+		assertTrue(builtFeature.getVersion().startsWith("0.0.7."),
+				"Feature version should start with 0.0.7: " + builtFeature.getVersion());
 	}
 
 	@Test
@@ -180,10 +180,10 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 
 		Path basedir = Path.of(verifier.getBasedir());
 		Path bundleJar = basedir.resolve("bundles/org.example.bundle/target/org.example.bundle-0.0.7-SNAPSHOT.jar");
-		assertTrue("Bundle jar not found: " + bundleJar, Files.isRegularFile(bundleJar));
+		assertTrue(Files.isRegularFile(bundleJar), "Bundle jar not found: " + bundleJar);
 		try (JarFile jar = new JarFile(bundleJar.toFile())) {
 			String bundleVersion = jar.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-			assertTrue("Bundle-Version should start with 0.0.7: " + bundleVersion, bundleVersion.startsWith("0.0.7."));
+			assertTrue(bundleVersion.startsWith("0.0.7."), "Bundle-Version should start with 0.0.7: " + bundleVersion);
 		}
 	}
 
@@ -198,17 +198,17 @@ public class CiFriendlyVersionsTest extends AbstractTychoIntegrationTest {
 		Path basedir = Path.of(verifier.getBasedir());
 
 		Path bundleJar = basedir.resolve("bundles/org.example.bundle/target/org.example.bundle-0.0.7-SNAPSHOT.jar");
-		assertTrue("Bundle jar not found: " + bundleJar, Files.isRegularFile(bundleJar));
+		assertTrue(Files.isRegularFile(bundleJar), "Bundle jar not found: " + bundleJar);
 		try (JarFile jar = new JarFile(bundleJar.toFile())) {
 			String bundleVersion = jar.getManifest().getMainAttributes().getValue(Constants.BUNDLE_VERSION);
-			assertTrue("Bundle-Version should start with 0.0.7: " + bundleVersion, bundleVersion.startsWith("0.0.7."));
+			assertTrue(bundleVersion.startsWith("0.0.7."), "Bundle-Version should start with 0.0.7: " + bundleVersion);
 		}
 
 		Path featureJar = basedir.resolve("features/org.example.feature/target/org.example.feature-0.0.7-SNAPSHOT.jar");
-		assertTrue("Feature jar not found: " + featureJar, Files.isRegularFile(featureJar));
+		assertTrue(Files.isRegularFile(featureJar), "Feature jar not found: " + featureJar);
 		Feature builtFeature = Feature.readJar(featureJar.toFile());
-		assertTrue("Feature version should start with 0.0.7: " + builtFeature.getVersion(),
-				builtFeature.getVersion().startsWith("0.0.7."));
+		assertTrue(builtFeature.getVersion().startsWith("0.0.7."),
+				"Feature version should start with 0.0.7: " + builtFeature.getVersion());
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/PomlessTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/PomlessTest.java
@@ -3,8 +3,8 @@ package org.eclipse.tycho.test.buildextension;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
@@ -23,7 +23,7 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.io.DefaultModelReader;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PomlessTest extends AbstractTychoIntegrationTest {
 
@@ -35,7 +35,7 @@ public class PomlessTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "bnd/target/classes/module-info.class");
-		assertTrue("module-info.class is not generated!", file.isFile());
+		assertTrue(file.isFile(), "module-info.class is not generated!");
 	}
 
 	@Test
@@ -47,7 +47,7 @@ public class PomlessTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "package"));
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "sourcefolder/generated.pom.xml");
-		assertTrue("generated.pom.xml is not generated!", file.isFile());
+		assertTrue(file.isFile(), "generated.pom.xml is not generated!");
 		Model model = new DefaultModelReader().read(file, Map.of());
 		Build build = model.getBuild();
 		assertNotNull(build);
@@ -62,7 +62,7 @@ public class PomlessTest extends AbstractTychoIntegrationTest {
 		PluginExecution execution = executions.get(0);
 		assertTrue(execution.getGoals().contains("add-source"));
 		String config = String.valueOf(execution.getConfiguration());
-		assertTrue(file + "->" + config, config.contains("<source>src2</source>"));
+		assertTrue(config.contains("<source>src2</source>"), file + "->" + config);
 	}
 
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compare/CompareWithBaselineTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compare/CompareWithBaselineTest.java
@@ -12,7 +12,7 @@ package org.eclipse.tycho.test.compare;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompareWithBaselineTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/AnnotationProcessorTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/AnnotationProcessorTest.java
@@ -13,13 +13,13 @@
 
 package org.eclipse.tycho.test.compiler;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AnnotationProcessorTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathEntryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathEntryTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.compiler;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompilerClasspathEntryTest extends AbstractTychoIntegrationTest {
 
@@ -105,15 +105,15 @@ public class CompilerClasspathEntryTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
 		File dependencies = new File(verifier.getBasedir(), "target/dependencies-list.txt");
-		assertTrue(dependencies.getAbsoluteFile() + " not found!", dependencies.isFile());
+		assertTrue(dependencies.isFile(), dependencies.getAbsoluteFile() + " not found!");
 		List<String> lines = Files.readAllLines(dependencies.toPath());
 		String collect = lines.stream().collect(Collectors.joining(",\r\n"));
-		assertTrue("org.eclipse.osgi.services not found in dependencies: " + collect,
-				lines.stream().anyMatch(s -> s.contains("org.osgi.service.component.annotations")));
-		assertTrue("org.osgi.annotation.bundle not found in dependencies: " + collect,
-				lines.stream().anyMatch(s -> s.contains("org.osgi.annotation.bundle")));
-		assertTrue("org.osgi.annotation.versioning not found in dependencies: " + collect,
-				lines.stream().anyMatch(s -> s.contains("org.osgi.annotation.versioning")));
+		assertTrue(lines.stream().anyMatch(s -> s.contains("org.osgi.service.component.annotations")),
+				"org.eclipse.osgi.services not found in dependencies: " + collect);
+		assertTrue(lines.stream().anyMatch(s -> s.contains("org.osgi.annotation.bundle")),
+				"org.osgi.annotation.bundle not found in dependencies: " + collect);
+		assertTrue(lines.stream().anyMatch(s -> s.contains("org.osgi.annotation.versioning")),
+				"org.osgi.annotation.versioning not found in dependencies: " + collect);
 	}
 
 	@Test
@@ -122,11 +122,11 @@ public class CompilerClasspathEntryTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
 		File dependencies = new File(verifier.getBasedir(), "target/dependencies-list.txt");
-		assertTrue(dependencies.getAbsoluteFile() + " not found!", dependencies.isFile());
+		assertTrue(dependencies.isFile(), dependencies.getAbsoluteFile() + " not found!");
 		List<String> lines = Files.readAllLines(dependencies.toPath());
 		String collect = lines.stream().collect(Collectors.joining(",\r\n"));
-		assertTrue("org.eclipse.osgi.services not found in dependencies: " + collect,
-				lines.stream().anyMatch(s -> s.contains("org.eclipse.jdt.annotation")));
+		assertTrue(lines.stream().anyMatch(s -> s.contains("org.eclipse.jdt.annotation")),
+				"org.eclipse.osgi.services not found in dependencies: " + collect);
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerClasspathTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.compiler;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompilerClasspathTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerExcludeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerExcludeTest.java
@@ -18,8 +18,8 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CompilerExcludeTest extends AbstractTychoIntegrationTest {
 
@@ -30,8 +30,8 @@ public class CompilerExcludeTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 
 		try (ZipFile zip = new ZipFile(new File(verifier.getBasedir(), "mycodelib.jar"))) {
-			Assert.assertNotNull(zip.getEntry("exclude/Activator.class"));
-			Assert.assertNull(zip.getEntry("exclude/filetoexlude.txt"));
+			Assertions.assertNotNull(zip.getEntry("exclude/Activator.class"));
+			Assertions.assertNull(zip.getEntry("exclude/filetoexlude.txt"));
 		}
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerExtraExportsJava17Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerExtraExportsJava17Test.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.compiler;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompilerExtraExportsJava17Test extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerExtraExportsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/CompilerExtraExportsTest.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.compiler;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompilerExtraExportsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/FailOnWarningTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/FailOnWarningTest.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.tycho.test.compiler;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FailOnWarningTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/FragmentsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/FragmentsTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.compiler;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FragmentsTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/JavaxAnnotationImportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/JavaxAnnotationImportTest.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.compiler;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JavaxAnnotationImportTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/MavenCompilerPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/MavenCompilerPluginTest.java
@@ -13,14 +13,14 @@
 
 package org.eclipse.tycho.test.compiler;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MavenCompilerPluginTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/MisconfigurationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/MisconfigurationTest.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.tycho.test.compiler;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MisconfigurationTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/RequireJREPackagesImportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/RequireJREPackagesImportTest.java
@@ -13,17 +13,17 @@
 
 package org.eclipse.tycho.test.compiler;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class RequireJREPackagesImportTest extends AbstractTychoIntegrationTest {
 
-	@Ignore("TODO bug 514471 check if we can re-enable strict access rules for JDK packages")
+	@Disabled("TODO bug 514471 check if we can re-enable strict access rules for JDK packages")
 	@Test
 	public void testStrictImportJREPackages() throws Exception {
 		Verifier verifier = getVerifier("compiler.requireJREPackageImports", false);

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/TestErrorMessages.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/TestErrorMessages.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.compiler;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test some nicer error messages if something is missing

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eclipserun/EclipseRunBundleStartLevelTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eclipserun/EclipseRunBundleStartLevelTest.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EclipseRunBundleStartLevelTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/CustomProfileIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/CustomProfileIntegrationTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.eeProfile;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -20,7 +20,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CustomProfileIntegrationTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/DependencyResolverEETest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/DependencyResolverEETest.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.eeProfile;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // tests that the dependency resolver resolves for the configured execution environment (bug 364095)
 public class DependencyResolverEETest extends AbstractTychoIntegrationTest {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/FragmentsAttachedTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/FragmentsAttachedTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FragmentsAttachedTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/Java11ResolutionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/Java11ResolutionTest.java
@@ -21,14 +21,14 @@ import java.util.List;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class Java11ResolutionTest extends AbstractTychoIntegrationTest {
 
 	private static File buildResult;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		Verifier verifier = new Java11ResolutionTest().getVerifier("eeProfile.java11", false);
 		verifier.executeGoal("verify");

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/Java17ResolutionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/Java17ResolutionTest.java
@@ -21,14 +21,14 @@ import java.util.List;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class Java17ResolutionTest extends AbstractTychoIntegrationTest {
 
 	private static File buildResult;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		Verifier verifier = new Java17ResolutionTest().getVerifier("eeProfile.java17", false);
 		verifier.executeGoal("verify");

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/Java18ResolutionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/Java18ResolutionTest.java
@@ -21,16 +21,16 @@ import java.util.List;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Ignore("unless java 18 jvm is aviable to tycho build")
+@Disabled("unless java 18 jvm is aviable to tycho build")
 public class Java18ResolutionTest extends AbstractTychoIntegrationTest {
 
 	private static File buildResult;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		Verifier verifier = new Java18ResolutionTest().getVerifier("eeProfile.java18", false);
 		verifier.executeGoal("verify");

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/Java7ResolutionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/Java7ResolutionTest.java
@@ -21,14 +21,14 @@ import java.util.List;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class Java7ResolutionTest extends AbstractTychoIntegrationTest {
 
 	private static File buildResult;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		Verifier verifier = new Java7ResolutionTest().getVerifier("eeProfile.java7", false);
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/extra/ListDependenciesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/extra/ListDependenciesTest.java
@@ -9,8 +9,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -18,7 +18,7 @@ import java.nio.file.Files;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ListDependenciesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/extra/SetVersionPomlessITest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/extra/SetVersionPomlessITest.java
@@ -20,8 +20,8 @@ import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.versions.pom.PomFile;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SetVersionPomlessITest extends AbstractTychoIntegrationTest {
 
@@ -35,17 +35,17 @@ public class SetVersionPomlessITest extends AbstractTychoIntegrationTest {
 		File baseDir = new File(verifier.getBasedir());
 
 		PomFile rootPom = PomFile.read(new File(baseDir, "pom.xml"), false);
-		Assert.assertEquals(newVersion, rootPom.getVersion());
+		Assertions.assertEquals(newVersion, rootPom.getVersion());
 
 		DefaultBundleReader reader = new DefaultBundleReader();
 		OsgiManifest bundleManifest = reader.loadManifest(new File(baseDir, "bundle1/META-INF/MANIFEST.MF"));
-		Assert.assertEquals(newVersion, bundleManifest.getBundleVersion());
+		Assertions.assertEquals(newVersion, bundleManifest.getBundleVersion());
 
 		OsgiManifest testBundleManifest = reader.loadManifest(new File(baseDir, "bundle1.tests/META-INF/MANIFEST.MF"));
-		Assert.assertEquals(newVersion, testBundleManifest.getBundleVersion());
+		Assertions.assertEquals(newVersion, testBundleManifest.getBundleVersion());
 
 		Feature feature = Feature.read(new File(baseDir, "feature/feature.xml"));
-		Assert.assertEquals(newVersion, feature.getVersion());
+		Assertions.assertEquals(newVersion, feature.getVersion());
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/extra/TychoPomlessITest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/extra/TychoPomlessITest.java
@@ -21,7 +21,7 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TychoPomlessITest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/feature/FeatureAttributesInferenceTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/feature/FeatureAttributesInferenceTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.List;
@@ -29,8 +29,8 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.XMLTool;
 import org.hamcrest.Matcher;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -49,7 +49,7 @@ public class FeatureAttributesInferenceTest extends AbstractTychoIntegrationTest
 				"feature.attributes.inference.test-1.0.0-sources-feature.jar")[0];
 
 		List<Element> pluginNodes = getPluginElements(featureJar);
-		Assert.assertEquals(3, pluginNodes.size());
+		Assertions.assertEquals(3, pluginNodes.size());
 
 		// Check the feature.xml in the feature-jar
 		assertAttributesOnlyElementWith(Map.of(//
@@ -69,7 +69,7 @@ public class FeatureAttributesInferenceTest extends AbstractTychoIntegrationTest
 
 		// Check the feature.xml in the source-feature-jar
 		List<Element> pluginSourceNodes = getPluginElements(featureSourceJar);
-		Assert.assertEquals(3, pluginSourceNodes.size());
+		Assertions.assertEquals(3, pluginSourceNodes.size());
 
 		assertAttributesOnlyElementWith(Map.of(//
 				"id", equalTo("junit-jupiter-api.source"), //

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/feature/FeatureWithDependenciesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/feature/FeatureWithDependenciesTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeatureWithDependenciesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/feature/FeatureWithMultipleFiltersTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/feature/FeatureWithMultipleFiltersTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.feature;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeatureWithMultipleFiltersTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/feature/FeatureWithRestrictionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/feature/FeatureWithRestrictionsTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.feature;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.Optional;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -42,9 +42,8 @@ public class FeatureWithRestrictionsTest extends AbstractTychoIntegrationTest {
 		Optional<Element> unit = artifactsDocument.root().childElements("unit").filter(elem -> {
 			return unitId.equals(elem.attribute("id"));
 		}).findFirst();
-		assertTrue("Unit with id " + unitId + " not found", unit.isPresent());
-		assertFalse("Version 2 was required by unit",
-				unit.stream().flatMap(elem -> elem.childElement("requires").orElse(null).childElements("required"))
-						.anyMatch(elem -> "[2.0.0,2.0.0]".equals(elem.attribute("range"))));
+		assertTrue(unit.isPresent(), "Unit with id " + unitId + " not found");
+		assertFalse(unit.stream().flatMap(elem -> elem.childElement("requires").orElse(null).childElements("required"))
+						.anyMatch(elem -> "[2.0.0,2.0.0]".equals(elem.attribute("range"))), "Version 2 was required by unit");
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/featurePatch/EclipseRepoIncludingFeaturePatchTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/featurePatch/EclipseRepoIncludingFeaturePatchTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.featurePatch;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -21,7 +21,7 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EclipseRepoIncludingFeaturePatchTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/featurePatch/FeaturePatchTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/featurePatch/FeaturePatchTest.java
@@ -17,7 +17,7 @@ import static org.eclipse.tycho.test.util.ResourceUtil.P2Repositories.ECLIPSE_35
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeaturePatchTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue1093/Issue1093Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue1093/Issue1093Test.java
@@ -10,14 +10,14 @@
 
 package org.eclipse.tycho.test.issue1093;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Issue1093Test extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue23/Issue23Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue23/Issue23Test.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.issue23;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Issue23Test extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue271/Issue271Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue271/Issue271Test.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Issue271Test extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue2937/Issue2937Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue2937/Issue2937Test.java
@@ -3,7 +3,7 @@ package org.eclipse.tycho.test.issue2937;
 import java.util.List;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Issue2937Test extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue697/Issue697Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue697/Issue697Test.java
@@ -4,13 +4,13 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class Issue697Test extends AbstractTychoIntegrationTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void test() throws Exception {
 		Verifier verifier = getVerifier("issue697");
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/iu/IUMetadataGenerationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/iu/IUMetadataGenerationTest.java
@@ -14,8 +14,8 @@ package org.eclipse.tycho.test.iu;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -24,14 +24,14 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.P2RepositoryTool.IU;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class IUMetadataGenerationTest extends AbstractTychoIntegrationTest {
 
 	private static P2RepositoryTool repo;
 
-	@BeforeClass
+	@BeforeAll
 	public static void runBuild() throws Exception {
 		Verifier verifier = new IUMetadataGenerationTest().getVerifier("iu.artifact", false);
 		verifier.executeGoal("verify");

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/iu/ProductWithIUTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/iu/ProductWithIUTest.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.iu;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductWithIUTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/jarsigning/JarSigningTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/jarsigning/JarSigningTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.jarsigning;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -21,7 +21,7 @@ import java.util.List;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.XMLTool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -56,7 +56,7 @@ public class JarSigningTest extends AbstractTychoIntegrationTest {
 		for (Node artifact : artifactNodes) {
 			List<Node> checksumProperties = XMLTool.getMatchingNodes(artifact,
 					"properties/property[@name='download.checksum.sha-256']");
-			assertFalse("artifact does not have a 'download.checksum.sha-256' attribute", checksumProperties.isEmpty());
+			assertFalse(checksumProperties.isEmpty(), "artifact does not have a 'download.checksum.sha-256' attribute");
 		}
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/licenseFeature/LicenseFeatureTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/licenseFeature/LicenseFeatureTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.licenseFeature;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,8 +26,8 @@ import java.util.zip.ZipFile;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 // tests the license feature support (bug 368985)
 public class LicenseFeatureTest extends AbstractTychoIntegrationTest {
@@ -51,8 +51,8 @@ public class LicenseFeatureTest extends AbstractTychoIntegrationTest {
 
 		try (ZipFile zip = new ZipFile(feature)) {
 
-			Assert.assertNotNull(zip.getEntry("file1.txt"));
-			Assert.assertNotNull(zip.getEntry("file2.txt"));
+			Assertions.assertNotNull(zip.getEntry("file1.txt"));
+			Assertions.assertNotNull(zip.getEntry("file2.txt"));
 
 			Properties p = new Properties();
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/licenseFeature/SetLicenseFeatureVersionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/licenseFeature/SetLicenseFeatureVersionTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.licenseFeature;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -20,7 +20,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.version.TychoVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // tests that license feature references are updated by the versions-plugin (bug 424945)
 // TODO make this a unit test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/limitations/MixedTychoVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/limitations/MixedTychoVersionsTest.java
@@ -13,13 +13,13 @@
 
 package org.eclipse.tycho.test.limitations;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.version.TychoVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MixedTychoVersionsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/limitations/NonUniqueBasedirsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/limitations/NonUniqueBasedirsTest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.limitations;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NonUniqueBasedirsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/mngeclipse1007/BinExcludedTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/mngeclipse1007/BinExcludedTest.java
@@ -17,8 +17,8 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BinExcludedTest extends AbstractTychoIntegrationTest {
 
@@ -30,9 +30,9 @@ public class BinExcludedTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 
 		try (ZipFile zip = new ZipFile(new File(verifier.getBasedir(), "target/MNGECLIPSE1007-1.0.0.jar"))) {
-			Assert.assertNotNull(zip.getEntry("files/included.txt"));
-			Assert.assertNull(zip.getEntry("files/excluded.txt"));
-			Assert.assertNull(zip.getEntry("Makefile"));
+			Assertions.assertNotNull(zip.getEntry("files/included.txt"));
+			Assertions.assertNull(zip.getEntry("files/excluded.txt"));
+			Assertions.assertNull(zip.getEntry("Makefile"));
 		}
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/mngeclipse937/CustomSourceEncodingTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/mngeclipse937/CustomSourceEncodingTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.mngeclipse937;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CustomSourceEncodingTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/multiplatform/MultiplatformProductTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/multiplatform/MultiplatformProductTest.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.multiplatform;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MultiplatformProductTest extends AbstractTychoIntegrationTest {
 	@Test
@@ -47,7 +47,7 @@ public class MultiplatformProductTest extends AbstractTychoIntegrationTest {
 	}
 
 	private void assertFile(File file) {
-		assertTrue(file.getAbsolutePath() + " is not a file", file.isFile());
+		assertTrue(file.isFile(), file.getAbsolutePath() + " is not a file");
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/multiplatform/MultiplatformReactorTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/multiplatform/MultiplatformReactorTest.java
@@ -16,7 +16,7 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MultiplatformReactorTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/CircularTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/CircularTest.java
@@ -13,7 +13,7 @@ import static java.util.Arrays.asList;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  */

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/ExtraUnitsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/ExtraUnitsTest.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.p2Inf;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExtraUnitsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/HostRequiresFragmentWithP2InfTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/HostRequiresFragmentWithP2InfTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.p2Inf;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HostRequiresFragmentWithP2InfTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/MultienvP2infTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/MultienvP2infTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Inf;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.InputStream;
@@ -23,7 +23,7 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -51,7 +51,7 @@ public class MultienvP2infTest extends AbstractTychoIntegrationTest {
 		}
 
 		// disabled due to a limitation of BundlesAction
-		// Assert.assertTrue(ids.contains("tychotest.bundle.macosx"));
+		// Assertions.assertTrue(ids.contains("tychotest.bundle.macosx"));
 
 		assertTrue(ids.contains("tychotest.feature.macosx"));
 		assertTrue(ids.contains("tychotest.product.macosx"));

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/VirtualUnitTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/VirtualUnitTest.java
@@ -10,7 +10,7 @@
 package org.eclipse.tycho.test.p2Inf;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -59,10 +59,10 @@ public class VirtualUnitTest extends AbstractTychoIntegrationTest {
 
 		Stream<Element> hostUnitRequirements = findRequirements(hostUnit);
 
-		assertTrue("Host IU " + hostUnitId + " not found", hostUnit.isPresent());
-		assertTrue("Configure IU " + configureUnitId + " not found", configureUnit.isPresent());
-		assertTrue("Requirement of IU " + configureUnitId + " not found in IU " + hostUnitId,
-				hostUnitRequirements.anyMatch(elem -> configureUnitId.equals(elem.attribute("name"))));
+		assertTrue(hostUnit.isPresent(), "Host IU " + hostUnitId + " not found");
+		assertTrue(configureUnit.isPresent(), "Configure IU " + configureUnitId + " not found");
+		assertTrue(hostUnitRequirements.anyMatch(elem -> configureUnitId.equals(elem.attribute("name"))),
+				"Requirement of IU " + configureUnitId + " not found in IU " + hostUnitId);
 	}
 
 	@Test
@@ -81,10 +81,10 @@ public class VirtualUnitTest extends AbstractTychoIntegrationTest {
 
 		Stream<Element> hostUnitRequirements = findRequirements(hostUnit);
 
-		assertTrue("Host IU " + hostUnitId + " not found", hostUnit.isPresent());
-		assertTrue("Configure IU " + configureUnitId + " not found", configureUnit.isPresent());
-		assertTrue("Requirement of IU " + configureUnitId + " not found in IU " + hostUnitId,
-				hostUnitRequirements.anyMatch(elem -> configureUnitId.equals(elem.attribute("name"))));
+		assertTrue(hostUnit.isPresent(), "Host IU " + hostUnitId + " not found");
+		assertTrue(configureUnit.isPresent(), "Configure IU " + configureUnitId + " not found");
+		assertTrue(hostUnitRequirements.anyMatch(elem -> configureUnitId.equals(elem.attribute("name"))),
+				"Requirement of IU " + configureUnitId + " not found in IU " + hostUnitId);
 
 		// Client bundle assertions
 		String clientUnitId = "pvumb.bundle2";
@@ -94,9 +94,9 @@ public class VirtualUnitTest extends AbstractTychoIntegrationTest {
 
 		Stream<Element> clientUnitRequirements = findRequirements(clientUnit);
 
-		assertTrue("Client IU " + clientUnitId + " not found", clientUnit.isPresent());
-		assertTrue("Requirement of IU " + hostUnitId + " not found in IU " + clientUnitId,
-				clientUnitRequirements.anyMatch(elem -> hostUnitId.equals(elem.attribute("name"))));
+		assertTrue(clientUnit.isPresent(), "Client IU " + clientUnitId + " not found");
+		assertTrue(clientUnitRequirements.anyMatch(elem -> hostUnitId.equals(elem.attribute("name"))),
+				"Requirement of IU " + hostUnitId + " not found in IU " + clientUnitId);
 	}
 
 	private static List<Element> getUnits(String baseDir, String filePath) {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/BasicP2RepositoryIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/BasicP2RepositoryIntegrationTest.java
@@ -16,7 +16,7 @@ package org.eclipse.tycho.test.p2Repository;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -26,8 +26,8 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.P2RepositoryTool.IU;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class BasicP2RepositoryIntegrationTest extends AbstractTychoIntegrationTest {
 
@@ -36,7 +36,7 @@ public class BasicP2RepositoryIntegrationTest extends AbstractTychoIntegrationTe
 	private static Verifier verifier;
 	private static P2RepositoryTool p2Repo;
 
-	@BeforeClass
+	@BeforeAll
 	public static void executeBuild() throws Exception {
 		verifier = new BasicP2RepositoryIntegrationTest().getVerifier("/p2Repository");
 		verifier.executeGoal("verify");

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/DownloadStatsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/DownloadStatsTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -27,7 +27,7 @@ import java.util.jar.JarFile;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/DownloadVerifyNoDigestAlgoTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/DownloadVerifyNoDigestAlgoTest.java
@@ -12,7 +12,7 @@ package org.eclipse.tycho.test.p2Repository;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DownloadVerifyNoDigestAlgoTest extends AbstractTychoIntegrationTest {
     @Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/IncludeAllSourcesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/IncludeAllSourcesTest.java
@@ -11,7 +11,7 @@ package org.eclipse.tycho.test.p2Repository;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -25,7 +25,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.p2.repository.FileBasedTychoRepositoryIndex;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IncludeAllSourcesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/MavenP2SiteTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/MavenP2SiteTest.java
@@ -10,8 +10,8 @@
 package org.eclipse.tycho.test.p2Repository;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -20,7 +20,7 @@ import java.nio.file.Paths;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MavenP2SiteTest extends AbstractTychoIntegrationTest {
 
@@ -52,14 +52,13 @@ public class MavenP2SiteTest extends AbstractTychoIntegrationTest {
 		verifyRepositoryExits(verifier, "site/");
 		String artifacts = Files.readString(Paths.get(verifier.getBasedir(), "site/target/repository/artifacts.xml"),
 				StandardCharsets.UTF_8);
-		assertTrue("artifact to deploy is missing", artifacts.contains("id='org.eclipse.tycho.it.deployme'"));
-		assertFalse("artifact is deployed but should't", artifacts.contains("id='org.eclipse.tycho.it.ignoreme'"));
-		assertFalse("artifact is deployed but should't",
-				artifacts.contains("id='org.eclipse.tycho.it.ignoreme-property'"));
-		assertFalse("There should be no plugins folder!",
-				new File(verifier.getBasedir(), "site/target/repository/plugins/").exists());
-		assertFalse("There should be no features folder!",
-				new File(verifier.getBasedir(), "site/target/repository/features/").exists());
+		assertTrue(artifacts.contains("id='org.eclipse.tycho.it.deployme'"), "artifact to deploy is missing");
+		assertFalse(artifacts.contains("id='org.eclipse.tycho.it.ignoreme'"), "artifact is deployed but should't");
+		assertFalse(artifacts.contains("id='org.eclipse.tycho.it.ignoreme-property'"), "artifact is deployed but should't");
+		assertFalse(new File(verifier.getBasedir(), "site/target/repository/plugins/").exists(),
+				"There should be no plugins folder!");
+		assertFalse(new File(verifier.getBasedir(), "site/target/repository/features/").exists(),
+				"There should be no features folder!");
 	}
 
 	@Test
@@ -72,10 +71,10 @@ public class MavenP2SiteTest extends AbstractTychoIntegrationTest {
 
 	protected void verifyRepositoryExits(Verifier verifier, String subdir) {
 		File artifacts = new File(verifier.getBasedir(), subdir + "target/repository/artifacts.xml");
-		assertTrue(artifacts.getAbsolutePath() + " is missing", artifacts.exists());
+		assertTrue(artifacts.exists(), artifacts.getAbsolutePath() + " is missing");
 		File content = new File(verifier.getBasedir(), subdir + "target/repository/content.xml");
-		assertTrue(content.getAbsolutePath() + " is missing", content.exists());
+		assertTrue(content.exists(), content.getAbsolutePath() + " is missing");
 		File site = new File(verifier.getBasedir(), subdir + "target/p2-site.zip");
-		assertTrue(site.getAbsolutePath() + " is missing", site.exists());
+		assertTrue(site.exists(), site.getAbsolutePath() + " is missing");
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/OSGiRepositoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/OSGiRepositoryTest.java
@@ -10,13 +10,13 @@
 package org.eclipse.tycho.test.p2Repository;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OSGiRepositoryTest extends AbstractTychoIntegrationTest {
 
@@ -26,7 +26,7 @@ public class OSGiRepositoryTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(asList("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 		File repoFile = new File(verifier.getBasedir(), "site/target/repository/repository.xml.gz");
-		assertTrue("repo file " + repoFile + " not found!", repoFile.exists());
+		assertTrue(repoFile.exists(), "repo file " + repoFile + " not found!");
 		// TODO assert some things about the content
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2ArtifactMappingToMavenRepoTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2ArtifactMappingToMavenRepoTest.java
@@ -9,7 +9,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -17,7 +17,7 @@ import java.nio.file.Files;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class P2ArtifactMappingToMavenRepoTest extends AbstractTychoIntegrationTest {
 
@@ -31,10 +31,7 @@ public class P2ArtifactMappingToMavenRepoTest extends AbstractTychoIntegrationTe
 		verifier.verifyErrorFreeLog();
 		File repository = new File(verifier.getBasedir(), "target/repository");
 		File artifactsXML = new File(repository, "artifacts.xml");
-		assertTrue(
-				artifactsXML.getAbsoluteFile() + " does not contain required line "
-						+ MAVEN_CENTRAL_URL,
-				Files.readAllLines(artifactsXML.toPath()).stream()
-						.anyMatch(line -> line.contains(MAVEN_CENTRAL_URL)));
+		assertTrue(Files.readAllLines(artifactsXML.toPath()).stream() .anyMatch(line -> line.contains(MAVEN_CENTRAL_URL)),
+				artifactsXML.getAbsoluteFile() + " does not contain required line " + MAVEN_CENTRAL_URL);
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryDownloadTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryDownloadTest.java
@@ -9,9 +9,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -25,7 +25,7 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.p2.repository.FileBasedTychoRepositoryIndex;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -60,8 +60,8 @@ public class P2RepositoryDownloadTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "install"));
 		verifier.verifyErrorFreeLog();
 		for (String bundle : bundles) {
-			VerificationException e = assertThrows(bundle + " is fetched twice!", VerificationException.class,
-					() -> verifier.verifyTextInLog("Writing P2 metadata for osgi.bundle," + bundle));
+			VerificationException e = assertThrows(VerificationException.class, () -> verifier.verifyTextInLog("Writing P2 metadata for osgi.bundle," + bundle),
+					bundle + " is fetched twice!");
 			assertTrue(e.getMessage().contains("Text not found"));
 		}
 	}
@@ -78,7 +78,7 @@ public class P2RepositoryDownloadTest extends AbstractTychoIntegrationTest {
 	}
 
 	private void verifyHasChecksum(File artifactXml) {
-		assertTrue("required artifact file " + artifactXml.getAbsolutePath() + " not found!", artifactXml.exists());
+		assertTrue(artifactXml.exists(), "required artifact file " + artifactXml.getAbsolutePath() + " not found!");
 		Document artifactsDocument = Document.of(artifactXml.toPath());
 		for (Element artifact : artifactsDocument.root().childElements("artifact").toList()) {
 			Map<String, String> map = artifact.childElement("properties").orElse(null).childElements("property")

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryFixArtifactsMetadataOldChecksumsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryFixArtifactsMetadataOldChecksumsTest.java
@@ -10,9 +10,9 @@
 package org.eclipse.tycho.test.p2Repository;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -27,7 +27,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.tukaani.xz.XZInputStream;
 
 /**
@@ -67,7 +67,7 @@ public class P2RepositoryFixArtifactsMetadataOldChecksumsTest extends AbstractTy
 		for(String checksumKey : checksumsThatMustNotBePresent) {
 			String checksumValue = artifactProperties.get(checksumKey);
 
-			assertNull("Property '" + checksumKey + "' is present in artifacts metadata", checksumValue);
+			assertNull(checksumValue, "Property '" + checksumKey + "' is present in artifacts metadata");
 		}
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryFtpHandlerTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryFtpHandlerTest.java
@@ -3,9 +3,9 @@ package org.eclipse.tycho.test.p2Repository;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockftpserver.core.command.Command;
 import org.mockftpserver.core.command.StaticReplyCommandHandler;
 import org.mockftpserver.core.session.Session;
@@ -33,7 +33,7 @@ public class P2RepositoryFtpHandlerTest extends AbstractTychoIntegrationTest {
     private String repositoryUrl;
     private FakeFtpServer ftpServer;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         repoDir = new File(getBasedir(TEST_BASEDIR), "repository");
         startFtpServer();
@@ -47,7 +47,7 @@ public class P2RepositoryFtpHandlerTest extends AbstractTychoIntegrationTest {
         verifier.verifyErrorFreeLog();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         ftpServer.stop();
     }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorCategoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorCategoryTest.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashSet;
@@ -27,7 +27,7 @@ import javax.xml.xpath.XPathFactory;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -59,10 +59,10 @@ public class P2RepositoryMirrorCategoryTest extends AbstractTychoIntegrationTest
 
 		String parentExpr = "repository/units/unit[@id='" + PARENT_CATEGORY_ID + "']";
 		Node parent = (Node) xpath.evaluate(parentExpr, content, XPathConstants.NODE);
-		assertNotNull("Parent category IU was not injected into the mirrored repository", parent);
+		assertNotNull(parent, "Parent category IU was not injected into the mirrored repository");
 
-		assertEquals("Parent IU must be marked as a category", "true", xpath.evaluate(
-				parentExpr + "/properties/property[@name='org.eclipse.equinox.p2.type.category']/@value", content));
+		assertEquals("true", xpath.evaluate(
+				parentExpr + "/properties/property[@name='org.eclipse.equinox.p2.type.category']/@value", content), "Parent IU must be marked as a category");
 
 		NodeList requiredNames = (NodeList) xpath.evaluate(parentExpr + "/requires/required/@name", content,
 				XPathConstants.NODESET);
@@ -71,8 +71,8 @@ public class P2RepositoryMirrorCategoryTest extends AbstractTychoIntegrationTest
 			requiredIds.add(requiredNames.item(i).getNodeValue());
 		}
 
-		assertTrue("Parent should wrap category alpha", requiredIds.contains("org.eclipse.example.category.alpha"));
-		assertTrue("Parent should wrap category beta", requiredIds.contains("org.eclipse.example.category.beta"));
-		assertEquals("Parent should wrap exactly the two source categories", 2, requiredIds.size());
+		assertTrue(requiredIds.contains("org.eclipse.example.category.alpha"), "Parent should wrap category alpha");
+		assertTrue(requiredIds.contains("org.eclipse.example.category.beta"), "Parent should wrap category beta");
+		assertEquals(2, requiredIds.size(), "Parent should wrap exactly the two source categories");
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorMvnProtocolTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorMvnProtocolTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class P2RepositoryMirrorMvnProtocolTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryMirrorTest.java
@@ -31,9 +31,9 @@ import org.eclipse.jetty.util.resource.EmptyResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -42,12 +42,12 @@ public class P2RepositoryMirrorTest extends AbstractTychoIntegrationTest {
 
 	private HttpServer server;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer();
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		server.stop();
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryPropertiesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryPropertiesTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Collections;
@@ -27,7 +27,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -54,7 +54,7 @@ public class P2RepositoryPropertiesTest extends AbstractTychoIntegrationTest {
 				expected.remove(propertyName);
 			}
 		});
-		assertEquals("Missing properties in artifact repository", Collections.emptyMap(), expected);
+		assertEquals(Collections.emptyMap(), expected, "Missing properties in artifact repository");
 
 	}
 
@@ -69,7 +69,7 @@ public class P2RepositoryPropertiesTest extends AbstractTychoIntegrationTest {
 		Optional<Element> optional = artifactsDocument.root().childElement("artifacts").orElse(null)
 				.childElements("artifact")
 				.filter(element -> element.attribute("id").equals("org.objenesis")).findAny();
-		assertTrue("artifact org.objenesis not found", optional.isPresent());
+		assertTrue(optional.isPresent(), "artifact org.objenesis not found");
 		Element element = optional.get();
 		Map<String, String> properties = element.childElement("properties").orElse(null).childElements("property")
 				.collect(Collectors.toMap(e -> e.attribute("name"), e -> e.attribute("value")));

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryValidateTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryValidateTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.util.Arrays;
@@ -22,7 +22,7 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class P2RepositoryValidateTest extends AbstractTychoIntegrationTest {
 
@@ -49,6 +49,6 @@ public class P2RepositoryValidateTest extends AbstractTychoIntegrationTest {
 		}
 		verifier.executeGoal("validate");
 		verifier.verifyErrorFreeLog();
-		assertFalse("Bundle shouldn't be copied locally just for validate", bundleCopyFolder.exists());
+		assertFalse(bundleCopyFolder.exists(), "Bundle shouldn't be copied locally just for validate");
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/QualifierExpansionAndArtifactAssemblyTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/QualifierExpansionAndArtifactAssemblyTest.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.p2Repository;
 import static org.eclipse.tycho.test.util.P2RepositoryTool.withIdAndVersion;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -26,8 +26,8 @@ import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.P2RepositoryTool.IU;
 import org.eclipse.tycho.test.util.P2RepositoryTool.IdAndVersion;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class QualifierExpansionAndArtifactAssemblyTest extends AbstractTychoIntegrationTest {
 
@@ -47,7 +47,7 @@ public class QualifierExpansionAndArtifactAssemblyTest extends AbstractTychoInte
 	private static Verifier verifier;
 	private static P2RepositoryTool p2Repository;
 
-	@BeforeClass
+	@BeforeAll
 	public static void executeBuild() throws Exception {
 		verifier = new QualifierExpansionAndArtifactAssemblyTest().getVerifier("p2Repository.reactor", false);
 		verifier.addCliOption("-De352-repo=" + P2Repositories.ECLIPSE_352.toString());

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepoRefLocationP2RepositoryIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepoRefLocationP2RepositoryIntegrationTest.java
@@ -18,8 +18,8 @@ import static org.eclipse.equinox.p2.repository.IRepository.TYPE_ARTIFACT;
 import static org.eclipse.equinox.p2.repository.IRepository.TYPE_METADATA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.List;
@@ -32,7 +32,7 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.P2RepositoryTool.RepositoryReference;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RepoRefLocationP2RepositoryIntegrationTest extends AbstractTychoIntegrationTest {
 
@@ -78,8 +78,8 @@ public class RepoRefLocationP2RepositoryIntegrationTest extends AbstractTychoInt
 				"/p2Repository.repositoryRef.filter.providing", c -> {
 				});
 
-		assertEquals(allRepositoryReferences.stream().map(rr -> rr.uri()).collect(Collectors.joining(", ")), 4,
-				allRepositoryReferences.size());
+		assertEquals(4, allRepositoryReferences.size(),
+				allRepositoryReferences.stream().map(rr -> rr.uri()).collect(Collectors.joining(", ")));
 		assertThat(allRepositoryReferences, containsInAnyOrder( //
 				new RepositoryReference("https://download.eclipse.org/eclipse/updates/4.29", TYPE_ARTIFACT, ENABLED),
 				new RepositoryReference("https://download.eclipse.org/eclipse/updates/4.29", TYPE_METADATA, ENABLED),

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepositoryIncludeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepositoryIncludeTest.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RepositoryIncludeTest extends AbstractTychoIntegrationTest {
 
@@ -32,7 +32,7 @@ public class RepositoryIncludeTest extends AbstractTychoIntegrationTest {
 				.forEclipseRepositoryModule(new File(verifier.getBasedir(), "repository"));
 		p2Repo.getUniqueIU("bundle");
 		p2Repo.assertNumberOfUnits(1, u -> u.id().equals("a.jre.javase") || u.id().endsWith(".test.category"));
-		assertTrue("Bundle artifact not found!", p2Repo.findBundleArtifact("bundle").isPresent());
+		assertTrue(p2Repo.findBundleArtifact("bundle").isPresent(), "Bundle artifact not found!");
 		p2Repo.assertNumberOfBundles(1);
 		p2Repo.assertNumberOfFeatures(0);
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/TransitiveP2RepoTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/TransitiveP2RepoTest.java
@@ -13,15 +13,15 @@
 package org.eclipse.tycho.test.p2Repository;
 
 import static org.eclipse.tycho.test.util.ResourceUtil.P2Repositories.ECLIPSE_352;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TransitiveP2RepoTest extends AbstractTychoIntegrationTest {
 
@@ -31,7 +31,7 @@ public class TransitiveP2RepoTest extends AbstractTychoIntegrationTest {
 
 	private static Verifier verifier;
 
-	@BeforeClass
+	@BeforeAll
 	public static void buildFeatureAndBundlesAndRepos() throws Exception {
 		verifier = new TransitiveP2RepoTest().getVerifier("p2Repository.transitive", false);
 		verifier.addCliOption("-Dp2.repo=" + ECLIPSE_352.toString());

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/AttachedZipTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/AttachedZipTest.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.packaging;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AttachedZipTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/BaselineValidateAndReplaceTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/BaselineValidateAndReplaceTest.java
@@ -1,7 +1,7 @@
 package org.eclipse.tycho.test.packaging;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,16 +12,16 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 // tests the support for reproducible artifacts (bug 362883 - "do not generate new artifact unless there is a change")
 public class BaselineValidateAndReplaceTest extends AbstractTychoIntegrationTest {
 
 	private static File baselineRepo;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setupClass() throws IOException {
 		baselineRepo = new File("projects/packaging.reproducibleArtifacts/baseline/repository").getCanonicalFile();
 	}
@@ -37,7 +37,7 @@ public class BaselineValidateAndReplaceTest extends AbstractTychoIntegrationTest
 	}
 
 	private void assertReactorContents(File repository, String path) throws IOException {
-		Assert.assertFalse(isBaselineContents(repository, path));
+		Assertions.assertFalse(isBaselineContents(repository, path));
 	}
 
 	private boolean isBaselineContents(File repository, String path) throws IOException {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/BuildQualifierTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/BuildQualifierTest.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BuildQualifierTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/ConsumerPomTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/ConsumerPomTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.packaging;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.HashMap;
@@ -26,14 +26,14 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.DefaultModelReader;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ConsumerPomTest extends AbstractTychoIntegrationTest {
 	DefaultModelReader reader = new DefaultModelReader();
 
 	@Test
-	@Ignore("Disabled because of maven central outages")
+	@Disabled("Disabled because of maven central outages")
 	public void testReplaceP2() throws Exception {
 		Verifier verifier = getVerifier("packaging.consumer.pom", true);
 		verifier.addCliOption("-U");
@@ -72,7 +72,7 @@ public class ConsumerPomTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		DefaultModelReader reader = new DefaultModelReader();
 		Model model = reader.read(new File(verifier.getBasedir(), "bundle/.tycho-consumer-pom.xml"), new HashMap<>());
-		assertEquals("packaging was not replaced", "jar", model.getPackaging());
+		assertEquals("jar", model.getPackaging(), "packaging was not replaced");
 	}
 
 	private void assertHasDependency(String g, String a, List<Dependency> dependencies) {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/CustomManifestAndFeatureTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/CustomManifestAndFeatureTest.java
@@ -2,8 +2,8 @@ package org.eclipse.tycho.test.packaging;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,20 +23,22 @@ public class CustomManifestAndFeatureTest extends AbstractTychoIntegrationTest {
 
         // Verify filtered MANIFEST.MF
         final Path targetManifestPath = Path.of(verifier.getBasedir(), "plugin1/target/MANIFEST.MF");
-        Assert.assertTrue("Missing MANIFEST.MF under " + targetManifestPath.getParent(), Files.exists(targetManifestPath));
+        Assertions.assertTrue(Files.exists(targetManifestPath),
+        		"Missing MANIFEST.MF under " + targetManifestPath.getParent());
 
         final String manifestContent = Files.readString(targetManifestPath);
         final Matcher bundleVendorMatcher = PATTERN_BUNDLE_VENDOR.matcher(manifestContent);
-        Assert.assertTrue("Could not find Bundle-Vendor in MANIFEST.MF", bundleVendorMatcher.find());
-        Assert.assertEquals("Vendor name example", bundleVendorMatcher.group(1).trim());
+        Assertions.assertTrue(bundleVendorMatcher.find(), "Could not find Bundle-Vendor in MANIFEST.MF");
+        Assertions.assertEquals("Vendor name example", bundleVendorMatcher.group(1).trim());
 
         // Verify filtered feature.xml
         final Path targetFeaturePath = Path.of(verifier.getBasedir(), "feature1/target/feature.xml");
-        Assert.assertTrue("Missing feature.xml under " + targetFeaturePath.getParent(), Files.exists(targetFeaturePath));
+        Assertions.assertTrue(Files.exists(targetFeaturePath),
+        		"Missing feature.xml under " + targetFeaturePath.getParent());
 
         final String featureContent = Files.readString(targetFeaturePath);
         final Matcher providerMatcher = PATTERN_FEATURE_PROVIDER.matcher(featureContent);
-        Assert.assertTrue("Could not find provider-name=\"...\" in feature.xml", providerMatcher.find());
-        Assert.assertEquals("Provider name example", providerMatcher.group(1).trim());
+        Assertions.assertTrue(providerMatcher.find(), "Could not find provider-name=\"...\" in feature.xml");
+        Assertions.assertEquals("Provider name example", providerMatcher.group(1).trim());
     }
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/DefaultBuildTimestampProviderTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/DefaultBuildTimestampProviderTest.java
@@ -20,8 +20,8 @@ import java.util.Date;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test uses a project that contains 3 plugins (2 eclipse-plugins and one maven plugin). The
@@ -47,10 +47,9 @@ public class DefaultBuildTimestampProviderTest extends AbstractTychoIntegrationT
         String plugin1Manifest = Files.readString(Paths.get(baseDir.getAbsolutePath(), "plugin01/target/MANIFEST.MF"));
         String plugin2Manifest = Files.readString(Paths.get(baseDir.getAbsolutePath(), "plugin02/target/MANIFEST.MF"));
         String expectedBundleVersion = "Bundle-Version: 1.0.0." + format.format(buildTimestamp);
-        Assert.assertTrue(
-                "Expected Bundle-Version in MANIFEST: '" + expectedBundleVersion + "'\nbut was\n" + plugin1Manifest,
-                plugin1Manifest.contains(expectedBundleVersion));
-        Assert.assertTrue(plugin2Manifest.contains(expectedBundleVersion));
+        Assertions.assertTrue(plugin1Manifest.contains(expectedBundleVersion),
+        		"Expected Bundle-Version in MANIFEST: '" + expectedBundleVersion + "'\nbut was\n" + plugin1Manifest);
+        Assertions.assertTrue(plugin2Manifest.contains(expectedBundleVersion));
     }
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/PackageNestedJarsAndDirsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/PackageNestedJarsAndDirsTest.java
@@ -13,10 +13,10 @@
 
 package org.eclipse.tycho.test.packaging;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.InputStream;
@@ -26,7 +26,7 @@ import java.util.zip.ZipInputStream;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PackageNestedJarsAndDirsTest extends AbstractTychoIntegrationTest {
 
@@ -60,16 +60,15 @@ public class PackageNestedJarsAndDirsTest extends AbstractTychoIntegrationTest {
 						break;
 					}
 				}
-				assertTrue(internal1ClassName + " not found in nested jar " + internal1Jar, found);
+				assertTrue(found, internal1ClassName + " not found in nested jar " + internal1Jar);
 			}
 		}
 	}
 
 	private ZipEntry assertFileEntryExists(String entry, JarFile jarFile) {
 		ZipEntry jarEntry = jarFile.getEntry(entry);
-		assertNotNull("entry '" + entry + " does not exist in " + jarFile.getName(), jarEntry);
-		assertFalse("entry '" + entry + " exists in " + jarFile.getName() + " but is a directory",
-				jarEntry.isDirectory());
+		assertNotNull(jarEntry, "entry '" + entry + " does not exist in " + jarFile.getName());
+		assertFalse(jarEntry.isDirectory(), "entry '" + entry + " exists in " + jarFile.getName() + " but is a directory");
 		return jarEntry;
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/UseDefaultExcludesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/UseDefaultExcludesTest.java
@@ -13,35 +13,32 @@
 
 package org.eclipse.tycho.test.packaging;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.util.jar.JarFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UseDefaultExcludesTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testDefaultExcludesRemoveGitignoreByDefault() throws Exception {
 		try (JarFile jarFile = buildAndGetPluginJar("enabled")) {
-			assertNotNull("testdata/file.txt is missing from " + jarFile.getName(),
-					jarFile.getEntry("testdata/file.txt"));
-			assertNull("testdata/.gitignore should have been excluded from " + jarFile.getName(),
-					jarFile.getEntry("testdata/.gitignore"));
+			assertNotNull(jarFile.getEntry("testdata/file.txt"), "testdata/file.txt is missing from " + jarFile.getName());
+			assertNull(jarFile.getEntry("testdata/.gitignore"),
+					"testdata/.gitignore should have been excluded from " + jarFile.getName());
 		}
 	}
 
 	@Test
 	public void testDisabledDefaultExcludesKeepGitignore() throws Exception {
 		try (JarFile jarFile = buildAndGetPluginJar("disabled")) {
-			assertNotNull("testdata/file.txt is missing from " + jarFile.getName(),
-					jarFile.getEntry("testdata/file.txt"));
-			assertNotNull("testdata/.gitignore is missing from " + jarFile.getName(),
-					jarFile.getEntry("testdata/.gitignore"));
+			assertNotNull(jarFile.getEntry("testdata/file.txt"), "testdata/file.txt is missing from " + jarFile.getName());
+			assertNotNull(jarFile.getEntry("testdata/.gitignore"), "testdata/.gitignore is missing from " + jarFile.getName());
 		}
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/pgp/TestPGPSigning.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/pgp/TestPGPSigning.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.tycho.test.pgp;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ import org.eclipse.tycho.gpg.BouncyCastleSigner;
 import org.eclipse.tycho.gpg.KeyStore;
 import org.eclipse.tycho.gpg.SignatureStore;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.tukaani.xz.XZInputStream;
 
 public class TestPGPSigning extends AbstractTychoIntegrationTest {
@@ -526,7 +526,7 @@ public class TestPGPSigning extends AbstractTychoIntegrationTest {
 				var key = properties.get("pgp.publicKeys");
 				var signature = properties.get("pgp.signatures");
 				if (signature != null) {
-					assertNotNull("A key is expected when there is a signature.", key);
+					assertNotNull(key, "A key is expected when there is a signature.");
 					var fingerprints = verifyArtifactSignature(repository, id, version, classifier, key, signature);
 					data.signedIUs.put(id, fingerprints);
 				} else {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencies/PomDependencyWrapTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencies/PomDependencyWrapTest.java
@@ -14,8 +14,8 @@ import java.io.File;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PomDependencyWrapTest extends AbstractTychoIntegrationTest {
 
@@ -30,9 +30,9 @@ public class PomDependencyWrapTest extends AbstractTychoIntegrationTest {
         String testProjectRoot = verifier.getBasedir();
         P2RepositoryTool p2Repo = P2RepositoryTool.forEclipseRepositoryModule(new File(testProjectRoot, "repository"));
 
-        Assert.assertTrue(p2Repo.getAllUnitIds().stream().anyMatch("org.bundle"::equals));
-        Assert.assertTrue(p2Repo.getAllUnitIds().stream().anyMatch(id -> id.contains("undertow")));
-        Assert.assertTrue(
+        Assertions.assertTrue(p2Repo.getAllUnitIds().stream().anyMatch("org.bundle"::equals));
+        Assertions.assertTrue(p2Repo.getAllUnitIds().stream().anyMatch(id -> id.contains("undertow")));
+        Assertions.assertTrue(
                 p2Repo.getAllProvidedPackages().stream().anyMatch(packageName -> packageName.contains("io.undertow")));
     }
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PackagingPomDependencyWithTimestampProviderTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PackagingPomDependencyWithTimestampProviderTest.java
@@ -4,7 +4,7 @@ import static java.util.Arrays.asList;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PackagingPomDependencyWithTimestampProviderTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencyIgnoreTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencyIgnoreTest.java
@@ -11,7 +11,7 @@ package org.eclipse.tycho.test.pomDependencyConsider;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PomDependencyIgnoreTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencyOnLocallyBuiltTychoArtifactTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencyOnLocallyBuiltTychoArtifactTest.java
@@ -19,8 +19,8 @@ import org.eclipse.tycho.p2.repository.GAV;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.NoopFileLockService;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PomDependencyOnLocallyBuiltTychoArtifactTest extends AbstractTychoIntegrationTest {
 
@@ -50,8 +50,8 @@ public class PomDependencyOnLocallyBuiltTychoArtifactTest extends AbstractTychoI
 				TEST_PROJECT_POM_DEPENDENCY.getVersion());
 		File expectedSourceBundle = p2Repo.getBundleArtifact(TEST_PROJECT_POM_DEPENDENCY.getArtifactId() + ".source",
 				TEST_PROJECT_POM_DEPENDENCY.getVersion());
-		Assert.assertTrue(expectedBinaryBundle.isFile());
-		Assert.assertTrue(expectedSourceBundle.isFile());
+		Assertions.assertTrue(expectedBinaryBundle.isFile());
+		Assertions.assertTrue(expectedSourceBundle.isFile());
 	}
 
 	private void setUpBundleWithSourceBundle() throws Exception {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencyOnNonTychoArtifactTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencyOnNonTychoArtifactTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.pomDependencyConsider;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.jar.JarFile;
@@ -20,8 +20,8 @@ import java.util.jar.JarFile;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PomDependencyOnNonTychoArtifactTest extends AbstractTychoIntegrationTest {
 	private static final String POM_DEPENDENCY_BUNDLE_ID = "com.google.gson";
@@ -43,11 +43,11 @@ public class PomDependencyOnNonTychoArtifactTest extends AbstractTychoIntegratio
 		// this was bug TYCHO-570: the build passed, but the POM dependency bundle was
 		// missing
 		File expectedBundle = p2Repo.getBundleArtifact(POM_DEPENDENCY_BUNDLE_ID, POM_DEPENDENCY_BUNDLE_VERSION);
-		Assert.assertTrue(expectedBundle.isFile());
+		Assertions.assertTrue(expectedBundle.isFile());
 		// bug 368596 assert that pom dependency with classifier works
 		File sourceBundle = p2Repo.getBundleArtifact(POM_DEPENDENCY_CLASSIFIER_BUNDLE_ID,
 				POM_DEPENDENCY_CLASSIFIER_BUNDLE_VERSION);
-		Assert.assertTrue(sourceBundle.isFile());
+		Assertions.assertTrue(sourceBundle.isFile());
 		try (JarFile jarFile = new JarFile(sourceBundle)) {
 			String sourceBundleSymbolicName = jarFile.getManifest().getMainAttributes().getValue("Bundle-SymbolicName");
 			assertEquals(POM_DEPENDENCY_CLASSIFIER_BUNDLE_ID, sourceBundleSymbolicName);

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencySystemScopedTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencySystemScopedTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PomDependencySystemScopedTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/BuildProductWithIgnoredContentTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/BuildProductWithIgnoredContentTest.java
@@ -26,7 +26,7 @@ import org.eclipse.tycho.test.util.P2RepositoryTool.IU;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // TODO make this a unit test?
 public class BuildProductWithIgnoredContentTest extends AbstractTychoIntegrationTest {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/BuildProductWithoutCleanTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/BuildProductWithoutCleanTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.product;
 
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -22,7 +22,7 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.P2RepositoryTool.IU;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BuildProductWithoutCleanTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/InvalidProductTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/InvalidProductTest.java
@@ -9,13 +9,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.product;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InvalidProductTest extends AbstractTychoIntegrationTest {
 
@@ -25,8 +25,8 @@ public class InvalidProductTest extends AbstractTychoIntegrationTest {
 		verifier.addCliOption("-Dtest-data-repo=" + P2Repositories.ECLIPSE_342.toString());
 
 		// run build and verify we get a proper error message instead of an NPE
-		assertThrows("We expect to fail on malformed product definitions", VerificationException.class,
-				() -> verifier.executeGoal("package"));
+		assertThrows(VerificationException.class, () -> verifier.executeGoal("package"),
+				"We expect to fail on malformed product definitions");
 		verifier.verifyTextInLog("The product file invalid.product does not contain the mandatory attribute");
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/MetaRequirementsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/MetaRequirementsTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.product;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MetaRequirementsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductArchiveFormatTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductArchiveFormatTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductArchiveFormatTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductBuildTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductBuildTest.java
@@ -11,8 +11,8 @@ package org.eclipse.tycho.test.product;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
@@ -30,7 +30,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.TychoConstants;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -93,18 +93,18 @@ public class ProductBuildTest extends AbstractTychoIntegrationTest {
 
 	protected void checkPGP(Verifier verifier, String repositoryArtifacts) {
 		File artifactXml = new File(verifier.getBasedir(), repositoryArtifacts);
-		assertTrue("required artifacts file " + artifactXml.getAbsolutePath() + " not found!", artifactXml.isFile());
+		assertTrue(artifactXml.isFile(), "required artifacts file " + artifactXml.getAbsolutePath() + " not found!");
 		Document artifactsDocument = Document.of(artifactXml.toPath());
 		Optional<Element> optional = artifactsDocument.root().childElement("artifacts").orElse(null)
 				.childElements("artifact").filter(element -> element.attribute("id").equals("org.mockito.mockito-core"))
 				.findAny();
-		assertTrue("artifact org.mockito.mockito-core not found", optional.isPresent());
+		assertTrue(optional.isPresent(), "artifact org.mockito.mockito-core not found");
 		Element element = optional.get();
 		Map<String, String> properties = element.childElement("properties").orElse(null).childElements("property")
 				.collect(Collectors.toMap(e -> e.attribute("name"), e -> e.attribute("value")));
 		for (String property : REQUIRED_PGP_PROPERTIES) {
-			assertTrue("property " + property + " is missing", properties.containsKey(property));
-			assertFalse("property " + property + " is present but empty", properties.get(property).isBlank());
+			assertTrue(properties.containsKey(property), "property " + property + " is missing");
+			assertFalse(properties.get(property).isBlank(), "property " + property + " is present but empty");
 
 		}
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductDefinitionCrosstalkTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductDefinitionCrosstalkTest.java
@@ -22,7 +22,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // TODO make this a unit test
 public class ProductDefinitionCrosstalkTest extends AbstractTychoIntegrationTest {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductDuplicateIUsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductDuplicateIUsTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.product;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductDuplicateIUsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductMixedVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductMixedVersionsTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.product;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -22,7 +22,7 @@ import java.util.Arrays;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductMixedVersionsTest extends AbstractTychoIntegrationTest {
 	@Test
@@ -37,9 +37,9 @@ public class ProductMixedVersionsTest extends AbstractTychoIntegrationTest {
 		for (String bundleInfo : Files.readAllLines(bundleInfoFiles[0].toPath(), StandardCharsets.UTF_8)) {
 			String[] parts = bundleInfo.split(",");
 			if (parts.length == 5 && "org.apache.activemq.activemq-core".equals(parts[0])) {
-				assertEquals("Version of activemq bundle does not match", "5.2.0", parts[1]);
-				assertEquals("Start level of activemq bundle does not match", "3", parts[3]);
-				assertEquals("Autostart of activemq bundle does not match", "true", parts[4]);
+				assertEquals("5.2.0", parts[1], "Version of activemq bundle does not match");
+				assertEquals("3", parts[3], "Start level of activemq bundle does not match");
+				assertEquals("true", parts[4], "Autostart of activemq bundle does not match");
 			}
 			return;
 		}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductRepositoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductRepositoryTest.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductRepositoryTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductTypesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductTypesTest.java
@@ -18,14 +18,14 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ProductTypesTest extends AbstractTychoIntegrationTest {
 
 	private static Verifier testBuildVerifier;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setupBeforeClass() throws Exception {
 		testBuildVerifier = new ProductTypesTest().getVerifier("product.types", false);
 		testBuildVerifier.executeGoals(List.of("clean", "verify"));

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ReferenceBetweenProductsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ReferenceBetweenProductsTest.java
@@ -22,7 +22,7 @@ import java.io.File;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReferenceBetweenProductsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho188P2EnabledRcpTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho188P2EnabledRcpTest.java
@@ -16,8 +16,8 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -36,12 +36,11 @@ import org.eclipse.tycho.test.util.ArchiveContentUtil;
 import org.eclipse.tycho.test.util.EclipseInstallationTool;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.P2RepositoryTool.IU;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+
 
 /**
  * Integration test for building and installing Eclipse RCP (Rich Client Platform) products with P2 enabled.
@@ -57,7 +56,7 @@ import org.junit.runner.RunWith;
  * <li>Validating product artifacts and attachments for different target environments</li>
  * </ul>
  * <p>
- * The test uses JUnit's Theories framework to test multiple target environments (Windows/Linux, different architectures).
+ * The test is parameterized over multiple target environments (Windows/Linux, different architectures).
  * It covers several product scenarios:
  * <ul>
  * <li><b>main.product.id</b>: Standard product with local features</li>
@@ -68,7 +67,6 @@ import org.junit.runner.RunWith;
  * 
  * @see org.eclipse.tycho.test.AbstractTychoIntegrationTest
  */
-@RunWith(Theories.class)
 public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 
 	private static final String MODULE = "eclipse-repository";
@@ -82,13 +80,12 @@ public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 			new Product("extra.product.id", "extra", "rootfolder", true, false, false),
 			new Product("repoonly.product.id", false));
 
-	@DataPoints
 	public static final TargetEnvironment[] TEST_ENVIRONMENTS = new TargetEnvironment[] {
 			new TargetEnvironment("win32", "win32", "x86_64"), new TargetEnvironment("linux", "gtk", "x86_64") };
 
 	private static Verifier verifier;
 
-	@BeforeClass
+	@BeforeAll
 	public static void buildProduct() throws Exception {
 		verifier = new Tycho188P2EnabledRcpTest().getVerifier("product.installation", false);
 
@@ -168,7 +165,8 @@ public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 		verifier.verifyTextInLog("Installing pi.root-level-installed-feature");
 	}
 
-	@Theory
+	@ParameterizedTest
+	@FieldSource("TEST_ENVIRONMENTS")
 	public void testRootLevelFeaturesAreInstalledInRightProducts(TargetEnvironment env) {
 		File basedir = new File(verifier.getBasedir(), MODULE);
 
@@ -207,7 +205,7 @@ public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 					.getParentFile();
 			File installedProductArchive = new File(artifactDirectory,
 					ARTIFACT_ID + '-' + VERSION + product.getAttachIdSegment() + "-" + toOsWsArch(env, ".") + ".zip");
-			assertTrue("Product archive not found at: " + installedProductArchive, installedProductArchive.exists());
+			assertTrue(installedProductArchive.exists(), "Product archive not found at: " + installedProductArchive);
 
 			if (product.hasBundlePool()) {
 				for (TargetEnvironment subEnv : TEST_ENVIRONMENTS) {
@@ -231,13 +229,12 @@ public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 
 		Properties configIni = openPropertiesFromZip(installedProductArchive, rootFolder + "configuration/config.ini");
 		String bundleConfiguration = configIni.getProperty("osgi.bundles");
-		assertTrue("Installation is not configured to use the simpleconfigurator",
-				bundleConfiguration.startsWith("reference:file:org.eclipse.equinox.simpleconfigurator"));
+		assertTrue(bundleConfiguration.startsWith("reference:file:org.eclipse.equinox.simpleconfigurator"),
+				"Installation is not configured to use the simpleconfigurator");
 		// TODO all these assertions should be in the test method directly
 		String expectedProfileName = env.getOs().equals("linux") ? "ProfileNameForLinux"
 				: "ConfiguredDefaultProfileName";
-		assertEquals("eclipse.p2.profile in config.ini", expectedProfileName,
-				configIni.getProperty("eclipse.p2.profile"));
+		assertEquals(expectedProfileName, configIni.getProperty("eclipse.p2.profile"), "eclipse.p2.profile in config.ini");
 
 		Set<String> archiveFiles = ArchiveContentUtil.getFilesInZip(installedProductArchive);
 		if (!rootFolder.isEmpty()) {
@@ -282,7 +279,7 @@ public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 				files.add(fileName);
 			}
 		}
-		assertEquals(files.toString(), expectedArtifacts, zipArtifacts);
+		assertEquals(expectedArtifacts, zipArtifacts, files.toString());
 	}
 
 	public static Properties openPropertiesFromZip(File zipFile, String propertyFile) throws Exception {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho465RootFilesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho465RootFilesTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.product;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,8 +26,8 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -96,19 +96,19 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 		for (File file : listFiles) {
 			if (file.getName().startsWith(prefix)) {
 				if (file.getName().endsWith(".qualifier.jar")) {
-					Assert.fail("replacement of build qualifier missing in file " + file + ", name: " + file.getName());
+					Assertions.fail("replacement of build qualifier missing in file " + file + ", name: " + file.getName());
 				}
 				return;
 			}
 		}
-		Assert.fail("Missing entry " + prefix + "* in assembled repository directory " + dir);
+		Assertions.fail("Missing entry " + prefix + "* in assembled repository directory " + dir);
 	}
 
 	static void assertFeatureIU(Document contentXml, File assembledRepoDir, String featureId, String... requiredIus) {
 		String featureIuId = featureId + ".feature.group";
 		Set<Element> featureIus = findIU(contentXml, featureIuId);
-		assertEquals("Feature iu with id = '" + featureIuId + "' does not occur exactly once in content.xml", 1,
-				featureIus.size());
+		assertEquals(1, featureIus.size(),
+				"Feature iu with id = '" + featureIuId + "' does not occur exactly once in content.xml");
 
 		Element featureIu = featureIus.iterator().next();
 
@@ -121,12 +121,11 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 
 	static void assertCategoryIU(Document contentXml, String categoryIuId, String featureIuId) {
 		Set<Element> categoryIus = findIU(contentXml, categoryIuId);
-		assertEquals("Unique category iu not found", 1, categoryIus.size());
+		assertEquals(1, categoryIus.size(), "Unique category iu not found");
 		Element categoryIu = categoryIus.iterator().next();
 
-		assertTrue("IU not typed as category",
-				iuHasProperty(categoryIu, "org.eclipse.equinox.p2.type.category", "true"));
-		assertTrue("Category name missing", iuHasProperty(categoryIu, "org.eclipse.equinox.p2.name", "A Category"));
+		assertTrue(iuHasProperty(categoryIu, "org.eclipse.equinox.p2.type.category", "true"), "IU not typed as category");
+		assertTrue(iuHasProperty(categoryIu, "org.eclipse.equinox.p2.name", "A Category"), "Category name missing");
 		assertTrue(iuHasAllRequirements(categoryIu, featureIuId));
 	}
 
@@ -136,29 +135,29 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 		File mainWinConfigProductDir = new File(targetDir, "products/main.product.id/win32/win32/x86_64");
 		File rootFile = new File(mainWinConfigProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		File mainLinuxConfigProductDir = new File(targetDir, "products/main.product.id/linux/gtk/x86_64");
 		rootFile = new File(mainLinuxConfigProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 	}
 
 	static void assertConfigIndependentRootFiles(File mainProductDir) {
 		String relRootFilePath = "rootFile.txt";
 		File rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		relRootFilePath = "file5.txt";
 		rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		relRootFilePath = "dir/file6.txt";
 		rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 	}
 
 	static void assertInstalledLinuxConfigRootFile(File targetDir) {
@@ -166,12 +165,12 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 		String relRootFilePath = "file1.txt";
 		File rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		relRootFilePath = "dir/file2.txt";
 		rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		// without config specified root files => included all config specific products
 		assertConfigIndependentRootFiles(mainProductDir);
@@ -182,22 +181,22 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 		String relRootFilePath = "file1.txt";
 		File rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		relRootFilePath = "file2.txt";
 		rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		relRootFilePath = "dir1/file3.txt";
 		rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		relRootFilePath = "dir1/dir2/file4.txt";
 		rootFile = new File(mainProductDir, relRootFilePath);
 
-		assertTrue(getFileNotExistsInDirMsg(relRootFilePath, rootFile), rootFile.exists());
+		assertTrue(rootFile.exists(), getFileNotExistsInDirMsg(relRootFilePath, rootFile));
 
 		// without config specified root files => included all config specific products
 		assertConfigIndependentRootFiles(mainProductDir);
@@ -208,29 +207,25 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 		String featureIuId = featureId + ".feature.group";
 		Set<Element> featureIus = findIU(contentXml, featureIuId);
 
-		assertEquals("Feature iu with id = '" + featureIuId + "' does not occur exactly once in content.xml", 1,
-				featureIus.size());
+		assertEquals(1, featureIus.size(),
+				"Feature iu with id = '" + featureIuId + "' does not occur exactly once in content.xml");
 
 		Element featureIu = featureIus.iterator().next();
 		String rootWinConfigFeatureIuId = featureId + "_root.win32.win32.x86_64";
 
-		assertTrue(
-				"Verifying content.xml failed because feature iu with id = '" + featureIuId
-						+ "' does not contain required root iu with id = '" + rootWinConfigFeatureIuId + "'",
-				iuHasAllRequirements(featureIu, rootWinConfigFeatureIuId));
+		assertTrue(iuHasAllRequirements(featureIu, rootWinConfigFeatureIuId), "Verifying content.xml failed because feature iu with id = '" + featureIuId
+						+ "' does not contain required root iu with id = '" + rootWinConfigFeatureIuId + "'");
 
 		String rootLinuxConfigFeatureIuId = featureId + "_root.gtk.linux.x86_64";
 
-		assertTrue(
-				"Verifying content.xml failed because feature iu with id = '" + featureIuId
-						+ "' does not contain required root iu with id = '" + rootLinuxConfigFeatureIuId + "'",
-				iuHasAllRequirements(featureIu, rootLinuxConfigFeatureIuId));
+		assertTrue(iuHasAllRequirements(featureIu, rootLinuxConfigFeatureIuId), "Verifying content.xml failed because feature iu with id = '" + featureIuId
+						+ "' does not contain required root iu with id = '" + rootLinuxConfigFeatureIuId + "'");
 
 		String featureIuRootId = featureId + "_root";
 		Set<Element> featureRootIus = findIU(contentXml, featureIuRootId);
 
-		assertEquals("Feature root iu with id = '" + featureIuRootId + "' does not occur exactly once in content.xml",
-				1, featureRootIus.size());
+		assertEquals(1, featureRootIus.size(),
+				"Feature root iu with id = '" + featureIuRootId + "' does not occur exactly once in content.xml");
 	}
 
 	static void assertRootIuPermissionsMetaData(Document contentXml) {
@@ -239,16 +234,16 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 
 		String expectedTouchpointDataInstruction = "chmod(targetDir:${installFolder}, targetFile:file5.txt, permissions:755);";
 
-		assertTrue("Expected chmod touchpointData instruction '" + expectedTouchpointDataInstruction + "' not found.",
-				iuHasTouchpointDataInstruction(featureRootIus.iterator().next(), expectedTouchpointDataInstruction));
+		assertTrue(iuHasTouchpointDataInstruction(featureRootIus.iterator().next(), expectedTouchpointDataInstruction),
+				"Expected chmod touchpointData instruction '" + expectedTouchpointDataInstruction + "' not found.");
 		// permission defined in build.properties: root.linux.gtk.x86_64.permissions.555
 		// = **/*.so
 		Element linuxRootIu = findIU(contentXml, "prf.feature_root.gtk.linux.x86_64").iterator().next();
 
 		String chmod555Instruction = "chmod(targetDir:${installFolder}, targetFile:dir/test.so, permissions:555);";
 
-		assertTrue("Expected chmod touchpointData instruction '" + chmod555Instruction + "' not found.",
-				iuHasTouchpointDataInstruction(linuxRootIu, chmod555Instruction));
+		assertTrue(iuHasTouchpointDataInstruction(linuxRootIu, chmod555Instruction),
+				"Expected chmod touchpointData instruction '" + chmod555Instruction + "' not found.");
 	}
 
 	static void assertRootIuLinksMetaData(Document contentXml) {
@@ -258,11 +253,9 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 
 		String expectedGlobalTouchpointDataInstruction = "ln(linkTarget:dir/file6.txt,targetDir:${installFolder},linkName:alias_file6.txt);";
 
-		assertTrue(
-				"Expected link (ln) touchpointData instruction '" + expectedGlobalTouchpointDataInstruction
-						+ "' not found.",
-				iuHasTouchpointDataInstruction(globalFeatureRootIus.iterator().next(),
-						expectedGlobalTouchpointDataInstruction));
+		assertTrue(iuHasTouchpointDataInstruction(globalFeatureRootIus.iterator().next(),
+						expectedGlobalTouchpointDataInstruction), "Expected link (ln) touchpointData instruction '" + expectedGlobalTouchpointDataInstruction
+						+ "' not found.");
 
 		// specific link defined in build.properties: root.linux.gtk.x86_64.link =
 		// file1.txt,alias_file1.txt
@@ -270,18 +263,16 @@ public class Tycho465RootFilesTest extends AbstractTychoIntegrationTest {
 
 		String expectedSpecificTouchpointDataInstruction = "ln(linkTarget:file1.txt,targetDir:${installFolder},linkName:alias_file1.txt);";
 
-		assertTrue(
-				"Expected link (ln) touchpointData instruction '" + expectedSpecificTouchpointDataInstruction
-						+ "' not found.",
-				iuHasTouchpointDataInstruction(specificRootfeatureIus.iterator().next(),
-						expectedSpecificTouchpointDataInstruction));
+		assertTrue(iuHasTouchpointDataInstruction(specificRootfeatureIus.iterator().next(),
+						expectedSpecificTouchpointDataInstruction), "Expected link (ln) touchpointData instruction '" + expectedSpecificTouchpointDataInstruction
+						+ "' not found.");
 	}
 
 	private static Document openMetadataRepositoryDocument(File repositoryTargetDirectory)
 			throws IOException, ZipException {
 
 		File contentJar = new File(repositoryTargetDirectory, "content.jar");
-		assertTrue("content.jar not found \n" + contentJar.getAbsolutePath(), contentJar.isFile());
+		assertTrue(contentJar.isFile(), "content.jar not found \n" + contentJar.getAbsolutePath());
 
 		return openXmlFromZip(contentJar, "content.xml");
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/reactor/BomCreationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/reactor/BomCreationTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.reactor;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
@@ -30,13 +30,13 @@ import org.cyclonedx.model.Dependency;
 import org.cyclonedx.parsers.Parser;
 import org.cyclonedx.parsers.XmlParser;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BomCreationTest extends AbstractTychoIntegrationTest {
 	private static Verifier verifier;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		if (verifier == null) {
 			verifier = getVerifier("sbom", false);

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/reactor/makeBehaviour/MavenReactorMakeOptionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/reactor/makeBehaviour/MavenReactorMakeOptionsTest.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.reactor.makeBehaviour;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Maven reactor make behaviors
@@ -41,7 +41,7 @@ public class MavenReactorMakeOptionsTest extends AbstractTychoIntegrationTest {
 
 	private Verifier verifier;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		verifier = getVerifier("reactor.makeBehaviour", false, true);
 		verifier.addCliOption("-T1C");
@@ -137,8 +137,8 @@ public class MavenReactorMakeOptionsTest extends AbstractTychoIntegrationTest {
 	@Test
 	public void testSingleProjectNoOptionFails() throws Exception {
 		verifier.addCliOption("-pl feature1");
-		assertThrows("Build should fail due to missing reactor dependency", VerificationException.class,
-				() -> verifier.executeGoals(List.of("clean", "verify")));
+		assertThrows(VerificationException.class, () -> verifier.executeGoals(List.of("clean", "verify")),
+				"Build should fail due to missing reactor dependency");
 		verifier.verifyTextInLog(
 				"Missing requirement: feature1.feature.group 1.0.0.qualifier requires 'org.eclipse.equinox.p2.iu; bundle1 0.0.0' but it could not be found");
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/reproducible/ReproducibleBuildTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/reproducible/ReproducibleBuildTest.java
@@ -23,8 +23,8 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that the build artifacts produced by Tycho are reproducible.
@@ -79,7 +79,7 @@ public class ReproducibleBuildTest extends AbstractTychoIntegrationTest {
 			final var entries = zip.entries();
 			while (entries.hasMoreElements()) {
 				final ZipEntry entry = entries.nextElement();
-				Assert.assertEquals(EXPECTED_TIMESTAMP_INSTANT, entry.getLastModifiedTime().toInstant());
+				Assertions.assertEquals(EXPECTED_TIMESTAMP_INSTANT, entry.getLastModifiedTime().toInstant());
 			}
 		}
 	}
@@ -96,7 +96,7 @@ public class ReproducibleBuildTest extends AbstractTychoIntegrationTest {
 		try (FileSystem fileSystem = FileSystems.newFileSystem(Path.of(file))) {
 			final Path manifest = fileSystem.getPath("META-INF/MANIFEST.MF");
 			final List<String> lines = Files.readAllLines(manifest);
-			Assert.assertTrue(lines.stream().anyMatch(l -> l.equals("Bundle-Version: 1.0.0.202301010000")));
+			Assertions.assertTrue(lines.stream().anyMatch(l -> l.equals("Bundle-Version: 1.0.0.202301010000")));
 		}
 	}
 
@@ -110,7 +110,7 @@ public class ReproducibleBuildTest extends AbstractTychoIntegrationTest {
 		try (FileSystem fileSystem = FileSystems.newFileSystem(Path.of(file))) {
 			final Path propFile = fileSystem.getPath("OSGI-INF/l10n/bundle-src.properties");
 			final String content = Files.readString(propFile, StandardCharsets.ISO_8859_1);
-			Assert.assertEquals("bundleName=Reproducible-bundle Source\n" + "bundleVendor=unknown\n", content);
+			Assertions.assertEquals("bundleName=Reproducible-bundle Source\n" + "bundleVendor=unknown\n", content);
 		}
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/BundleNativeCodeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/BundleNativeCodeTest.java
@@ -11,7 +11,7 @@ package org.eclipse.tycho.test.resolver;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BundleNativeCodeTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/CycleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/CycleTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CycleTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ExtraCompilerRequirementsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ExtraCompilerRequirementsTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // tests the various use cases of extraRequirements (bug 363331)
 public class ExtraCompilerRequirementsTest extends AbstractTychoIntegrationTest {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/JustJJRETest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/JustJJRETest.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JustJJRETest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/OptionalDependenciesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/OptionalDependenciesTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.resolver;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // tests that optional dependencies are put on the compile class path (bug 351842)
 public class OptionalDependenciesTest extends AbstractTychoIntegrationTest {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/P2CapabilityTransportTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.resolver;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for OSGi capability resolution with Provide-Capability and Require-Capability.
@@ -67,7 +67,7 @@ public class P2CapabilityTransportTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 
 		File file = new File(verifier.getBasedir(), "client.bundle/target/dependencies-list.txt");
-		assertTrue("dependencies-list.txt was not generated for client.bundle", file.exists());
+		assertTrue(file.exists(), "dependencies-list.txt was not generated for client.bundle");
 		List<String> fileNames = new ArrayList<>();
 		try (BufferedReader reader = Files.newBufferedReader(file.toPath())) {
 			String line;
@@ -77,10 +77,10 @@ public class P2CapabilityTransportTest extends AbstractTychoIntegrationTest {
 				}
 			}
 		}
-		assertTrue("consumer.bundle jar not found in client.bundle dependencies: " + fileNames,
-				fileNames.stream().anyMatch(name -> name.startsWith("consumer.bundle-")));
-		assertTrue("provider.bundle jar not found in client.bundle dependencies: " + fileNames,
-				fileNames.stream().anyMatch(name -> name.startsWith("provider.bundle-")));
+		assertTrue(fileNames.stream().anyMatch(name -> name.startsWith("consumer.bundle-")),
+				"consumer.bundle jar not found in client.bundle dependencies: " + fileNames);
+		assertTrue(fileNames.stream().anyMatch(name -> name.startsWith("provider.bundle-")),
+				"provider.bundle jar not found in client.bundle dependencies: " + fileNames);
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/PomDependenciesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/PomDependenciesTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.resolver;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PomDependenciesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ReexportedRequireBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ReexportedRequireBundleTest.java
@@ -11,7 +11,7 @@ package org.eclipse.tycho.test.resolver;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReexportedRequireBundleTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ResolverTests.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ResolverTests.java
@@ -9,15 +9,15 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.resolver;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ResolverTests extends AbstractTychoIntegrationTest {
 
@@ -103,8 +103,8 @@ public class ResolverTests extends AbstractTychoIntegrationTest {
 				startLine = line.endsWith("Resolved fragments:");
 			}
 		}
-		assertTrue("Start line not found!", startLine);
-		assertTrue("Highest version was not found", highestVersionFound);
+		assertTrue(startLine, "Start line not found!");
+		assertTrue(highestVersionFound, "Highest version was not found");
 	}
 
 	@Test
@@ -115,7 +115,7 @@ public class ResolverTests extends AbstractTychoIntegrationTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	// Due to technical reasons, the Maven artifact is rebundled during the
 	// target-platform phase.
 	// Therefore dependency:tree lists it as 'wrapped.com.squareup.okhttp3.okhttp'

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/SplitPackagesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/SplitPackagesTest.java
@@ -11,7 +11,7 @@ package org.eclipse.tycho.test.resolver;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SplitPackagesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/Tycho1127AddjarsIssueTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/Tycho1127AddjarsIssueTest.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho1127AddjarsIssueTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/TychoGenerateSourcesIssueTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/TychoGenerateSourcesIssueTest.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TychoGenerateSourcesIssueTest extends AbstractTychoIntegrationTest {
     @Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sbom/SbomPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sbom/SbomPluginTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.sbom;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,7 +22,7 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.EnvironmentUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SbomPluginTest extends AbstractTychoIntegrationTest {
 
@@ -33,8 +33,8 @@ public class SbomPluginTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 		Path basedir = Path.of(verifier.getBasedir());
-		assertTrue("sbom.xml is missing!", Files.isRegularFile(basedir.resolve("target/sbom-simple-product.xml")));
-		assertTrue("sbom.json is missing!", Files.isRegularFile(basedir.resolve("target/sbom-simple-product.json")));
+		assertTrue(Files.isRegularFile(basedir.resolve("target/sbom-simple-product.xml")), "sbom.xml is missing!");
+		assertTrue(Files.isRegularFile(basedir.resolve("target/sbom-simple-product.json")), "sbom.json is missing!");
 	}
 
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/selundqma/SeLundqmaTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/selundqma/SeLundqmaTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.selundqma;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SeLundqmaTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/AutoGenerateSourceArtifactsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/AutoGenerateSourceArtifactsTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.sourceBundle;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AutoGenerateSourceArtifactsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/AutoNoSourceBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/AutoNoSourceBundleTest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.sourceBundle;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AutoNoSourceBundleTest extends AbstractTychoIntegrationTest {
 
@@ -27,8 +27,8 @@ public class AutoNoSourceBundleTest extends AbstractTychoIntegrationTest {
 		// missing source bundles (see bug 367637)
 
 		Verifier verifier = getVerifier("/sourceBundle.autoSkip", false);
-		assertThrows("Reference to a missing source bundle did not fail the build", VerificationException.class,
-				() -> verifier.executeGoal("verify"));
+		assertThrows(VerificationException.class, () -> verifier.executeGoal("verify"),
+				"Reference to a missing source bundle did not fail the build");
 		verifier.verifyTextInLog(
 				"feature.feature.group 1.0.0.qualifier requires 'org.eclipse.equinox.p2.iu; bundle.source 0.0.0' but it could not be found");
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/MultiReleaseSourceBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/MultiReleaseSourceBundleTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.sourceBundle;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -26,7 +26,7 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Integration test for multi-release JAR source bundle support.
@@ -44,22 +44,21 @@ public class MultiReleaseSourceBundleTest extends AbstractTychoIntegrationTest {
         
         File sourceBundle = new File(verifier.getBasedir(), 
                 "target/bundle.multiRelease-1.0.0-SNAPSHOT-sources.jar");
-        assertTrue("Missing expected source bundle: " + sourceBundle, sourceBundle.exists());
+        assertTrue(sourceBundle.exists(), "Missing expected source bundle: " + sourceBundle);
         
         try (ZipFile zip = new ZipFile(sourceBundle)) {
             // Verify base source files are included
-            assertTrue("Base source Main.java not found", 
-                    findEntry(zip, "tycho/mr/example/Main.java").isPresent());
-            assertTrue("Base source HttpClient.java not found", 
-                    findEntry(zip, "tycho/mr/example/HttpClient.java").isPresent());
+            assertTrue(findEntry(zip, "tycho/mr/example/Main.java").isPresent(), "Base source Main.java not found");
+            assertTrue(findEntry(zip, "tycho/mr/example/HttpClient.java").isPresent(),
+            		"Base source HttpClient.java not found");
             
             // Verify multi-release source files for Java 9 are included
-            assertTrue("Multi-release source for Java 9 not found", 
-                    findEntry(zip, "META-INF/versions/9/tycho/mr/example/HttpClient.java").isPresent());
+            assertTrue(findEntry(zip, "META-INF/versions/9/tycho/mr/example/HttpClient.java").isPresent(),
+            		"Multi-release source for Java 9 not found");
             
             // Verify multi-release source files for Java 11 are included
-            assertTrue("Multi-release source for Java 11 not found", 
-                    findEntry(zip, "META-INF/versions/11/tycho/mr/example/HttpClient.java").isPresent());
+            assertTrue(findEntry(zip, "META-INF/versions/11/tycho/mr/example/HttpClient.java").isPresent(),
+            		"Multi-release source for Java 11 not found");
         }
     }
     

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/PDESourceHeaderGenerationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/PDESourceHeaderGenerationTest.java
@@ -1,6 +1,6 @@
 package org.eclipse.tycho.test.sourceBundle;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Files;

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/SourceBundlesNestedJarsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/SourceBundlesNestedJarsTest.java
@@ -13,9 +13,9 @@
 package org.eclipse.tycho.test.sourceBundle;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashSet;
@@ -24,7 +24,7 @@ import java.util.jar.JarFile;
 import org.apache.maven.it.Verifier;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SourceBundlesNestedJarsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/TychoSourcePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/sourceBundle/TychoSourcePluginTest.java
@@ -13,9 +13,9 @@
 package org.eclipse.tycho.test.sourceBundle;
 
 import static org.eclipse.tycho.test.util.ResourceUtil.P2Repositories.ECLIPSE_342;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +31,7 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import eu.maveniverse.domtrip.Document;
 
@@ -47,43 +47,40 @@ public class TychoSourcePluginTest extends AbstractTychoIntegrationTest {
 				"sourcefeature.repository/target/repository/features/sourcefeature.feature_1.0.0.123abc.jar");
 		File sourceFeature = new File(verifier.getBasedir(),
 				"sourcefeature.repository/target/repository/features/sourcefeature.feature.source_1.0.0.123abc.jar");
-		assertTrue("Missing expected file " + feature, feature.canRead());
-		assertTrue("Missing expected file " + sourceFeature, sourceFeature.canRead());
+		assertTrue(feature.canRead(), "Missing expected file " + feature);
+		assertTrue(sourceFeature.canRead(), "Missing expected file " + sourceFeature);
 
 		try (ZipFile featureZip = new ZipFile(feature); ZipFile sourceFeatureZip = new ZipFile(sourceFeature)) {
-			assertTrue("Missing expected file featrue.properties in " + feature,
-					findEntry(featureZip, "feature.properties").isPresent());
+			assertTrue(findEntry(featureZip, "feature.properties").isPresent(),
+					"Missing expected file featrue.properties in " + feature);
 
-			assertTrue("Content of sourceTemplateFeature not included",
-					findEntry(sourceFeatureZip, "feature.properties").isPresent());
+			assertTrue(findEntry(sourceFeatureZip, "feature.properties").isPresent(),
+					"Content of sourceTemplateFeature not included");
 
 			// Test for bug 552066
-			assertTrue("license.html not found in " + feature, findEntry(featureZip, "license.html").isPresent());
-			assertTrue("bin-only.txt not found in " + feature, findEntry(featureZip, "bin-only.txt").isPresent());
-			assertTrue("src-only.txt found in " + feature, findEntry(featureZip, "src-only.txt").isEmpty());
-			assertTrue("license.html not found in " + sourceFeature,
-					findEntry(sourceFeatureZip, "license.html").isPresent());
-			assertTrue("bin-only.txt found in " + sourceFeature, findEntry(sourceFeatureZip, "bin-only.txt").isEmpty());
-			assertTrue("src-only.txt not found in " + sourceFeature,
-					findEntry(sourceFeatureZip, "src-only.txt").isPresent());
+			assertTrue(findEntry(featureZip, "license.html").isPresent(), "license.html not found in " + feature);
+			assertTrue(findEntry(featureZip, "bin-only.txt").isPresent(), "bin-only.txt not found in " + feature);
+			assertTrue(findEntry(featureZip, "src-only.txt").isEmpty(), "src-only.txt found in " + feature);
+			assertTrue(findEntry(sourceFeatureZip, "license.html").isPresent(), "license.html not found in " + sourceFeature);
+			assertTrue(findEntry(sourceFeatureZip, "bin-only.txt").isEmpty(), "bin-only.txt found in " + sourceFeature);
+			assertTrue(findEntry(sourceFeatureZip, "src-only.txt").isPresent(), "src-only.txt not found in " + sourceFeature);
 		}
 		// Test Bug 374349
 		Document sourceFeatureXml = parseFeatureXml(sourceFeature);
-		assertEquals("Wrong label - bug 374349", "%label",
-				sourceFeatureXml.root().attribute("label"));
+		assertEquals("%label", sourceFeatureXml.root().attribute("label"), "Wrong label - bug 374349");
 		// Test bug 407706
 		assertNull(sourceFeatureXml.root().attributeObject("plugin"));
 
 		File indirectFeature = new File(verifier.getBasedir(),
 				"sourcefeature.repository/target/repository/features/sourcefeature.feature.indirect.source_1.0.0.123abc.jar");
-		assertTrue("Missing expected file " + indirectFeature, indirectFeature.canRead());
+		assertTrue(indirectFeature.canRead(), "Missing expected file " + indirectFeature);
 
 		Document indirectFeatureXml = parseFeatureXml(indirectFeature);
 //		// Test bug 407706
 		assertEquals("sourcefeature.bundle", indirectFeatureXml.root().attribute("plugin"));
 		File bundle = new File(verifier.getBasedir(),
 				"sourcefeature.repository/target/repository/plugins/sourcefeature.bundle.source_1.0.0.123abc.jar");
-		assertTrue("Missing expected file " + bundle, bundle.canRead());
+		assertTrue(bundle.canRead(), "Missing expected file " + bundle);
 	}
 
 	private Document parseFeatureXml(File file) throws IOException {
@@ -107,7 +104,7 @@ public class TychoSourcePluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(),
 				"sourcefeature.repository/target/repository/plugins/extra.sourcefeature.bundle_1.0.0.123abc.jar");
-		assertTrue("Missing expected file", file.canRead());
+		assertTrue(file.canRead(), "Missing expected file");
 	}
 
 	@Test
@@ -117,12 +114,12 @@ public class TychoSourcePluginTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoals(List.of("clean", "install"));
 		verifier.verifyErrorFreeLog();
 		File sourceFeature = new File(verifier.getBasedir(), "feature/target/feature-1.0.0-sources-feature.jar");
-		assertTrue("Missing expected file " + sourceFeature, sourceFeature.canRead());
+		assertTrue(sourceFeature.canRead(), "Missing expected file " + sourceFeature);
 		ZipFile featureZip = new ZipFile(sourceFeature);
-		assertTrue("feature.properties not found in " + sourceFeature,
-				findEntry(featureZip, "feature.properties").isPresent());
+		assertTrue(findEntry(featureZip, "feature.properties").isPresent(),
+				"feature.properties not found in " + sourceFeature);
 		// test for bug 403950
-		assertTrue("license.html not found in " + sourceFeature, findEntry(featureZip, "license.html").isPresent());
+		assertTrue(findEntry(featureZip, "license.html").isPresent(), "license.html not found in " + sourceFeature);
 		// test bug 395773
 		Properties actual = new Properties();
 		actual.load(featureZip.getInputStream(featureZip.getEntry("feature.properties")));
@@ -142,10 +139,10 @@ public class TychoSourcePluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(),
 				"sourcefeature.repository/target/repository/plugins/org.junit.source_4.13.2.v20240929-1000.jar");
-		assertTrue("Missing expected file " + file.getName(), file.canRead());
+		assertTrue(file.canRead(), "Missing expected file " + file.getName());
 		file = new File(verifier.getBasedir(),
 				"sourcefeature.repository/target/repository/plugins/org.hamcrest.core.source_2.2.0.v20230809-1000.jar");
-		assertTrue("Missing expected file " + file.getName(), file.canRead());
+		assertTrue(file.canRead(), "Missing expected file " + file.getName());
 
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/BundleStartInSurefireTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/BundleStartInSurefireTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BundleStartInSurefireTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/CategoriesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/CategoriesTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CategoriesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/DirectTestPluginInvocationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/DirectTestPluginInvocationTest.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DirectTestPluginInvocationTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/EnableAssertionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/EnableAssertionsTest.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.surefire;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EnableAssertionsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/EnvVarTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/EnvVarTest.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EnvVarTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/ExplodedTestDependenciesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/ExplodedTestDependenciesTest.java
@@ -16,8 +16,8 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ExplodedTestDependenciesTest extends AbstractTychoIntegrationTest {
 
@@ -32,7 +32,7 @@ public class ExplodedTestDependenciesTest extends AbstractTychoIntegrationTest {
 		// jars are accessible as file URLs
 		File antHome = new File(v01.getBasedir(),
 				"tycho340.test/target/work/plugins/org.apache.ant_1.10.17.v20260410-1000");
-		Assert.assertTrue(antHome.isDirectory());
+		Assertions.assertTrue(antHome.isDirectory());
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/ExtraTestApplicationArgumentsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/ExtraTestApplicationArgumentsTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExtraTestApplicationArgumentsTest extends AbstractTychoIntegrationTest {
     @Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/FailIfNoTestsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/FailIfNoTestsTest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.surefire;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FailIfNoTestsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/FrameworkExtensionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/FrameworkExtensionsTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FrameworkExtensionsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit4Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit4Test.java
@@ -13,13 +13,13 @@
 package org.eclipse.tycho.test.surefire;
 
 import static org.eclipse.tycho.test.util.SurefireUtil.testResultFile;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JUnit4Test extends AbstractTychoIntegrationTest {
 
@@ -97,7 +97,7 @@ public class JUnit4Test extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("integration-test");
 		verifier.verifyErrorFreeLog();
 		File testResultFile = testResultFile(verifier.getBasedir(), "contextclassloader.test", "JUnit4Test");
-		assertTrue("Test Result File" + testResultFile + " is missing", testResultFile.exists());
+		assertTrue(testResultFile.exists(), "Test Result File" + testResultFile + " is missing");
 
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit5TempDirTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JUnit5TempDirTest.java
@@ -4,7 +4,7 @@ import static org.eclipse.tycho.test.util.SurefireUtil.assertTestMethodWasSucces
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JUnit5TempDirTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JVMArgsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JVMArgsTest.java
@@ -16,8 +16,8 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JVMArgsTest extends AbstractTychoIntegrationTest {
 
@@ -30,6 +30,6 @@ public class JVMArgsTest extends AbstractTychoIntegrationTest {
 
         File testReport = new File(verifier.getBasedir(),
                 "bundle.tests/target/surefire-reports/TEST-bundle.tests.SystemPropertyTest.xml");
-        Assert.assertTrue(testReport.exists());
+        Assertions.assertTrue(testReport.exists());
     }
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JavaToolchainInSurefireTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/JavaToolchainInSurefireTest.java
@@ -13,7 +13,7 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JavaToolchainInSurefireTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/OpenTest4JTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/OpenTest4JTest.java
@@ -19,7 +19,7 @@ import static org.eclipse.tycho.test.util.SurefireUtil.assertNumberOfSuccessfulT
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OpenTest4JTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/P2InstalledTestRuntimeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/P2InstalledTestRuntimeTest.java
@@ -18,7 +18,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.TargetEnvironment;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class P2InstalledTestRuntimeTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/ParallelTestExecutionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/ParallelTestExecutionTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.tycho.test.surefire;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -26,7 +26,7 @@ import java.util.Set;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.XMLTool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/RequireBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/RequireBundleTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RequireBundleTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/RunOrderTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/RunOrderTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RunOrderTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/RunSingleTestTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/RunSingleTestTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RunSingleTestTest extends AbstractTychoIntegrationTest {
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/SystemPropertiesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/SystemPropertiesTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SystemPropertiesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestBundleShapeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestBundleShapeTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestBundleShapeTest extends AbstractTychoIntegrationTest {
     @Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestFragmentTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestFragmentTest.java
@@ -16,8 +16,8 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestFragmentTest extends AbstractTychoIntegrationTest {
 
@@ -29,6 +29,6 @@ public class TestFragmentTest extends AbstractTychoIntegrationTest {
         verifier.verifyErrorFreeLog();
 
         File testReport = new File(verifier.getBasedir(), "p1.test/target/surefire-reports/TEST-p1.test.ATest.xml");
-        Assert.assertTrue(testReport.exists());
+        Assertions.assertTrue(testReport.exists());
     }
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestNGBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestNGBundleTest.java
@@ -13,13 +13,13 @@
 package org.eclipse.tycho.test.surefire;
 
 import static org.eclipse.tycho.test.util.SurefireUtil.testResultFile;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestNGBundleTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestOptionalDependenciesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestOptionalDependenciesTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.surefire;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestOptionalDependenciesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestsInBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestsInBundleTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.surefire;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestsInBundleTest extends AbstractTychoIntegrationTest {
 
@@ -30,10 +30,10 @@ public class TestsInBundleTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
 		verifier.executeGoals(Arrays.asList("clean", "test-compile"));
 		verifier.verifyErrorFreeLog();
-		assertTrue("compiled class file does not exist",
-				new File(verifier.getBasedir(), "target/classes/bundle/test/Counter.class").exists());
-		assertTrue("compiled test-class file does not exist",
-				new File(verifier.getBasedir(), "target/test-classes/bundle/test/AdderTest.class").exists());
+		assertTrue(new File(verifier.getBasedir(), "target/classes/bundle/test/Counter.class").exists(),
+				"compiled class file does not exist");
+		assertTrue(new File(verifier.getBasedir(), "target/test-classes/bundle/test/AdderTest.class").exists(),
+				"compiled test-class file does not exist");
 	}
 
 	@Test
@@ -41,17 +41,17 @@ public class TestsInBundleTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = getVerifier("surefire.combinedtests/bundle5.test");
 		verifier.executeGoals(Arrays.asList("clean", "test-compile"));
 		verifier.verifyErrorFreeLog();
-		assertTrue("compiled class file does not exist",
-				new File(verifier.getBasedir(), "target/classes/bundle/test/Counter.class").exists());
-		assertTrue("compiled test-class file does not exist",
-				new File(verifier.getBasedir(), "target/test-classes/bundle/test/AdderTest.class").exists());
+		assertTrue(new File(verifier.getBasedir(), "target/classes/bundle/test/Counter.class").exists(),
+				"compiled class file does not exist");
+		assertTrue(new File(verifier.getBasedir(), "target/test-classes/bundle/test/AdderTest.class").exists(),
+				"compiled test-class file does not exist");
 	}
 
 	@Test
 	public void testCompile5WithoutVintage() throws Exception {
 		Verifier verifier = getVerifier("surefire.combinedtests/bundle5.no.vintage.test");
-		assertThrows("Compilation must fail because the usage of junit 4 annotations", VerificationException.class,
-				() -> verifier.executeGoals(Arrays.asList("clean", "test-compile")));
+		assertThrows(VerificationException.class, () -> verifier.executeGoals(Arrays.asList("clean", "test-compile")),
+				"Compilation must fail because the usage of junit 4 annotations");
 		verifier.verifyTextInLog("The import org.junit.Assert cannot be resolved");
 		verifier.verifyTextInLog("The import org.junit.Test cannot be resolved");
 	}
@@ -61,8 +61,8 @@ public class TestsInBundleTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
 		verifier.executeGoals(Arrays.asList("clean", "test"));
 		verifier.verifyErrorFreeLog();
-		assertTrue("tests were not run",
-				new File(verifier.getBasedir(), "target/surefire-reports/bundle.test.AdderTest.txt").exists());
+		assertTrue(new File(verifier.getBasedir(), "target/surefire-reports/bundle.test.AdderTest.txt").exists(),
+				"tests were not run");
 	}
 
 	@Test
@@ -70,8 +70,8 @@ public class TestsInBundleTest extends AbstractTychoIntegrationTest {
 		Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
 		verifier.executeGoals(Arrays.asList("clean", "integration-test"));
 		verifier.verifyErrorFreeLog();
-		assertTrue("summary report not found",
-				new File(verifier.getBasedir(), "target/failsafe-reports/failsafe-summary.xml").exists());
+		assertTrue(new File(verifier.getBasedir(), "target/failsafe-reports/failsafe-summary.xml").exists(),
+				"summary report not found");
 		verifier.verifyTextInLog("Tests run: 2, Failures: 1, Errors: 0, Skipped: 0");
 		verifier.verifyTextInLog("OSGiRunningIT.willFail:30 This fail is intentional");
 	}
@@ -79,8 +79,8 @@ public class TestsInBundleTest extends AbstractTychoIntegrationTest {
 	@Test
 	public void testVerify() throws Exception {
 		Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
-		assertThrows("the build succeed but test-failures are expected!", VerificationException.class,
-				() -> verifier.executeGoals(Arrays.asList("clean", "verify")));
+		assertThrows(VerificationException.class, () -> verifier.executeGoals(Arrays.asList("clean", "verify")),
+				"the build succeed but test-failures are expected!");
 		// thats good indeed...
 		verifier.verifyTextInLog("There are test failures");
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TrimStackTrace.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TrimStackTrace.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.surefire;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TrimStackTrace extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TwoJunitVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TwoJunitVersionsTest.java
@@ -16,7 +16,7 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // regression test for TYCHO-380
 // TODO is this case really tested? The target platform only a single JUnit version!

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/symlinks/SymbolicLinkTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/symlinks/SymbolicLinkTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.symlinks;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -20,8 +20,8 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class SymbolicLinkTest extends AbstractTychoIntegrationTest {
 
@@ -30,7 +30,7 @@ public class SymbolicLinkTest extends AbstractTychoIntegrationTest {
 
 	private static Verifier verifier;
 
-	@BeforeClass
+	@BeforeAll
 	public static void checkLinkCreation() throws Exception {
 		SymbolicLinkTest instance = new SymbolicLinkTest();
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/DifferentTargetFilesSameAbsolutePathTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/DifferentTargetFilesSameAbsolutePathTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DifferentTargetFilesSameAbsolutePathTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/OfflineModeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/OfflineModeTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.target;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,20 +25,20 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class OfflineModeTest extends AbstractTychoIntegrationTest {
 
 	private HttpServer server;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer();
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		server.stop();
 	}
@@ -84,7 +84,7 @@ public class OfflineModeTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("integration-test");
 		verifier.verifyErrorFreeLog();
 		Set<String> urls = new LinkedHashSet<>(server.getAccessedUrls("test"));
-		assertTrue(urls.toString(), urls.isEmpty());
+		assertTrue(urls.isEmpty(), urls.toString());
 	}
 
 	private void runAndVerifyOnlineBuild(Verifier verifier) throws VerificationException {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedCompositeP2RepositoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedCompositeP2RepositoryTest.java
@@ -20,9 +20,9 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PasswordProtectedCompositeP2RepositoryTest extends AbstractTychoIntegrationTest {
 
@@ -35,7 +35,7 @@ public class PasswordProtectedCompositeP2RepositoryTest extends AbstractTychoInt
 	private HttpServer authMirror;
 	private String p2AuthMirrorUrl;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer("test-user", "test-password");
 		p2RepoUrl = server.addServer("foo", ResourceUtil.resolveTestResource("repositories/issue_2331_reproducer"))
@@ -50,7 +50,7 @@ public class PasswordProtectedCompositeP2RepositoryTest extends AbstractTychoInt
 				ResourceUtil.resolveTestResource("repositories/issue_2331_reproducer")) + "/bundles";
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		authMirror.stop();
 		mirror.stop();

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedM2RepositoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedM2RepositoryTest.java
@@ -20,22 +20,22 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PasswordProtectedM2RepositoryTest extends AbstractTychoIntegrationTest {
 
 	private HttpServer server;
 	private String m2RepoUrl;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer("test-user", "test-password");
 		m2RepoUrl = server.addServer("foo", ResourceUtil.resolveTestResource("repositories/m2"));
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		server.stop();
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedP2RepositoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedP2RepositoryTest.java
@@ -19,9 +19,9 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PasswordProtectedP2RepositoryTest extends AbstractTychoIntegrationTest {
 
@@ -34,7 +34,7 @@ public class PasswordProtectedP2RepositoryTest extends AbstractTychoIntegrationT
 	private HttpServer authMirror;
 	private String p2AuthMirrorUrl;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer("test-user", "test-password");
 		p2RepoUrl = server.addServer("foo", ResourceUtil.resolveTestResource("repositories/e342"));
@@ -46,7 +46,7 @@ public class PasswordProtectedP2RepositoryTest extends AbstractTychoIntegrationT
 		p2AuthMirrorUrl = authMirror.addServer("bar", ResourceUtil.resolveTestResource("repositories/e342"));
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		authMirror.stop();
 		mirror.stop();

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetDefinitionPackagingTypeTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetDefinitionPackagingTypeTest.java
@@ -20,8 +20,8 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TargetDefinitionPackagingTypeTest extends AbstractTychoIntegrationTest {
 
@@ -33,7 +33,7 @@ public class TargetDefinitionPackagingTypeTest extends AbstractTychoIntegrationT
 	private Verifier verifier;
 	private File targetDefinitionFile;
 
-	@Before
+	@BeforeEach
 	public void prepare() throws Exception {
 		verifier = getVerifier("target.packagingType", false);
 		// make sure target is not installed already

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetDependenciesAccrossLocationsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetDependenciesAccrossLocationsTest.java
@@ -1,6 +1,6 @@
 package org.eclipse.tycho.test.target;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,9 +14,9 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 public class TargetDependenciesAccrossLocationsTest extends AbstractTychoIntegrationTest {
@@ -25,7 +25,7 @@ public class TargetDependenciesAccrossLocationsTest extends AbstractTychoIntegra
 	private String repoAUrl;
 	private String repoBUrl;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer();
 		repoAUrl = server.addServer("repoA",
@@ -34,7 +34,7 @@ public class TargetDependenciesAccrossLocationsTest extends AbstractTychoIntegra
 				ResourceUtil.resolveTestResource("repositories/target.dependenciesAcrossLocations/repoB"));
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		if (server != null) {
 			server.stop();

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformArtifactJUnitTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformArtifactJUnitTest.java
@@ -4,13 +4,13 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 // See PR https://github.com/eclipse-tycho/tycho/pull/1773
 public class TargetPlatformArtifactJUnitTest extends AbstractTychoIntegrationTest {
 	@Test
-	@Ignore("No longer works, needs update to more recent examples")
+	@Disabled("No longer works, needs update to more recent examples")
 	public void testTargetPlatformForJUnit5() throws Exception {
 		Verifier verifier = getVerifier("target.artifact.junit", false, true);
 		verifier.executeGoals(List.of("clean", "verify"));

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformEagerResolverTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformEagerResolverTest.java
@@ -10,7 +10,7 @@ package org.eclipse.tycho.test.target;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformFilteringIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformFilteringIntegrationTest.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.target;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TargetPlatformFilteringIntegrationTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.target;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,9 +33,9 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.tycho.core.osgitools.DefaultBundleReader;
 import org.eclipse.tycho.core.osgitools.OsgiManifest;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 
@@ -45,11 +45,10 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
 		// check that there are no warnings
-		assertThrows("Warning about missing digest algorithm was printed to the log", VerificationException.class,
-				() -> {
+		assertThrows(VerificationException.class, () -> {
 					verifier.verifyTextInLog(
 							"No digest algorithm is available to verify download of osgi.bundle,org.apache.velocity");
-				});
+				}, "Warning about missing digest algorithm was printed to the log");
 	}
 
 	@Test
@@ -65,8 +64,8 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 		verifier.addCliOption("-DoutputAbsoluteArtifactFilename=true");
 		verifier.executeGoal("dependency:list");
 		verifier.verifyErrorFreeLog();
-		assertFalse("Location for Maven deps should not resolve to cache",
-				Files.readString(Path.of(verifier.getBasedir(), verifier.getLogFileName())).contains("p2/osgi"));
+		assertFalse(Files.readString(Path.of(verifier.getBasedir(), verifier.getLogFileName())).contains("p2/osgi"),
+				"Location for Maven deps should not resolve to cache");
 	}
 
 	@Test
@@ -87,7 +86,7 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 	}
 
 	@Test
-	@Ignore(value = "This test is flaky on the buildserver")
+	@Disabled(value = "This test is flaky on the buildserver")
 	public void testMavenLocationRepositories() throws Exception {
 		Verifier verifier = getVerifier("target.mavenRepos", false, true);
 		verifier.executeGoal("verify");
@@ -110,7 +109,7 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 				"target.test/plugins/osgi.annotation.bundle_0.0.1/META-INF/MANIFEST.MF");
 		DefaultBundleReader reader = new DefaultBundleReader();
 		OsgiManifest annotBundleManifest = reader.loadManifest(annotBundleManifestFile);
-		Assert.assertEquals("tycho.test.package", annotBundleManifest.getValue("Export-Package"));
+		Assertions.assertEquals("tycho.test.package", annotBundleManifest.getValue("Export-Package"));
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
 
@@ -119,8 +118,8 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 		Files.write(annotBundleManifestFile.toPath(), out, StandardOpenOption.WRITE,
 				StandardOpenOption.TRUNCATE_EXISTING);
 
-		assertThrows("Reference to the not exported package did not fail the build", VerificationException.class,
-				() -> verifier.executeGoal("verify"));
+		assertThrows(VerificationException.class, () -> verifier.executeGoal("verify"),
+				"Reference to the not exported package did not fail the build");
 		verifier.verifyTextInLog(
 				" Missing requirement: test.bundle 0.0.1.qualifier requires 'java.package; tycho.test.package 0.0.0' but it could not be found");
 	}
@@ -141,19 +140,19 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 					.findFirst();
 			sourceFeature.ifPresentOrElse(it -> {
 				Xpp3Dom[] requirements = it.getChild("requires").getChildren("required");
-				Assert.assertNotEquals("Expecting requirements for org.apache.commons.io.feature.source.feature.group",
-						0, requirements.length);
+				Assertions.assertNotEquals(0, requirements.length,
+						"Expecting requirements for org.apache.commons.io.feature.source.feature.group");
 				Optional<String> badRequirement = Stream.of(requirements)
 						.map(requirement -> requirement.getAttribute("name")).filter(name -> name == null
 								|| !name.endsWith(".source") && !name.endsWith(".source.feature.jar"))
 						.findFirst();
-				badRequirement.ifPresent(name -> Assert
+				badRequirement.ifPresent(name -> Assertions
 						.fail("All requirements are expected to be source requirements, but found '" + name + "'"));
 			}, () -> {
-				Assert.fail("Expecting to find source feature org.apache.commons.io.feature.source.feature.group");
+				Assertions.fail("Expecting to find source feature org.apache.commons.io.feature.source.feature.group");
 			});
 		} catch (IOException | XmlPullParserException e) {
-			Assert.fail("Expecting to find valid XML content at " + targetPlatformRepository);
+			Assertions.fail("Expecting to find valid XML content at " + targetPlatformRepository);
 		}
 	}
 
@@ -197,8 +196,8 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 	@Test
 	public void testMavenRewriteManifestNoInstruction() throws Exception {
 		Verifier verifier = getVerifier("target.maven-rewriteManifest-noInstruction", false, true);
-		assertThrows("Verification did not fail even if bnd instruction was missing.", VerificationException.class,
-				() -> verifier.executeGoal("verify"));
+		assertThrows(VerificationException.class, () -> verifier.executeGoal("verify"),
+				"Verification did not fail even if bnd instruction was missing.");
 		verifier.verifyTextInLog(
 				"Reason: The location must contain exactly one bnd instruction which must contain a symbolic name that differs from the original one.");
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetRestrictionThroughTargetFilesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetRestrictionThroughTargetFilesTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.target;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -21,7 +21,7 @@ import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TargetRestrictionThroughTargetFilesTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetVariableResolutionTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetVariableResolutionTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.target;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,15 +28,15 @@ import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.P2RepositoryTool;
 import org.eclipse.tycho.test.util.P2RepositoryTool.RepositoryReference;
 import org.eclipse.tycho.test.util.ResourceUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TargetVariableResolutionTest extends AbstractTychoIntegrationTest {
 	private HttpServer server;
 	private String baseurl;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer();
 		server.addServer("repo", ResourceUtil.resolveTestResource("repositories/javax.xml"));
@@ -46,7 +46,7 @@ public class TargetVariableResolutionTest extends AbstractTychoIntegrationTest {
 				: urlWithContextPath;
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		server.stop();
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/transport/P2TransportCacheTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/transport/P2TransportCacheTest.java
@@ -9,10 +9,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.transport;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 
 import org.apache.maven.it.Verifier;
@@ -20,11 +22,10 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * End-to-end test for the Tycho p2 transport cache. A small Tycho project
@@ -40,17 +41,17 @@ public class P2TransportCacheTest extends AbstractTychoIntegrationTest {
 	private static final String BUNDLE_ID = "tycho.its.p2cache.bundle";
 	private static final String ARTIFACT_PATH = "/plugins/" + BUNDLE_ID + "_1.0.0.jar";
 
-	@Rule
-	public final TemporaryFolder tempFolder = new TemporaryFolder();
+	@TempDir
+	Path tempFolder;
 
 	private HttpServer server;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer();
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		if (server != null) {
 			server.stop();
@@ -69,7 +70,7 @@ public class P2TransportCacheTest extends AbstractTychoIntegrationTest {
 		// Isolate Tycho's p2 transport cache from the developer's ~/.m2 so
 		// previous runs cannot mask a real fetch. The same directory is reused
 		// across both invocations below, so the second build must hit the cache.
-		File cacheDir = tempFolder.newFolder("tycho-transport-cache");
+		File cacheDir = Files.createDirectory(tempFolder.resolve("tycho-transport-cache")).toFile();
 		verifier.setSystemProperty("tycho.p2.transport.cache", cacheDir.getAbsolutePath());
 		// Tycho also surfaces resolved p2 artifacts under p2/osgi/bundle/... in
 		// the Maven local repository; wipe any leftover from a previous run.
@@ -79,14 +80,14 @@ public class P2TransportCacheTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 
 		int firstRunFetches = Collections.frequency(server.getAccessedUrls(REPO_ID), ARTIFACT_PATH);
-		assertTrue("Bundle JAR should be fetched on cold-cache build, accessed urls were: "
-				+ server.getAccessedUrls(REPO_ID), firstRunFetches >= 1);
+		assertTrue(firstRunFetches >= 1, "Bundle JAR should be fetched on cold-cache build, accessed urls were: "
+				+ server.getAccessedUrls(REPO_ID));
 
 		verifier.executeGoal("package");
 		verifier.verifyErrorFreeLog();
 
 		int secondRunFetches = Collections.frequency(server.getAccessedUrls(REPO_ID), ARTIFACT_PATH);
-		assertEquals("Bundle JAR was re-fetched on warm-cache build, accessed urls were: "
-				+ server.getAccessedUrls(REPO_ID), firstRunFetches, secondRunFetches);
+		assertEquals(firstRunFetches, secondRunFetches, "Bundle JAR was re-fetched on warm-cache build, accessed urls were: "
+				+ server.getAccessedUrls(REPO_ID));
 	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho001/P2MetadataGenerationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho001/P2MetadataGenerationTest.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.tycho001;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class P2MetadataGenerationTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho026/Tycho26MissingFeatureTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho026/Tycho26MissingFeatureTest.java
@@ -15,18 +15,22 @@ package org.eclipse.tycho.test.tycho026;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /* java -jar \eclipse\plugins\org.eclipse.equinox.launcher_1.0.1.R33x_v20080118.jar -application org.eclipse.update.core.siteOptimizer -digestBuilder -digestOutputDir=d:\temp\eclipse\digest -siteXML=D:\sonatype\workspace\tycho\tycho-its\projects\tycho129\tycho.demo.site\target\site\site.xml  -jarProcessor -processAll -pack -outputDir d:\temp\eclipse\site D:\sonatype\workspace\tycho\tycho-its\projects\tycho129\tycho.demo.site\target\site */
 public class Tycho26MissingFeatureTest extends AbstractTychoIntegrationTest {
 
-    @Test(expected = VerificationException.class)
+    @Test
     public void test() throws Exception {
         Verifier verifier = getVerifier("/tycho026");
         verifier.setAutoclean(false);
 
-        verifier.executeGoal("package");
-        verifier.verifyErrorFreeLog();
+        assertThrows(VerificationException.class, () -> {
+            verifier.executeGoal("package");
+            verifier.verifyErrorFreeLog();
+        });
     }
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho136/Tycho136GenerateFeatureTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho136/Tycho136GenerateFeatureTest.java
@@ -14,11 +14,11 @@ package org.eclipse.tycho.test.tycho136;
 
 import java.io.File;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho136GenerateFeatureTest extends AbstractTychoIntegrationTest {
 
@@ -31,9 +31,9 @@ public class Tycho136GenerateFeatureTest extends AbstractTychoIntegrationTest {
 
         File basedir = new File(verifier.getBasedir());
         File featureSource = new File(basedir, "SiteA/target/site/features/FeatureA.source_1.0.0.jar");
-        Assert.assertTrue("Site should generate FeatureA.source", featureSource.exists());
+        Assertions.assertTrue(featureSource.exists(), "Site should generate FeatureA.source");
 
         File featurePlugin = new File(basedir, "SiteA/target/site/plugins/FeatureA.source_1.0.0.jar");
-        Assert.assertTrue("Site should generate FeatureA.source Plugin", featurePlugin.exists());
+        Assertions.assertTrue(featurePlugin.exists(), "Site should generate FeatureA.source Plugin");
     }
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho136/Tycho136GenerateIndividualSourceBundlesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho136/Tycho136GenerateIndividualSourceBundlesTest.java
@@ -14,11 +14,11 @@ package org.eclipse.tycho.test.tycho136;
 
 import java.io.File;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho136GenerateIndividualSourceBundlesTest extends AbstractTychoIntegrationTest {
 
@@ -31,10 +31,10 @@ public class Tycho136GenerateIndividualSourceBundlesTest extends AbstractTychoIn
 
         File basedir = new File(verifier.getBasedir());
         File sourceFeature = new File(basedir, "SiteC/target/site/features/FeatureC.source_1.0.0.jar");
-        Assert.assertTrue("Site should generate FeatureC.source", sourceFeature.exists());
+        Assertions.assertTrue(sourceFeature.exists(), "Site should generate FeatureC.source");
         File sourcePluginC = new File(basedir, "SiteC/target/site/plugins/PluginC.source_1.0.0.jar");
-        Assert.assertTrue("Site should generate PluginC.source", sourcePluginC.exists());
+        Assertions.assertTrue(sourcePluginC.exists(), "Site should generate PluginC.source");
         File sourcePluginCExtra = new File(basedir, "SiteC/target/site/plugins/PluginC.Extra.source_1.0.0.jar");
-        Assert.assertTrue("Site should generate PluginC.Extra.source", sourcePluginCExtra.exists());
+        Assertions.assertTrue(sourcePluginCExtra.exists(), "Site should generate PluginC.Extra.source");
     }
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho136/Tycho136GeneratePluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho136/Tycho136GeneratePluginTest.java
@@ -14,11 +14,11 @@ package org.eclipse.tycho.test.tycho136;
 
 import java.io.File;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho136GeneratePluginTest extends AbstractTychoIntegrationTest {
 
@@ -31,6 +31,6 @@ public class Tycho136GeneratePluginTest extends AbstractTychoIntegrationTest {
 
         File basedir = new File(verifier.getBasedir());
         File sourcePlugin = new File(basedir, "SiteB/target/site/plugins/PluginB.source_1.0.0.jar");
-        Assert.assertTrue("Site should generate PluginB.source", sourcePlugin.exists());
+        Assertions.assertTrue(sourcePlugin.exists(), "Site should generate PluginB.source");
     }
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho154/Tycho154BundleJarTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho154/Tycho154BundleJarTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.tycho154;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho154BundleJarTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho2938/ContentJarTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho2938/ContentJarTest.java
@@ -30,26 +30,25 @@ import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.xml.sax.SAXException;
 
 public class ContentJarTest extends AbstractTychoIntegrationTest {
 	private HttpServer server;
 	private static final String TARGET_FEATURE_PATH = "/features/issue_2938_reproducer_1.0.0.202310211419.jar";
-	@Rule
-	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	Path temporaryFolder;
 	private Verifier verifier;
 	private String mainRepoUrl;
 
-	@Before
+	@BeforeEach
 	public void startServer() throws Exception {
 		server = HttpServer.startServer();
-		File repositoryRoot = temporaryFolder.getRoot();
+		File repositoryRoot = temporaryFolder.toFile();
 		this.mainRepoUrl = server.addServer("repoA", repositoryRoot);
 		File originalResource = ResourceUtil.resolveTestResource("repositories/content_jar");
 		FileUtils.copyDirectory(originalResource, repositoryRoot);
@@ -57,7 +56,7 @@ public class ContentJarTest extends AbstractTychoIntegrationTest {
 		verifier.deleteArtifacts("p2.org.eclipse.update.feature", "issue_2938_reproducer", "1.0.0.202310211419");
 	}
 
-	@After
+	@AfterEach
 	public void stopServer() throws Exception {
 		if (server != null) {
 			server.stop();
@@ -85,14 +84,14 @@ public class ContentJarTest extends AbstractTychoIntegrationTest {
 	public void redirectToBadLocation() throws Exception {
 		String redirectedUrl = server.addRedirect("repoB", originalPath -> mainRepoUrl + originalPath + "_invalid");
 		configureRepositoryInTargetDefinition(redirectedUrl);
-		Assert.assertThrows(VerificationException.class, () -> verifier.executeGoal("package"));
+		Assertions.assertThrows(VerificationException.class, () -> verifier.executeGoal("package"));
 		verifier.verifyTextInLog("Unable to read repository at " + redirectedUrl);
 		assertVisited("/content.jar_invalid");
 	}
 
 	@Test
 	public void redirectToMangledLocations() throws Exception {
-		File repositoryRoot = temporaryFolder.getRoot();
+		File repositoryRoot = temporaryFolder.toFile();
 		mangleFileNames(repositoryRoot.toPath());
 
 		// https://github.com/eclipse-tycho/tycho/issues/2938
@@ -108,8 +107,8 @@ public class ContentJarTest extends AbstractTychoIntegrationTest {
 
 	private void assertVisited(String path) {
 		List<String> accessedUrls = server.getAccessedUrls("repoA");
-		Assert.assertTrue(String.format("Path %s should be visited, %s were visited instead", path, accessedUrls),
-				accessedUrls.contains(path));
+		Assertions.assertTrue(accessedUrls.contains(path),
+				String.format("Path %s should be visited, %s were visited instead", path, accessedUrls));
 	}
 
 	private void mangleFileNames(Path repositoryRoot) throws IOException {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho476/ExecutionEnvironmentTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho476/ExecutionEnvironmentTest.java
@@ -18,8 +18,8 @@ import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ExecutionEnvironmentTest extends AbstractTychoIntegrationTest {
 
@@ -31,10 +31,10 @@ public class ExecutionEnvironmentTest extends AbstractTychoIntegrationTest {
 		// is configured indirectly via Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 		verifier.verifyErrorFreeLog();
 		File classFile = new File(verifier.getBasedir(), "target/classes/TestRunnable.class");
-		Assert.assertTrue(classFile.canRead());
+		Assertions.assertTrue(classFile.canRead());
 		JavaClass javaClass = new ClassParser(classFile.getAbsolutePath()).parse();
 		// bytecode major level 61 == target 17
-		Assert.assertEquals(61, javaClass.getMajor());
+		Assertions.assertEquals(61, javaClass.getMajor());
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho503/TYCHO503DoubleEncodedUrlTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho503/TYCHO503DoubleEncodedUrlTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.tycho503;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TYCHO503DoubleEncodedUrlTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho937/Tycho937Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho937/Tycho937Test.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho937Test extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho98/Tycho98MultiSourcesBundleJarTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho98/Tycho98MultiSourcesBundleJarTest.java
@@ -14,7 +14,7 @@ package org.eclipse.tycho.test.tycho98;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tycho98MultiSourcesBundleJarTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/util/SurefireUtil.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/util/SurefireUtil.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -52,8 +52,8 @@ public class SurefireUtil {
 		String testCaseXPath = String.format("/testsuite/testcase[@classname='%s' and @name='%s']", classNameInReport,
 				methodName);
 		List<Node> testCaseNodes2 = XMLTool.getMatchingNodes(document, testCaseXPath);
-		assertEquals(resultFile.getAbsolutePath() + " with xpath " + testCaseXPath
-				+ " does not match the number of iterations", iterations, testCaseNodes2.size());
+		assertEquals(iterations, testCaseNodes2.size(),
+				resultFile.getAbsolutePath() + " with xpath " + testCaseXPath + " does not match the number of iterations");
 
 		List<Node> failureNodes = XMLTool.getMatchingNodes(document, testCaseXPath + "/failure");
 		assertEquals(0, failureNodes.size());
@@ -98,7 +98,7 @@ public class SurefireUtil {
 	}
 
 	private static Document readDocument(File sureFireTestReport) throws Exception {
-		assertTrue("report file not found!" + sureFireTestReport, sureFireTestReport.isFile());
+		assertTrue(sureFireTestReport.isFile(), "report file not found!" + sureFireTestReport);
 		return XMLTool.parseXMLDocument(sureFireTestReport);
 	}
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/versionsplugin/BumpVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/versionsplugin/BumpVersionsTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.versionsplugin;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -24,8 +24,8 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Integration tests for the bump-versions mojo from tycho-versions-plugin.
@@ -37,7 +37,7 @@ public class BumpVersionsTest extends AbstractTychoIntegrationTest {
 
 	private static File baselineRepo = null;
 
-	@Before
+	@BeforeEach
 	public void buildBaselineRepository() throws Exception {
 		if (baselineRepo == null) {
 			Verifier verifier = getVerifier(PROJECT, false, true);
@@ -45,8 +45,7 @@ public class BumpVersionsTest extends AbstractTychoIntegrationTest {
 			verifier.executeGoals(List.of("clean", "package"));
 			verifier.verifyErrorFreeLog();
 			File repoDir = new File(verifier.getBasedir(), "repo/target/repository");
-			assertTrue("Baseline p2 repository was not created at: " + repoDir.getAbsolutePath(),
-					repoDir.isDirectory());
+			assertTrue(repoDir.isDirectory(), "Baseline p2 repository was not created at: " + repoDir.getAbsolutePath());
 			baselineRepo = new File("target/projects", getClass().getSimpleName() + "/baselineRepo").getAbsoluteFile();
 			if (baselineRepo.isDirectory()) {
 				FileUtils.deleteDirectory(baselineRepo);
@@ -90,20 +89,20 @@ public class BumpVersionsTest extends AbstractTychoIntegrationTest {
 		// Read MANIFEST.MF before run 2 overwrites the log
 		String manifestAfterRun1 = Files.readString(bundleDir.resolve("META-INF/MANIFEST.MF"));
 
-		assertTrue("Bundle version should be bumped to 2.0.0 after run 1:\n" + manifestAfterRun1,
-				manifestAfterRun1.contains("Bundle-Version: 2.0.0"));
-		assertTrue("Export-Package version should still be 1.0.0 after run 1:\n" + manifestAfterRun1,
-				manifestAfterRun1.contains("Export-Package: tycho.its.bump.versions;version=\"1.0.0\""));
+		assertTrue(manifestAfterRun1.contains("Bundle-Version: 2.0.0"),
+				"Bundle version should be bumped to 2.0.0 after run 1:\n" + manifestAfterRun1);
+		assertTrue(manifestAfterRun1.contains("Export-Package: tycho.its.bump.versions;version=\"1.0.0\""),
+				"Export-Package version should still be 1.0.0 after run 1:\n" + manifestAfterRun1);
 
 		// === Run 2: Export-Package version bumped to match the bundle ===
 		assertThrows(VerificationException.class, () -> verifier.executeGoals(List.of("verify")));
 
 		String manifestAfterRun2 = Files.readString(bundleDir.resolve("META-INF/MANIFEST.MF"));
 
-		assertTrue("Bundle version should remain 2.0.0 after run 2:\n" + manifestAfterRun2,
-				manifestAfterRun2.contains("Bundle-Version: 2.0.0"));
-		assertTrue("Export-Package version should be bumped to 2.0.0 after run 2:\n" + manifestAfterRun2,
-				manifestAfterRun2.contains("Export-Package: tycho.its.bump.versions;version=\"2.0.0\""));
+		assertTrue(manifestAfterRun2.contains("Bundle-Version: 2.0.0"),
+				"Bundle version should remain 2.0.0 after run 2:\n" + manifestAfterRun2);
+		assertTrue(manifestAfterRun2.contains("Export-Package: tycho.its.bump.versions;version=\"2.0.0\""),
+				"Export-Package version should be bumped to 2.0.0 after run 2:\n" + manifestAfterRun2);
 
 		// === Run 3: both versions consistent, build must succeed ===
 		verifier.executeGoals(List.of("verify"));

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/versionsplugin/MissingPluginVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/versionsplugin/MissingPluginVersionsTest.java
@@ -15,7 +15,7 @@ package org.eclipse.tycho.test.versionsplugin;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MissingPluginVersionsTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/versionsplugin/TychoVersionsPluginTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/versionsplugin/TychoVersionsPluginTest.java
@@ -13,10 +13,10 @@
 package org.eclipse.tycho.test.versionsplugin;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,7 +38,7 @@ import org.apache.maven.model.Parent;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.version.TychoVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
@@ -79,7 +79,7 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 
 		MavenXpp3Reader pomReader = new MavenXpp3Reader();
 		Model pomModel = pomReader.read(new FileReader(new File(verifier.getBasedir(), "pom.xml")));
-		assertEquals("<version> in pom.xml has not been changed!", expectedNewVersion, pomModel.getVersion());
+		assertEquals(expectedNewVersion, pomModel.getVersion(), "<version> in pom.xml has not been changed!");
 	}
 
 	@Test
@@ -93,9 +93,8 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 
 		verifier.verifyErrorFreeLog();
 		String targetContent = Files.readString(new File(verifier.getBasedir(), "including/including.target").toPath());
-		assertTrue("Actual Target content = " + targetContent,
-				targetContent.contains("mvn:org.tycho.its:other:" + expectedNewVersion + ":target")
-						&& targetContent.contains("sequenceNumber=\"12\""));
+		assertTrue(targetContent.contains("mvn:org.tycho.its:other:" + expectedNewVersion + ":target")
+						&& targetContent.contains("sequenceNumber=\"12\""), "Actual Target content = " + targetContent);
 	}
 
 	@Test
@@ -111,8 +110,8 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		Properties properties = new Properties();
 		properties.load(Files.newInputStream(new File(verifier.getBasedir(), "bundle/pde.bnd").toPath()));
 		String versionProperty = properties.getProperty("Bundle-Version");
-		assertNotNull("Bundle-Version is null", versionProperty);
-		assertEquals("Bundle-Version is not as expected!", expectedNewVersion, versionProperty);
+		assertNotNull(versionProperty, "Bundle-Version is null");
+		assertEquals(expectedNewVersion, versionProperty, "Bundle-Version is not as expected!");
 	}
 
 	@Test
@@ -131,19 +130,18 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 			MavenXpp3Reader pomReader = new MavenXpp3Reader();
 			Model pomModel = pomReader.read(new FileReader(new File(verifier.getBasedir(), pom)));
 			if (bundlePom.equals(pom)) {
-				assertNull("child should inherit version from parent", pomModel.getVersion());
+				assertNull(pomModel.getVersion(), "child should inherit version from parent");
 				Parent parent = pomModel.getParent();
-				assertNotNull("project > parent is null", parent);
-				assertEquals("project > parent > version in " + pom + " has not been changed!", expectedNewVersion,
-						parent.getVersion());
+				assertNotNull(parent, "project > parent is null");
+				assertEquals(expectedNewVersion, parent.getVersion(),
+						"project > parent > version in " + pom + " has not been changed!");
 			} else {
-				assertEquals("project > version in " + pom + " has not been changed!", expectedNewVersion,
-						pomModel.getVersion());
+				assertEquals(expectedNewVersion, pomModel.getVersion(), "project > version in " + pom + " has not been changed!");
 			}
 		}
 		Manifest manifest = getManifest(verifier, "bundle");
-		assertEquals("version in manifest was not updated!", expectedNewVersion,
-				manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+		assertEquals(expectedNewVersion, manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+				"version in manifest was not updated!");
 	}
 
 	@Test
@@ -170,19 +168,19 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 			Model pomModel = pomReader.read(new FileReader(new File(verifier.getBasedir(), pom)));
 			Parent parent = pomModel.getParent();
 
-			assertEquals("project > version in " + pom + " is not as expected!", expectation.expectedVersion(),
-					pomModel.getVersion());
+			assertEquals(expectation.expectedVersion(), pomModel.getVersion(),
+					"project > version in " + pom + " is not as expected!");
 			if (expectation.expectedParentVersion() == null) {
-				assertNull("project > parent in " + pom + " should be null", parent);
+				assertNull(parent, "project > parent in " + pom + " should be null");
 			} else {
-				assertEquals("project > parent > version in " + pom + " is not as expected!",
-						expectation.expectedParentVersion(), parent.getVersion());
+				assertEquals(expectation.expectedParentVersion(), parent.getVersion(),
+						"project > parent > version in " + pom + " is not as expected!");
 			}
 		}
-		assertEquals("version in manifest p/m1 is not as expected!", "1.0.1",
-				getManifest(verifier, "p/m1").getMainAttributes().getValue(Constants.BUNDLE_VERSION));
-		assertEquals("version in manifest q/m2 is not as expected!", "2.0.0",
-				getManifest(verifier, "q/m2").getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+		assertEquals("1.0.1", getManifest(verifier, "p/m1").getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+				"version in manifest p/m1 is not as expected!");
+		assertEquals("2.0.0", getManifest(verifier, "q/m2").getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+				"version in manifest q/m2 is not as expected!");
 	}
 
 	@Test
@@ -203,35 +201,35 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		verifier.executeGoal("org.eclipse.tycho:tycho-versions-plugin:" + VERSION + ":set-version");
 		{// check the package itself is updated
 			Manifest provider = getManifest(verifier, "provider.bundle");
-			assertEquals("version in manifest was not updated for provider bundle!", expectedNewOSGiVersion,
-					provider.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+			assertEquals(expectedNewOSGiVersion, provider.getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+					"version in manifest was not updated for provider bundle!");
 			assertVersion(provider, expectedPackageVersion, Constants.EXPORT_PACKAGE);
 		}
 		{// check open range is updated
 			Manifest consumerOpen = getManifest(verifier, "consumer.open");
-			assertEquals("version in manifest was not updated for open consumer bundle!", expectedNewOSGiVersion,
-					consumerOpen.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+			assertEquals(expectedNewOSGiVersion, consumerOpen.getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+					"version in manifest was not updated for open consumer bundle!");
 			assertVersion(consumerOpen, expectedPackageVersion, Constants.IMPORT_PACKAGE);
 			assertVersion(consumerOpen, expectedPackageVersion, Constants.REQUIRE_BUNDLE);
 		}
 		{// check wide version range is updated
 			Manifest consumerWide = getManifest(verifier, "consumer.wide");
-			assertEquals("version in manifest was not updated for wide consumer bundle!", expectedNewOSGiVersion,
-					consumerWide.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+			assertEquals(expectedNewOSGiVersion, consumerWide.getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+					"version in manifest was not updated for wide consumer bundle!");
 			assertVersionRange(consumerWide, expectedWideVersionRange, Constants.IMPORT_PACKAGE);
 			assertVersionRange(consumerWide, expectedWideVersionRange, Constants.REQUIRE_BUNDLE);
 		}
 		{// check narrow version range is updated
 			Manifest consumerNarrow = getManifest(verifier, "consumer.narrow");
-			assertEquals("version in manifest was not updated for narrow consumer bundle!", expectedNewOSGiVersion,
-					consumerNarrow.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+			assertEquals(expectedNewOSGiVersion, consumerNarrow.getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+					"version in manifest was not updated for narrow consumer bundle!");
 			assertVersionRange(consumerNarrow, expectedNarrowVersionRange, Constants.IMPORT_PACKAGE);
 			assertVersionRange(consumerNarrow, expectedNarrowVersionRange, Constants.REQUIRE_BUNDLE);
 		}
 		{// check micro version range is updated
 			Manifest consumerNarrow = getManifest(verifier, "consumer.micro");
-			assertEquals("version in manifest was not updated for micro consumer bundle!", expectedNewOSGiVersion,
-					consumerNarrow.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+			assertEquals(expectedNewOSGiVersion, consumerNarrow.getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+					"version in manifest was not updated for micro consumer bundle!");
 			assertVersionRange(consumerNarrow, expectedMicroVersionRange, Constants.IMPORT_PACKAGE);
 			assertVersionRange(consumerNarrow, expectedMicroVersionRange, Constants.REQUIRE_BUNDLE);
 		}
@@ -250,18 +248,18 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		{// check the pom.xml is updated
 			MavenXpp3Reader pomReader = new MavenXpp3Reader();
 			Model pomModel = pomReader.read(new FileReader(new File(verifier.getBasedir(), "pom.xml")));
-			assertEquals("<version> in pom.xml has not been changed!", expectedNewMavenVersion, pomModel.getVersion());
+			assertEquals(expectedNewMavenVersion, pomModel.getVersion(), "<version> in pom.xml has not been changed!");
 		}
 		{// check require-Bundle is updated
 			Manifest consumerBundle = getManifest(verifier, "consumer.bundle");
-			assertEquals("version in manifest was not updated for consumer.bundle!", expectedNewOSGiVersion,
-					consumerBundle.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+			assertEquals(expectedNewOSGiVersion, consumerBundle.getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+					"version in manifest was not updated for consumer.bundle!");
 			assertVersionRange(consumerBundle, expectedUpperBoundVersion, Constants.REQUIRE_BUNDLE);
 		}
 		{// check Import-Package is updated
 			Manifest consumerPackage = getManifest(verifier, "consumer.package");
-			assertEquals("version in manifest was not updated for consumer.package!", expectedNewOSGiVersion,
-					consumerPackage.getMainAttributes().getValue(Constants.BUNDLE_VERSION));
+			assertEquals(expectedNewOSGiVersion, consumerPackage.getMainAttributes().getValue(Constants.BUNDLE_VERSION),
+					"version in manifest was not updated for consumer.package!");
 			assertVersionRange(consumerPackage, expectedUpperBoundVersion, Constants.IMPORT_PACKAGE);
 		}
 	}
@@ -283,8 +281,8 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		Properties properties = new Properties();
 		properties.load(Files.newInputStream(new File(verifier.getBasedir(), "pde.bnd").toPath()));
 		String versionProperty = properties.getProperty("Bundle-Version");
-		assertNotNull("Bundle-Version is null", versionProperty);
-		assertEquals("Bundle-Version is not as expected!", expectedNewVersion, versionProperty);
+		assertNotNull(versionProperty, "Bundle-Version is null");
+		assertEquals(expectedNewVersion, versionProperty, "Bundle-Version is not as expected!");
 	}
 
 	/**
@@ -307,7 +305,7 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		MavenXpp3Reader pomReader = new MavenXpp3Reader();
 		Model pomModel = pomReader.read(new FileReader(new File(verifier.getBasedir(), POM_NAME)));
-		assertEquals("<version> in pom.xml has not been changed!", MANIFEST_VERSION, pomModel.getVersion());
+		assertEquals(MANIFEST_VERSION, pomModel.getVersion(), "<version> in pom.xml has not been changed!");
 	}
 
 	/**
@@ -330,7 +328,7 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		MavenXpp3Reader pomReader = new MavenXpp3Reader();
 		Model pomModel = pomReader.read(new FileReader(new File(verifier.getBasedir(), POM_NAME)));
-		assertEquals("<version> in pom.xml has not been changed!", MANIFEST_VERSION, pomModel.getVersion());
+		assertEquals(MANIFEST_VERSION, pomModel.getVersion(), "<version> in pom.xml has not been changed!");
 	}
 
 	/**
@@ -354,7 +352,7 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		MavenXpp3Reader pomReader = new MavenXpp3Reader();
 		Model pomModel = pomReader.read(new FileReader(new File(verifier.getBasedir(), POM_NAME)));
-		assertEquals("<version> in foo.bar.pom.xml has not been changed!", MANIFEST_VERSION, pomModel.getVersion());
+		assertEquals(MANIFEST_VERSION, pomModel.getVersion(), "<version> in foo.bar.pom.xml has not been changed!");
 	}
 
 	/**
@@ -383,14 +381,13 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 		Model pomCustom = pomReader.read(new FileReader(file(verifier, "customPomName", "customPomName.xml")));
 		Model pomDeepNest = pomReader.read(new FileReader(file(verifier, "deepNest", "a", "b", "deepNest.xml")));
 
-		assertEquals("<version> in defaultPomNameA/pom.xml has not been changed!", MANIFEST_VERSION,
-				pomImplicit.getVersion());
-		assertEquals("<version> in defaultPomNameB/pom.xml has not been changed!", MANIFEST_VERSION,
-				pomDefault.getVersion());
-		assertEquals("<version> in customPomName/customPomName.xml has not been changed!", MANIFEST_VERSION,
-				pomCustom.getVersion());
-		assertEquals("<version> in deepNest/a/b/deepNest.xml has not been changed!", MANIFEST_VERSION,
-				pomDeepNest.getVersion());
+		assertEquals(MANIFEST_VERSION, pomImplicit.getVersion(),
+				"<version> in defaultPomNameA/pom.xml has not been changed!");
+		assertEquals(MANIFEST_VERSION, pomDefault.getVersion(), "<version> in defaultPomNameB/pom.xml has not been changed!");
+		assertEquals(MANIFEST_VERSION, pomCustom.getVersion(),
+				"<version> in customPomName/customPomName.xml has not been changed!");
+		assertEquals(MANIFEST_VERSION, pomDeepNest.getVersion(),
+				"<version> in deepNest/a/b/deepNest.xml has not been changed!");
 
 	}
 
@@ -420,24 +417,24 @@ public class TychoVersionsPluginTest extends AbstractTychoIntegrationTest {
 
 	private static void assertVersionRange(Manifest manifest, String versionRange, String header) {
 		String value = manifest.getMainAttributes().getValue(header);
-		assertNotNull("Header " + header + " not found", value);
+		assertNotNull(value, "Header " + header + " not found");
 		Matcher matcher = VERSION_PATTERN.matcher(value);
-		assertTrue("no version found on " + value, matcher.find());
+		assertTrue(matcher.find(), "no version found on " + value);
 		VersionRange expected = VersionRange.valueOf(versionRange);
 		VersionRange actual = VersionRange.valueOf(matcher.group(1));
-		assertTrue(header + " " + value + ": expected version range = " + expected + " but actual version range = "
-				+ actual, expected.equals(actual));
+		assertTrue(expected.equals(actual),
+				header + " " + value + ": expected version range = " + expected + " but actual version range = " + actual);
 	}
 
 	private static void assertVersion(Manifest manifest, String version, String header) {
 		String value = manifest.getMainAttributes().getValue(header);
-		assertNotNull("Header " + header + " not found", value);
+		assertNotNull(value, "Header " + header + " not found");
 		Matcher matcher = VERSION_PATTERN.matcher(value);
-		assertTrue("no version found on " + value, matcher.find());
+		assertTrue(matcher.find(), "no version found on " + value);
 		Version expected = Version.valueOf(version);
 		Version actual = Version.valueOf(matcher.group(1));
-		assertTrue(header + " " + value + ": expected version = " + expected + " but actual version = " + actual,
-				expected.equals(actual));
+		assertTrue(expected.equals(actual),
+				header + " " + value + ": expected version = " + expected + " but actual version = " + actual);
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/workspacereader/WorkspaceReaderTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/workspacereader/WorkspaceReaderTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WorkspaceReaderTest extends AbstractTychoIntegrationTest {
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/xtend/TychoXtendTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/xtend/TychoXtendTest.java
@@ -16,7 +16,7 @@ import static java.util.Arrays.asList;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TychoXtendTest extends AbstractTychoIntegrationTest {
 


### PR DESCRIPTION
The integration test projects under tycho-its/projects keep JUnit 4, as they are what the tests of the JUnit 4 support run against, so tycho-its still needs junit on its own classpath as well.

AbstractTychoIntegrationTest takes the test name from TestInfo instead of the TestName rule, Tycho188P2EnabledRcpTest replaces the Theories runner with @ParameterizedTest over a @FieldSource, @Rule TemporaryFolder becomes @TempDir and the assertions that put the message first are reordered.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])