### PR TITLE
Drop Apache BCEL dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,11 +263,6 @@
 				<version>1.6.0</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.bcel</groupId>
-				<artifactId>bcel</artifactId>
-				<version>6.12.0</version>
-			</dependency>
-			<dependency>
 				<groupId>org.apache.maven.plugin-testing</groupId>
 				<artifactId>maven-plugin-testing-harness</artifactId>
 				<version>3.5.1</version>

--- a/tycho-compiler-plugin/pom.xml
+++ b/tycho-compiler-plugin/pom.xml
@@ -83,11 +83,6 @@
 			<classifier>tests</classifier>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.bcel</groupId>
-			<artifactId>bcel</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 		    <groupId>org.codehaus.plexus</groupId>
 		    <artifactId>plexus-compiler-javac</artifactId>
 		    <version>${plexusCompilerVersion}</version>

--- a/tycho-its/pom.xml
+++ b/tycho-its/pom.xml
@@ -202,12 +202,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.bcel</groupId>
-			<artifactId>bcel</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.jface</artifactId>
 			<version>3.39.100</version>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/tycho476/ExecutionEnvironmentTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/tycho476/ExecutionEnvironmentTest.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.tycho476;
 
+import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 
-import org.apache.bcel.classfile.ClassParser;
-import org.apache.bcel.classfile.JavaClass;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.jupiter.api.Assertions;
@@ -32,9 +32,16 @@ public class ExecutionEnvironmentTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		File classFile = new File(verifier.getBasedir(), "target/classes/TestRunnable.class");
 		Assertions.assertTrue(classFile.canRead());
-		JavaClass javaClass = new ClassParser(classFile.getAbsolutePath()).parse();
 		// bytecode major level 61 == target 17
-		Assertions.assertEquals(61, javaClass.getMajor());
+		Assertions.assertEquals(61, readClassFileMajorVersion(classFile));
+	}
+
+	private static int readClassFileMajorVersion(File classFile) throws Exception {
+		try (DataInputStream in = new DataInputStream(new FileInputStream(classFile))) {
+			Assertions.assertEquals(0xCAFEBABE, in.readInt(), "not a class file: " + classFile);
+			in.readUnsignedShort(); // minor version
+			return in.readUnsignedShort();
+		}
 	}
 
 }


### PR DESCRIPTION
BCEL was used in a single place: ExecutionEnvironmentTest in tycho-its parses a compiled class to assert its major version. The declaration in tycho-compiler-plugin has been unused since the Mojo test cases were removed in 41e857430.

Read the class file header directly instead (magic, minor, major) and remove the dependency from all POMs.

Assisted-by: Anthropic Claude Code (claude-fable-5-1)

