### PR TITLE
Match Maven settings server id additionaly with target location URL

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultMavenRepositorySettings.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/DefaultMavenRepositorySettings.java
@@ -14,11 +14,15 @@
 package org.eclipse.tycho.p2maven.repository;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.maven.RepositoryUtils;
@@ -101,7 +105,14 @@ public class DefaultMavenRepositorySettings implements MavenRepositorySettings, 
             return null;
         }
 		Server serverSettings = settings.getServer(location.getId());
-
+		if (serverSettings == null) {
+			URI url = location.getURL();
+			Map<String, Server> servers = settings.getServers().stream() // more efficient for many id lookups
+					.collect(Collectors.toMap(Server::getId, s -> s, (s1, s2) -> s1));
+			serverSettings = Stream.concat(Stream.of(url), parentPathURLs(url)) //
+					.map(URI::toString).map(u -> u.startsWith("//") ? u.substring(2) : u) //
+					.map(servers::get).filter(Objects::nonNull).findFirst().orElse(null);
+		}
         if (serverSettings != null) {
             SettingsDecryptionResult result = decrypter.decryptAndLogProblems(serverSettings);
             Server decryptedServer = result.getServer();
@@ -110,6 +121,28 @@ public class DefaultMavenRepositorySettings implements MavenRepositorySettings, 
         }
         return null;
     }
