### PR TITLE
Document how pomless modules find their parent POM

### DIFF
--- a/src/site/markdown/StructuredBuild.md
+++ b/src/site/markdown/StructuredBuild.md
@@ -88,3 +88,33 @@ Tycho however can derive most of the information from other already existing fil
 ```
 
 - You can now run your build with `mvn verify`.
+
+## Where a pomless module looks for its parent
+
+A pomless module has no `pom.xml` in which a `<parent>` could be declared, so Tycho derives the parent from the file system.
+By default it uses the directory one level up (`..`), which is what a structured layout provides.
+
+If the parent is somewhere else, set the property `tycho.pomless.parent` in the `build.properties` of the module.
+The value may point to a directory or directly to a POM file, and it is resolved relative to the module directory:
+
+```properties
+bin.includes = META-INF/,.
+source.. = src/
+tycho.pomless.parent = ../../releng/parent
+```
+
+The same property can be set as a system property to change the default for every module of the build, for example in `.mvn/maven.config`:
+
+```properties
+-Dtycho.pomless.parent=../../releng/parent
+```
+
+Absolute values are used as they are, which is useful if the modules are not all at the same depth, for example because they come from Git submodules or from a flat layout.
+Combined with `${maven.multiModuleProjectDirectory}`, which Maven sets to the directory containing the `.mvn` folder, every module of the build resolves the root POM as its parent, no matter how deeply it is nested:
+
+```properties
+-Dtycho.pomless.parent=${maven.multiModuleProjectDirectory}
+```
+
+Note that this also bypasses any intermediate aggregator as a parent, so use it for layouts where the root POM is meant to be the parent of every module.
+A `build.properties` entry always wins over the system property, so individual modules can still opt out.

--- a/tycho-its/projects/extra/testpomless-nested/.mvn/extensions.xml
+++ b/tycho-its/projects/extra/testpomless-nested/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-build</artifactId>
+    <version>${tycho-version}</version>
+  </extension>
+</extensions>

--- a/tycho-its/projects/extra/testpomless-nested/.mvn/maven.config
+++ b/tycho-its/projects/extra/testpomless-nested/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho.pomless.parent=${maven.multiModuleProjectDirectory}

--- a/tycho-its/projects/extra/testpomless-nested/pom.xml
+++ b/tycho-its/projects/extra/testpomless-nested/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>testParent.groupId</groupId>
+	<artifactId>testparent</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<!-- The modules are nested at a depth the default parent lookup ('..') can not 
+		resolve, they rely on tycho.pomless.parent from .mvn/maven.config instead. -->
+	<modules>
+		<module>submodule-a/targetplatform</module>
+		<module>submodule-a/bundle1</module>
+		<module>submodule-a/bundle1.tests</module>
+		<module>submodule-b/feature</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<artifact>
+							<groupId>testParent.groupId</groupId>
+							<artifactId>targetplatform</artifactId>
+							<version>0.0.1-SNAPSHOT</version>
+						</artifact>
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1.tests/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: pomless.bundle.tests
+Bundle-Version: 1.0.1
+Require-Bundle: org.junit;bundle-version="4.0.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Import-Package: jakarta.annotation

--- a/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1.tests/build.properties
+++ b/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1.tests/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,.
+source.. = src/

--- a/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1.tests/src/DummyTest.java
+++ b/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1.tests/src/DummyTest.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2015 SAP SE and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    SAP SE - initial API and implementation
+ *******************************************************************************/
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DummyTest {
+
+    @Test
+    public void test() {
+    	Assert.assertTrue(true);
+    }
+
+}

--- a/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: pomless.bundle;singleton:=true
+Bundle-Version: 0.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+

--- a/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1/build.properties
+++ b/tycho-its/projects/extra/testpomless-nested/submodule-a/bundle1/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,.
+source.. = src/

--- a/tycho-its/projects/extra/testpomless-nested/submodule-a/targetplatform/targetplatform.target
+++ b/tycho-its/projects/extra/testpomless-nested/submodule-a/targetplatform/targetplatform.target
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="Thats my pomless Target" sequenceNumber="3">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
+<unit id="org.junit"/>
+<unit id="jakarta.annotation-api"/>
+<repository location="https://download.eclipse.org/releases/2025-06"/>
+</location>
+</locations>
+</target>

--- a/tycho-its/projects/extra/testpomless-nested/submodule-b/feature/build.properties
+++ b/tycho-its/projects/extra/testpomless-nested/submodule-b/feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/extra/testpomless-nested/submodule-b/feature/feature.xml
+++ b/tycho-its/projects/extra/testpomless-nested/submodule-b/feature/feature.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="pomless.feature"
+      version="1.0.0.qualifier">
+
+   <plugin
+         id="pomless.bundle"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="pomless.bundle.tests"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/extra/TychoPomlessITest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/extra/TychoPomlessITest.java
@@ -58,6 +58,19 @@ public class TychoPomlessITest extends AbstractTychoIntegrationTest {
 	}
 
 	@Test
+	public void testPomlessNestedBuildExtension() throws Exception {
+		// modules are nested deeper than the default parent lookup ('..') can resolve,
+		// the parent is given as an absolute path in .mvn/maven.config instead
+		Verifier verifier = getVerifier("extra/testpomless-nested", false);
+		verifier.executeGoals(asList("clean", "verify"));
+		verifier.verifyErrorFreeLog();
+		File baseDir = new File(verifier.getBasedir());
+		assertThat(new File(baseDir, "submodule-a/bundle1/target/pomless.bundle-0.1.0-SNAPSHOT.jar"), isFile());
+		assertThat(new File(baseDir, "submodule-a/bundle1.tests/target/pomless.bundle.tests-1.0.1.jar"), isFile());
+		assertThat(new File(baseDir, "submodule-b/feature/target/pomless.feature-1.0.0-SNAPSHOT.jar"), isFile());
+	}
+
+	@Test
 	public void testPomlessStructuredBuildExtension() throws Exception {
 		Verifier verifier = getVerifier("extra/testpomless-structured", false);
 		verifier.executeGoals(asList("clean", "verify"));


### PR DESCRIPTION
The `tycho.pomless.parent` property is currently only discoverable by reading `AbstractTychoMapping` or a few integration test projects. This documents it in the structured build page: it can be set per module in `build.properties` or globally as a system property, and an absolute value works as well.

The useful part is the combination with `${maven.multiModuleProjectDirectory}`, which makes every module of a build resolve the root POM as its parent regardless of how deeply it is nested. Flat layouts and repositories whose modules come from Git submodules then need no per module configuration at all, which is the parent resolution concern raised in #3504.

The added integration test covers exactly that setup and fails without the property ("No parent pom file found"), so the behaviour stays covered.

Disclaimer: Created and tested with the help of Qwen3.8 27B DenseHetzner Inference