### PR TITLE
Remove maven-compat dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,12 +112,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
-				<artifactId>maven-compat</artifactId>
-				<scope>provided</scope>
-				<version>${maven-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-model</artifactId>
 				<scope>provided</scope>
 				<version>${maven-version}</version>

--- a/tycho-compiler-plugin/pom.xml
+++ b/tycho-compiler-plugin/pom.xml
@@ -71,11 +71,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-core</artifactId>
 			<version>${project.version}</version>

--- a/tycho-core/pom.xml
+++ b/tycho-core/pom.xml
@@ -279,11 +279,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>

--- a/tycho-eclipse-plugin/pom.xml
+++ b/tycho-eclipse-plugin/pom.xml
@@ -86,11 +86,6 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/tycho-p2-repository-plugin/pom.xml
+++ b/tycho-p2-repository-plugin/pom.xml
@@ -33,6 +33,10 @@
 			<artifactId>maven-plugin-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>
@@ -48,11 +52,6 @@
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-testing-harness</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tycho-packaging-plugin/pom.xml
+++ b/tycho-packaging-plugin/pom.xml
@@ -55,11 +55,6 @@
 			<artifactId>maven-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>

--- a/tycho-source-plugin/pom.xml
+++ b/tycho-source-plugin/pom.xml
@@ -34,11 +34,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 		</dependency>
 		<dependency>

--- a/tycho-versions-plugin/pom.xml
+++ b/tycho-versions-plugin/pom.xml
@@ -33,11 +33,6 @@
 			<artifactId>maven-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>


### PR DESCRIPTION
No Tycho source uses a class or Plexus component that only maven-compat provides. It was added for maven-plugin-testing-harness 2.0, which required it; the 3.5.1 version in use no longer does.

tycho-p2-repository-plugin uses maven-core in its mojos but only got it onto the compile classpath through the test-scoped maven-compat, because the root pom manages maven-core as provided. Declare it directly like the other mojo modules do.

Assisted-by: Anthropic Claude Code (claude-fable-5-1)