+
+	public Stream<URI> parentPathURLs(URI uri) {
+		String originalPath = uri.getPath();
+		if (originalPath == null || originalPath.isEmpty()) {
+			return Stream.empty();
+		}
+		List<String> pathSegments = Arrays.asList(originalPath.split("/")); // Keep leading slash
+		List<URI> uris = IntStream.range(0, pathSegments.size())
+				.mapToObj(removed -> String.join("/", pathSegments.subList(0, pathSegments.size() - removed)))
+				.map(path -> derive(uri, uri.getScheme(), path)).filter(Objects::nonNull).toList();
+		return Stream.concat(uris.stream(),
+				uris.stream().map(u -> derive(u, null, u.getPath())).filter(Objects::nonNull));
+	}
+
+	private URI derive(URI uri, String scheme, String path) {
+		try {
+			return new URI(scheme, uri.getUserInfo(), uri.getHost(), uri.getPort(), path, null, null);
+		} catch (Exception e) {
+			logger.warn("Failed to create derived URI from " + uri, e);
+			return null; // ignore erroneous URIs
+		}
+	}
 
     public Mirror getTychoMirror(ArtifactRepository repository, List<Mirror> mirrors) {
         // if we find a mirror the default way (the maven way) we will use that mirror

--- a/src/site/markdown/TargetPlatform.md
+++ b/src/site/markdown/TargetPlatform.md
@@ -178,6 +178,53 @@ Since Tycho 0.17.0, it is also possible to configure multiple target files by sp
 
 Note: Eclipse PDE supports activating multiple target files at once using reference target locations (see [PDE reference target locations](https://eclipse.dev/eclipse/news/4.23/pde.html#pde-editor-include)).
 
+#### Authentication for p2 Repositories
+
+To access p2-repositories that require basic authentication, add a `<server>` entry in the `settings.xml` that specifies the required `username` and `password`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+	<servers>
+		<server>
+			<id>my_id</id>
+			<username>my_username</username>
+			<password>my_password</password>
+		</server>
+	</servers>
+</settings>
+```
+
+When accessing a p2 repository, Tycho will check if there is a `<server>` entry with matching ID and use these credentials.
+The ID of a p2 repository can be specified explicitly, e.g. when adding a repository in the POM or in a `.target` file by setting the `id` attribute for a `repository` element:
+```xml
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+	<repository location="https://my.company.com/repo/foo/" id="my_id"/>
+	...
+```
+
+But the `id` attribute is not considered by PDE and therefore can be removed by some editors, which makes using explicit IDs cumbersome.
+If no `id` is specified for a `repository` in a `.target` file, the repository's `location` URL is used as ID.
+First, a `server` with `id` equal to the repository `location` is searched.
+If none is found, a `server` is searched for each parent path of the `location` URL (without trailing slash).
+Last, that search is repeated with the _scheme_ part of the `location` URL being removed.
+
+In the example above, each of the following server IDs would match the specified repository location (and is searched for in that order):
+1. `https://my.company.com/repo/foo`
+2. `https://my.company.com/repo`
+3. `https://my.company.com`
+4. `my.company.com/repo/foo`
+5. `my.company.com/repo`
+6. `my.company.com`
+
+IDs corresponding to more specific locations are preferred.
+Using a location's parent path as `id` allows to use one `server` specification for multiple repositories under the same parent.
+
+To prevent storing passwords as plain text in files, see also Maven's [Settings#Servers](https://maven.apache.org/settings.html#servers) reference
+and its guide about [Password Encryption](https://maven.apache.org/guides/mini/guide-encryption.html).
+Furthermore consider the ability to supply passwords via environment variables, by using e.g. `<password>${env.MY_PASSWORD}</password>`, for CI pipelines.
+
 #### Tycho's interpretation of target definition files
 
 Note: Tycho's interpretation of the target definition file format differs from the PDE in the following aspects:

--- a/tycho-its/projects/target.httpAuthentication/platform-without-repository-id.target
+++ b/tycho-its/projects/target.httpAuthentication/platform-without-repository-id.target
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.5"?>
+
+<target name="platform">
+  <locations>
+    <location includeAllPlatforms="false" includeMode="planner"
+      type="InstallableUnit">
+      <unit id='org.eclipse.osgi' version='3.4.3.R34x_v20081215-1030' />
+      <repository location="[url]" />
+    </location>
+  </locations>
+</target>

--- a/tycho-its/projects/target.httpAuthentication/pom.xml
+++ b/tycho-its/projects/target.httpAuthentication/pom.xml
@@ -68,6 +68,30 @@
         </plugins>
       </build>
     </profile>
+    
+    <profile>
+      <id>target-definition-without-repository-id</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>target-platform-configuration</artifactId>
+            <version>${tycho-version}</version>
+            <configuration>
+              <resolver>p2</resolver>
+              <target>
+                <artifact>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>${project.version}</version>
+                  <classifier>platform-without-repository-id</classifier>
+                </artifact>
+              </target>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
 
   </profiles>
 </project>

--- a/tycho-its/projects/target.httpAuthentication/settings-repository-id.xml
+++ b/tycho-its/projects/target.httpAuthentication/settings-repository-id.xml
@@ -1,0 +1,9 @@
+<settings>
+  <servers>
+    <server>
+      <id>[serverId]</id>
+      <username>test-user</username>
+      <password>test-password</password>
+    </server>
+  </servers>
+</settings>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedP2RepositoryTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/PasswordProtectedP2RepositoryTest.java
@@ -13,29 +13,38 @@
 package org.eclipse.tycho.test.target;
 
 import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.ResourceUtil;
 import org.eclipse.tycho.test.util.TargetDefinitionUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class PasswordProtectedP2RepositoryTest extends AbstractTychoIntegrationTest {
 
-	private HttpServer server;
-	private String p2RepoUrl;
+	private static HttpServer server;
+	private static String p2RepoUrl;
 
-	private HttpServer mirror;
-	private String p2MirrorUrl;
+	private static HttpServer mirror;
+	private static String p2MirrorUrl;
 
-	private HttpServer authMirror;
-	private String p2AuthMirrorUrl;
+	private static HttpServer authMirror;
+	private static String p2AuthMirrorUrl;
 
-	@BeforeEach
-	public void startServer() throws Exception {
+	@BeforeAll
+	static void startServer() throws Exception {
 		server = HttpServer.startServer("test-user", "test-password");
 		p2RepoUrl = server.addServer("foo", ResourceUtil.resolveTestResource("repositories/e342"));
 
@@ -46,8 +55,8 @@ public class PasswordProtectedP2RepositoryTest extends AbstractTychoIntegrationT
 		p2AuthMirrorUrl = authMirror.addServer("bar", ResourceUtil.resolveTestResource("repositories/e342"));
 	}
 
-	@AfterEach
-	public void stopServer() throws Exception {
+	@AfterAll
+	static void stopServer() throws Exception {
 		authMirror.stop();
 		mirror.stop();
 		server.stop();
@@ -103,6 +112,35 @@ public class PasswordProtectedP2RepositoryTest extends AbstractTychoIntegrationT
 		File platformFile = new File(verifier.getBasedir(), "platform.target");
 		TargetDefinitionUtil.setRepositoryURLs(platformFile, p2RepoUrl);
 		verifier.addCliOption("-P=target-definition");
+		verifier.executeGoal("package");
+		verifier.verifyErrorFreeLog();
+	}
+
+	private static Stream<String> supportedURLBasedServerIds() {
+		URI serverURI = URI.create(p2RepoUrl);
+		String authority = serverURI.getAuthority();
+		List<String> pathSegments = Arrays.stream(serverURI.getPath().split("/")).filter(s -> !s.isEmpty()).toList();
+		List<String> paths = IntStream.rangeClosed(0, pathSegments.size())
+				.mapToObj(i -> String.join("/", pathSegments.subList(0, i))).map(p -> p.isEmpty() ? "" : ("/" + p))
+				.toList();
+
+		return Stream.of(serverURI.getScheme() + "://", "")
+				.flatMap(scheme -> paths.stream().map(p -> scheme + authority + p));
+	}
+
+	@ParameterizedTest
+	@MethodSource("supportedURLBasedServerIds")
+	public void testTargetDefinitionWithoutLocationID(String serverId) throws Exception {
+		Verifier verifier = createVerifier("settings-repository-id.xml");
+
+		File platformFile = new File(verifier.getBasedir(), "platform-without-repository-id.target");
+		TargetDefinitionUtil.setRepositoryURLs(platformFile, p2RepoUrl);
+		Path settingsFile = Path.of(verifier.getBasedir(), "settings-repository-id.xml");
+		Files.writeString(settingsFile, Files.readString(settingsFile).replace("[serverId]", serverId));
+		verifier.getCliOptions().removeIf(o -> o.startsWith("-s ") || o.startsWith("--settings"));
+		verifier.addCliOption("--settings " + settingsFile);
+
+		verifier.addCliOption("-P=target-definition-without-repository-id");
 		verifier.executeGoal("package");
 		verifier.verifyErrorFreeLog();
 	}


### PR DESCRIPTION
## What does this PR do?

Avoid the need to specify an `id` attribute for a target location repository, to supply e.g. credentials for that server, by matching also the repository's location URL against all server IDs specified in the 'settings.xml'.

If the p2-repository's location is `https://my.company.com/repo/foo` and the 'settings.xml' contains an entry like
```
<servers>
	<server>
		<id>https://my.company.com/repo/foo</id>
		<username>...
```
the credentials defined for that server are used to authenticate against that server.

The repository location is not only matched literally, but also all it's parent paths plus all variants without URL scheme. For a target definition like above, all the following server IDs match:
- `https://my.company.com/repo/foo`
- `https://my.company.com/repo`
- `https://my.company.com`
- `my.company.com/repo/foo`
- `my.company.com/repo`
- `my.company.com`

More specific server IDs are preferred.

## How was this tested?

A new test case was added for an existing test class to cover the new behavior.

## Checklist

- [x] I have searched existing PRs/issues and this is not a duplicate.
- [x] `mvn clean install -DskipTests` / relevant integration tests pass locally.
- [x] Commits are small and self-contained (see [CONTRIBUTING.md](../CONTRIBUTING.md#granularity)).
