### PR TITLE
Add professional support contact link to issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Contributing guide (incl. AI/GenAI usage policy)
     url: https://github.com/eclipse-tycho/tycho/blob/main/CONTRIBUTING.md#using-ai--genai-tools-to-contribute
     about: Read this before opening an issue, especially if an AI agent is helping you draft it.
+  - name: Professional / commercial support
+    url: https://github.com/eclipse-tycho/tycho#getting-support
+    about: This is a community project without guaranteed response times. If you need dedicated help or priority handling, see companies offering commercial support for Tycho.


### PR DESCRIPTION
This will make it easier for people to discover when they create issues.

<img width="2104" height="1376" alt="grafik" src="https://github.com/user-attachments/assets/678ba662-0c74-4d8a-9933-cfd52a43d032" />
