### PR TITLE
Fix NPE in createP2Index for in-place composite-repository edits

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/tools/P2RepositoryDataManipulator.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/tools/P2RepositoryDataManipulator.java
@@ -210,7 +210,7 @@ public class P2RepositoryDataManipulator {
 					}, modification, CompositeMetadataRepository.PI_REPOSITORY_TYPE,
 					CompositeMetadataRepositoryFactory.CONTENT_FILENAME);
 		}
-		createP2Index(repository.outputLocation(), repository.isMetadata(), repository.isArtifact());
+		createP2Index(resolveOutputLocation(repository), repository.isMetadata(), repository.isArtifact());
 	}
 
 	private <T, M extends IRepositoryManager<T>, R extends ICompositeRepository<T>> void modifyOutputCompositeRepository(
@@ -234,15 +234,7 @@ public class P2RepositoryDataManipulator {
 				throw e;
 			}
 		}
-		Path outputLocation = descriptor.outputLocation();
-		if (outputLocation == null) {
-			try {
-				outputLocation = Path.of(repository.getURL());
-			} catch (Exception e) {
-				throw new IllegalStateException(
-						"Repository is not modifable and no output location is defined: " + repository.getURL(), e);
-			}
-		}
+		Path outputLocation = resolveOutputLocation(descriptor);
 
 		modification.accept(state);
 
@@ -252,6 +244,24 @@ public class P2RepositoryDataManipulator {
 			state.getProperties().put(IRepository.PROP_COMPRESSED, Boolean.toString(compress));
 			new CompositeRepositoryIO().write(state, output, piRepositoryType);
 		}
+	}
+
+	private static Path resolveOutputLocation(ModifiedRepositoryDescriptor descriptor) {
+		Path outputLocation = descriptor.outputLocation();
+		if (outputLocation == null) {
+			// In-place edit (createDescriptor signals this with a null outputLocation) --
+			// modifyCompositeRepository's own call to createP2Index needs the same
+			// resolved path that modifyOutputCompositeRepository already computes below,
+			// so both call sites share this fallback rather than duplicating it (gh-6251).
+			MavenRepositoryLocation repository = descriptor.repository();
+			try {
+				outputLocation = Path.of(repository.getURL());
+			} catch (Exception e) {
+				throw new IllegalStateException(
+						"Repository is not modifable and no output location is defined: " + repository.getURL(), e);
+			}
+		}
+		return outputLocation;
 	}
 
 	private static OutputStream createCompositeFileOutputStream(Path directory, String filename, boolean compress)

--- a/tycho-its/projects/issue6251/pom.xml
+++ b/tycho-its/projects/issue6251/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Contributors to the Eclipse Foundation
+    This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project</groupId>
+	<artifactId>issue6251</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>modify-in-place</id>
+						<phase>initialize</phase>
+						<goals>
+							<goal>modify-composite-repository</goal>
+						</goals>
+						<configuration>
+							<repository>
+								<id>t</id>
+								<url>${project.baseUri}repo/</url>
+							</repository>
+							<repositoryKind>metadata</repositoryKind>
+							<childrenToAdd>
+								<child>../child</child>
+							</childrenToAdd>
+							<validateChildren>false</validateChildren>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue6251/Issue6251Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue6251/Issue6251Test.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.test.issue6251;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+public class Issue6251Test extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void modifyCompositeRepositoryInPlaceWritesP2Index() throws Exception {
+		Verifier verifier = getVerifier("issue6251");
+
+		verifier.executeGoals(List.of("initialize"));
+		verifier.verifyErrorFreeLog();
+
+		Path p2Index = Path.of(verifier.getBasedir(), "repo", "p2.index");
+		assertTrue(Files.exists(p2Index), "p2.index was not written to the in-place repository");
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a NullPointerException in `tycho-p2-repository-plugin:modify-composite-repository` that makes the goal's documented default mode -- in-place editing -- fail on every invocation (5.0.0 through 5.0.3). `modifyCompositeRepository` resolves the effective output location for an in-place edit as a local variable inside `modifyOutputCompositeRepository`, but never writes it back to the descriptor, so its own subsequent call to `createP2Index(repository.outputLocation(), ...)` passes the still-null field. Extracts the existing fallback into a shared `resolveOutputLocation()` helper used at both call sites.

Fixes #6251

## How was this tested?

Added `tycho-its/projects/issue6251` (the exact reproducer from the issue) and `Issue6251Test`, which runs `mvn initialize` against it and asserts `p2.index` is written to the in-place repository. Verified with a negative control: reverting only the fix (keeping the new IT) reproduces the exact reported stack trace (`P2RepositoryDataManipulator.createP2Index:282` -> `modifyCompositeRepository:213` -> `ModifyCompositeRepositoryMojo.execute:146`); restoring the fix passes.

## AI/GenAI disclosure

- Tool/agent + model/version + mode (interactive/autonomous): Claude Code, claude-sonnet-5, interactive
- [x] I have personally reviewed all code, tests, and text in this PR and understand and stand behind
      every change, per the [Eclipse GenAI contribution guidelines](https://www.eclipse.org/projects/handbook/#genai).
- [x] I will personally review and confirm any AI-assisted follow-up changes made in response to review
      comments before pushing them (see [AGENTS.md](../AGENTS.md) rule on reading full thread history).

## Checklist

- [x] I have searched existing PRs/issues and this is not a duplicate.
- [x] `mvn clean install -DskipTests` / relevant integration tests pass locally.
- [x] Commits are small and self-contained (see [CONTRIBUTING.md](../CONTRIBUTING.md#granularity)).
