### PR TITLE
Skip null/blank bndRunProperties values in BndTestMojo

### DIFF
--- a/tycho-its/projects/surefire.bndRunProperties/pom.xml
+++ b/tycho-its/projects/surefire.bndRunProperties/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>tycho-its-project.surefire.bndRunProperties</groupId>
+	<artifactId>tycho.its.surefire.bndrunproperties</artifactId>
+	<version>1.0.0</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<properties>
+		<!-- Simulates a shared parent configuration that declares a bndRunProperties instruction
+		     with a blank/placeholder default value, meant to be overridden by a specific module.
+		     A blank value must not cause a NullPointerException in the bnd-test goal. -->
+		<its.bndRunProperties.runsystemcapabilities></its.bndRunProperties.runsystemcapabilities>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.14.1</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<pomDependencies>consider</pomDependencies>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<runfw>org.apache.felix.framework</runfw>
+							<printTests>false</printTests>
+							<bndRunProperties>
+								<_runsystemcapabilities>${its.bndRunProperties.runsystemcapabilities}</_runsystemcapabilities>
+							</bndRunProperties>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/projects/surefire.bndRunProperties/src/main/java/org/eclipse/tycho/test/bnd/runprops/Calculator.java
+++ b/tycho-its/projects/surefire.bndRunProperties/src/main/java/org/eclipse/tycho/test/bnd/runprops/Calculator.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.tycho.test.bnd.runprops;
+
+public class Calculator {
+
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+}

--- a/tycho-its/projects/surefire.bndRunProperties/src/main/resources/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/surefire.bndRunProperties/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle for bndRunProperties test
+Bundle-SymbolicName: tycho.its.surefire.bndrunproperties
+Bundle-Version: 1.0.0
+Export-Package: org.eclipse.tycho.test.bnd.runprops
+Automatic-Module-Name: tycho.its.surefire.bndrunproperties
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tycho-its/projects/surefire.bndRunProperties/src/test/java/org/eclipse/tycho/test/bnd/runprops/CalculatorTest.java
+++ b/tycho-its/projects/surefire.bndRunProperties/src/test/java/org/eclipse/tycho/test/bnd/runprops/CalculatorTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.tycho.test.bnd.runprops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CalculatorTest {
+
+    @Test
+    public void testAdd() {
+        assertEquals(3, new Calculator().add(1, 2));
+    }
+
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/BndRunPropertiesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/BndRunPropertiesTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.surefire;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A blank/empty value in a shared {@code bndRunProperties} configuration (e.g. a placeholder
+ * meant to be overridden by a specific module) must not cause the {@code bnd-test} goal to fail
+ * with a NullPointerException.
+ */
+public class BndRunPropertiesTest extends AbstractTychoIntegrationTest {
+
+    @Test
+    public void testBlankBndRunPropertiesValueIsIgnored() throws Exception {
+        Verifier verifier = getVerifier("surefire.bndRunProperties");
+        verifier.executeGoal("verify");
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/BndTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/BndTestMojo.java
@@ -252,7 +252,7 @@ public class BndTestMojo extends AbstractTestMojo {
         if (debugPort > 0) {
             properties.setProperty("-runjdb", "+localhost:" + debugPort);
         }
-        bndRunProperties.forEach((key, value) -> properties.setProperty(key.replaceFirst("^_", "-"), value));
+        addBndRunProperties(properties, bndRunProperties);
         try {
             ReproducibleUtils.storeProperties(properties, runfile.toPath());
             String javaExecutable = getJavaExecutable();
@@ -352,6 +352,22 @@ public class BndTestMojo extends AbstractTestMojo {
             throw new MojoExecutionException("executing test container failed!", e);
         }
 
+    }
+
+    /**
+     * Applies the {@code bndRunProperties} to the given bnd-run {@link Properties}, translating the
+     * leading underscore used to escape Maven's instruction-key syntax (e.g. {@code _runpath} &rarr;
+     * {@code -runpath}). Entries with a blank value are skipped: a shared parent configuration may
+     * declare a property with an empty/placeholder default that is meant to be overridden per-module
+     * (e.g. via {@code build.properties}), and Maven/Plexus represents such blank Map values as
+     * {@code null}, which would otherwise NPE in {@link Properties#setProperty(String, String)}.
+     */
+    static void addBndRunProperties(Properties properties, Map<String, String> bndRunProperties) {
+        bndRunProperties.forEach((key, value) -> {
+            if (value != null && !value.isBlank()) {
+                properties.setProperty(key.replaceFirst("^_", "-"), value);
+            }
+        });
     }
 
     private String buildRunProperties() {

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/BndTestMojoTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/BndTestMojoTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.tycho.surefire;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+public class BndTestMojoTest {
+
+    @Test
+    public void testAddBndRunPropertiesTranslatesLeadingUnderscore() {
+        Properties properties = new Properties();
+        Map<String, String> bndRunProperties = new LinkedHashMap<>();
+        bndRunProperties.put("_runsystemcapabilities", "osgi.wiring.host;osgi.wiring.host=org.eclipse.osgi");
+
+        BndTestMojo.addBndRunProperties(properties, bndRunProperties);
+
+        assertEquals("osgi.wiring.host;osgi.wiring.host=org.eclipse.osgi",
+                properties.getProperty("-runsystemcapabilities"));
+    }
+
+    /**
+     * A shared parent configuration may declare a bndRunProperties entry with an empty/placeholder
+     * default value that is only meant to be overridden by specific modules (e.g. via
+     * build.properties/pom.model.property). Maven/Plexus represents such blank Map values as
+     * {@code null}. Verify that such entries are skipped instead of causing a NullPointerException
+     * in {@link Properties#setProperty(String, String)}.
+     */
+    @Test
+    public void testAddBndRunPropertiesSkipsNullValue() {
+        Properties properties = new Properties();
+        Map<String, String> bndRunProperties = new LinkedHashMap<>();
+        bndRunProperties.put("_runsystemcapabilities", null);
+
+        BndTestMojo.addBndRunProperties(properties, bndRunProperties);
+
+        assertNull(properties.getProperty("-runsystemcapabilities"));
+    }
+
+    @Test
+    public void testAddBndRunPropertiesSkipsBlankValue() {
+        Properties properties = new Properties();
+        Map<String, String> bndRunProperties = new LinkedHashMap<>();
+        bndRunProperties.put("_runsystemcapabilities", "   ");
+
+        BndTestMojo.addBndRunProperties(properties, bndRunProperties);
+
+        assertNull(properties.getProperty("-runsystemcapabilities"));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a `NullPointerException` in `BndTestMojo#runTests()` when a `bndRunProperties` entry has a blank/empty value.

A shared parent POM may declare a `bndRunProperties` instruction with an empty placeholder default value that individual modules are expected to override (e.g. via `build.properties`'s `pom.model.property.*` mechanism). When such a blank Maven property is substituted into a `Map<String,String>` Mojo parameter, Maven/Plexus converts it to `null` (not `""`), and `BndTestMojo` didn't guard against that, causing `properties.setProperty(key, null)` to NPE in `ConcurrentHashMap.put`.

The fix extracts the property-copying loop into a small `addBndRunProperties` helper that skips `null`/blank values, treating them as "not set".

Found while working on [eclipse-equinox/equinox#295](https://github.com/eclipse-equinox/equinox/pull/295), where scoping a shared `_runsystemcapabilities` bnd-test property per-module via an overridable, blank-by-default parent property triggered this exact NPE.

## How was this tested?

- New unit test `BndTestMojoTest` (3 cases: leading-underscore translation, skip-null, skip-blank).
- New integration test project `tycho-its/projects/surefire.bndRunProperties` + `BndRunPropertiesTest`, which declares a blank `bndRunProperties` value and asserts the `bnd-test` goal still succeeds. Verified locally that this integration test reproduces the NPE when the fix is reverted, and passes with the fix applied.
- `mvn install -pl tycho-surefire/tycho-surefire-plugin -am` builds cleanly.

## AI/GenAI disclosure

- Tool/agent + model/version + mode: GitHub Copilot CLI, claude-sonnet-5, interactive
- [x] I have personally reviewed all code, tests, and text in this PR and understand and stand behind every change, per the [Eclipse GenAI contribution guidelines](https://www.eclipse.org/projects/handbook/#genai).
- [x] I will personally review and confirm any AI-assisted follow-up changes made in response to review comments before pushing them (see [AGENTS.md](../AGENTS.md) rule on reading full thread history).

## Checklist

- [x] I have searched existing PRs/issues and this is not a duplicate.
- [x] `mvn clean install -DskipTests` / relevant integration tests pass locally.
- [x] Commits are small and self-contained (see [CONTRIBUTING.md](../CONTRIBUTING.md#granularity)).
